### PR TITLE
Refactor code structure and add visit functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,10 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 aux_source_directory(src ptx_frontend_srcs)
 add_library(ptx_frontend ${ptx_frontend_srcs})
 target_include_directories(ptx_frontend PUBLIC include)
+
+## target ptx_frontend_test
+aux_source_directory(test ptx_frontend_test_files)
+add_executable(ptx_frontend_test ${ptx_frontend_test_files})
+target_link_libraries(ptx_frontend_test PRIVATE ptx_frontend)
+find_package(GTest CONFIG REQUIRED)
+target_link_libraries(ptx_frontend_test PRIVATE GTest::gtest GTest::gtest_main)

--- a/include/ptx_ir.hpp
+++ b/include/ptx_ir.hpp
@@ -12,6 +12,7 @@
 namespace ptx_frontend {
 
 using tl::expected;
+using tl::unexpected;
 
 enum class ScalarType : uint8_t {
   U8,
@@ -737,7 +738,7 @@ struct Dp2aData {
 enum class CpAsyncCpSize { Bytes4, Bytes8, Bytes16 };
 struct CpAsyncDetails {
   CpAsyncCacheOperator caching;
-  StateSpace space;
+  StateSpace space;  // dst space
   CpAsyncCpSize cp_size;
   std::optional<uint64_t> src_size;
 };
@@ -927,9 +928,13 @@ struct InstrCvt {
   Op dst, src;
   Opt<Op> src2;
 };
+struct CvtPackDetails {
+  ScalarType from;  // source type (e.g., S32)
+  ScalarType to;    // destination element type (e.g., S16)
+};
 template <OperandLike Op>
 struct InstrCvtPack {
-  ScalarType data;
+  CvtPackDetails data;
   Op dst /*u32*/, src1 /*s32*/, src2 /*s32*/, src3 /*b32*/;
 };
 template <OperandLike Op>

--- a/include/ptx_ir.hpp
+++ b/include/ptx_ir.hpp
@@ -248,7 +248,6 @@ struct ParsedOperand {
   template <typename T>
     requires utils::is_one_of<T, RegOffset, VecMemberIdx, RegOrImmediate<Id>,
                               ImmediateValue, VecPack>
-
   static ParsedOperand from_value(T v) {
     ParsedOperand p;
     if constexpr (std::is_same_v<T, VecPack>) {
@@ -799,77 +798,77 @@ concept OperandLike = requires {
 template <OperandLike Op>
 using Opt = std::optional<Op>;  // models Option<T> arguments
 
-template <typename Op>
+template <OperandLike Op>
 struct InstrAbs {
   TypeFtz data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrActivemask {
   Op dst;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrAdd {
   ArithDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrAddExtended {
   CarryDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSubExtended {
   CarryDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMadExtended {
   MadCarryDetails data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrAnd {
   ScalarType data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrAtom {
   AtomDetails data;
   Op dst, src1 /*addr*/, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrAtomCas {
   AtomCasDetails data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBarWarp {
   Op src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBar {
   BarData data;
   Op src1;
   Opt<Op> src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBarRed {
   BarRedData data;
   Op dst1, src_barrier, src_predicate, src_negate_predicate;
   Opt<Op> src_threadcount;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBfe {
   ScalarType data;
   Op dst, src1, src2 /*u32*/, src3 /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBfi {
   ScalarType data;
   Op dst, src1, src2, src3 /*u32*/, src4 /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrBmsk {
   BmskMode data;
   Op dst, src_a, src_b;
@@ -881,14 +880,14 @@ struct InstrBra {
   Id src;
 };
 
-template <typename Op>
+template <OperandLike Op>
 struct InstrBrev {
   ScalarType data;
   Op dst, src;
 };
 
 // Call has its own args struct
-template <typename Op>
+template <OperandLike Op>
 struct InstrCall {
   CallDetails data;
   CallArgs<typename Op::id_type /* if Op = ParsedOperand<Id> */> arguments;
@@ -896,84 +895,84 @@ struct InstrCall {
 // NOTE: In C++ without Rust's associated types, you may need to pass Id as
 // a second template parameter for Call. See usage note below.
 
-template <typename Op>
+template <OperandLike Op>
 struct InstrClz {
   ScalarType data;
   Op dst /*u32*/, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCos {
   FlushToZero data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCpAsync {
   CpAsyncDetails data;
   Op src_to /*shared*/, src_from /*global*/;
 };
 struct InstrCpAsyncCommitGroup {};
-template <typename Op>
+template <OperandLike Op>
 struct InstrCpAsyncWaitGroup {
   Op src_group;
 };
 struct InstrCpAsyncWaitAll {};
-template <typename Op>
+template <OperandLike Op>
 struct InstrCreatePolicyFractional {
   CreatePolicyFractionalDetails data;
   Op dst_policy;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCvt {
   CvtDetails data;
   Op dst, src;
   Opt<Op> src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCvtPack {
   ScalarType data;
   Op dst /*u32*/, src1 /*s32*/, src2 /*s32*/, src3 /*b32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCvta {
   CvtaDetails data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrDiv {
   DivDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrDp4a {
   Dp4aDetails data;
   Op dst /*b32*/, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrEx2 {
   TypeFtz data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrFma {
   ArithFloat data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrLd {
   LdDetails data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrLg2 {
   FlushToZero data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMad {
   MadDetails data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMax {
   MinMaxDetails data;
   Op dst, src1, src2;
@@ -981,60 +980,60 @@ struct InstrMax {
 struct InstrMembar {
   MemScope data;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMin {
   MinMaxDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMov {
   MovDetails data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMul {
   MulDetails data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMul24 {
   Mul24Details data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrNanosleep {
   Op src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrNeg {
   TypeFtz data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrNot {
   ScalarType data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrOr {
   ScalarType data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrPopc {
   ScalarType data;
   Op dst /*u32*/, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrPrmt {
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrRcp {
   RcpData data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrRem {
   ScalarType data;
   Op dst, src1, src2;
@@ -1042,104 +1041,104 @@ struct InstrRem {
 struct InstrRet {
   RetData data;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrRsqrt {
   TypeFtz data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSelp {
   ScalarType data;
   Op dst, src1, src2, src3 /*pred*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSet {
   SetData data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSetBool {
   SetBoolData data;
   Op dst, src1, src2, src3 /*pred*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSetp {
   SetpData data;
   Op dst1 /*pred*/;
   Opt<Op> dst2 /*pred*/;
   Op src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSetpBool {
   SetpBoolData data;
   Op dst1;
   Opt<Op> dst2;
   Op src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrShflSync {
   ShflSyncDetails data;
   Op dst;
   Opt<Op> dst_pred;
   Op src, src_lane, src_opts, src_membermask;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrShf {
   ShfDetails data;
   Op dst, src_a, src_b, src_c;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrShl {
   ScalarType data;
   Op dst, src1, src2 /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrShr {
   ShrData data;
   Op dst, src1, src2 /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSin {
   FlushToZero data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSqrt {
   RcpData data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSt {
   StData data;
   Op src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSub {
   ArithDetails data;
   Op dst, src1, src2;
 };
 struct InstrTrap {};
-template <typename Op>
+template <OperandLike Op>
 struct InstrXor {
   ScalarType data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrTanh {
   ScalarType data;
   Op dst, src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrVote {
   VoteDetails data;
   Op dst, src1 /*pred*/, src2 /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrReduxSync {
   ReduxSyncData data;
   Op dst, src, src_membermask /*u32*/;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrLdMatrix {
   LdMatrixDetails data;
   Op dst, src;
@@ -1147,27 +1146,27 @@ struct InstrLdMatrix {
 struct InstrGridDepControl {
   GridDepControlAction data;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrMma {
   MmaDetails data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrCopysign {
   ScalarType data;
   Op dst, src1, src2;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrPrefetch {
   PrefetchData data;
   Op src;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrSad {
   ScalarType data;
   Op dst, src1, src2, src3;
 };
-template <typename Op>
+template <OperandLike Op>
 struct InstrDp2a {
   Dp2aData data;
   Op dst, src1, src2, src3;
@@ -1233,7 +1232,7 @@ using MultiVariable =
 // § 11  Statement<Op>  ←  ast.rs::Statement
 // ============================================================
 
-template <typename Op>
+template <OperandLike Op>
 struct Statement {
   using IdType = typename Op::id_type;  // for IdentLike constraint on Label
 
@@ -1301,7 +1300,7 @@ struct MethodDeclaration {
   std::optional<Ident> shared_mem;
 };
 
-template <typename Op>
+template <OperandLike Op>
 struct Function {
   MethodDeclaration func_directive;
   std::vector<TuningDirective> tuning;

--- a/include/ptx_visit.hpp
+++ b/include/ptx_visit.hpp
@@ -51,7 +51,8 @@ struct LambdaVisitor : Visitor<Op, Err> {
                                   bool relaxed) override {
     // english: By default, we wrap the raw Id into an Op and delegate to visit—this only works if Op can be constructed from Id.
     // For special handling, subclasses can override this method.
-    return fn_(Op::from_value(id), ts, is_dst, relaxed);
+    return fn_(Op::from_value(RegOrImmediate<typename Op::id_type>::Reg(id)),
+               ts, is_dst, relaxed);
   }
 };
 
@@ -91,7 +92,7 @@ struct LambdaVisitorMap : VisitorMap<From, To, Err> {
   expected<To, Err> visit(From args, std::optional<VisitTypeSpace> ts,
                           bool is_dst, bool relaxed) override {
     // From 需要提供 map_id() 方法（见 ParsedOperand 的实现）
-    return args.map_id(
+    return args.template map_id<typename To::id_type, Err>(
         [&](typename From::id_type id) -> expected<typename To::id_type, Err> {
           return fn_(id, ts, is_dst, relaxed);
         });

--- a/include/ptx_visit.hpp
+++ b/include/ptx_visit.hpp
@@ -31,7 +31,8 @@ struct Visitor {
       bool relaxed_type_check) = 0;
 };
 
-// 便利包装：允许直接传 lambda / FnMut 等价物
+// A convenient wrapper that allows directly passing a lambda / FnMut equivalent.
+// The lambda is expected to handle both full operands and pure symbolic references (labels/function names) by accepting an optional VisitTypeSpace and flags for destination operand and relaxed type checking.
 template <OperandLike Op, typename Err, typename Fn>
   requires std::invocable<Fn, const Op&, std::optional<VisitTypeSpace>, bool,
                           bool>
@@ -44,12 +45,12 @@ struct LambdaVisitor : Visitor<Op, Err> {
     return fn_(args, ts, is_dst, relaxed);
   }
 
-  // ident 默认委托给 visit（与 Rust 的 FnMut blanket impl 一致）
+  // ident by default delegates to visit
   expected<void, Err> visit_ident(const typename Op::id_type& id,
                                   std::optional<VisitTypeSpace> ts, bool is_dst,
                                   bool relaxed) override {
-    // 将裸 Id 包装成 Op 再转发——仅当 Op 支持从 Id 构造时有效
-    // 如需特殊处理，子类覆盖此方法即可
+    // english: By default, we wrap the raw Id into an Op and delegate to visit—this only works if Op can be constructed from Id.
+    // For special handling, subclasses can override this method.
     return fn_(Op::from_value(id), ts, is_dst, relaxed);
   }
 };
@@ -58,21 +59,6 @@ template <OperandLike Op, typename Err, typename Fn>
 auto make_visitor(Fn&& fn) {
   return LambdaVisitor<Op, Err, std::decay_t<Fn>>(std::forward<Fn>(fn));
 }
-
-// ---- 14.2  VisitorMut (mutable) -----------------------------------------
-
-template <OperandLike Op, typename Err>
-struct VisitorMut {
-  virtual ~VisitorMut() = default;
-
-  virtual expected<void, Err> visit(Op& args,
-                                    std::optional<VisitTypeSpace> type_space,
-                                    bool is_dst, bool relaxed_type_check) = 0;
-
-  virtual expected<void, Err> visit_ident(
-      typename Op::id_type& args, std::optional<VisitTypeSpace> type_space,
-      bool is_dst, bool relaxed_type_check) = 0;
-};
 
 // ---- 14.3  VisitorMap (consume old Op, produce new Op) -------------------------
 
@@ -85,7 +71,7 @@ struct VisitorMap {
                                   bool is_dst, bool relaxed_type_check) = 0;
 
   virtual expected<typename To::id_type, Err> visit_ident(
-      typename From::id_type args,  // by value：消费
+      typename From::id_type args,  // by value：consume
       std::optional<VisitTypeSpace> type_space, bool is_dst,
       bool relaxed_type_check) = 0;
 };

--- a/include/ptx_visit_dispatch.hpp
+++ b/include/ptx_visit_dispatch.hpp
@@ -1,0 +1,658 @@
+#pragma once
+#include "ptx_ir.hpp"
+#include "ptx_visit.hpp"
+
+namespace ptx_frontend {
+
+template <typename T>
+ScalarType get_scalar_type(const T& data);
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAbs<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data.type_;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
+    return r;
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAbs<To>, Err> map_instr(InstrAbs<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data.type_;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return tl::unexpected(src.error());
+  return InstrAbs<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrActivemask<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // activemask always produces b32, no data field
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  return v.visit(instr.dst, ts, /*is_dst*/ true, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrActivemask<To>, Err> map_instr(InstrActivemask<From> instr,
+                                             VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  return InstrActivemask<To>{*dst};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAdd<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = get_scalar_type(instr.data);
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAdd<To>, Err> map_instr(InstrAdd<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = get_scalar_type(instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  return InstrAdd<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAddExtended<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data.type_;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAddExtended<To>, Err> map_instr(InstrAddExtended<From> instr,
+                                              VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data.type_;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  return InstrAddExtended<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSubExtended<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data.type_;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSubExtended<To>, Err> map_instr(InstrSubExtended<From> instr,
+                                              VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data.type_;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  return InstrSubExtended<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMadExtended<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data.type_;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMadExtended<To>, Err> map_instr(InstrMadExtended<From> instr,
+                                              VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data.type_;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return tl::unexpected(src3.error());
+  return InstrMadExtended<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAnd<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAnd<To>, Err> map_instr(InstrAnd<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  return InstrAnd<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAtom<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = instr.data.typ;
+  VisitTypeSpace ts{&t, instr.data.space};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAtom<To>, Err> map_instr(InstrAtom<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = instr.data.typ;
+  VisitTypeSpace ts{&t, instr.data.space};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  return InstrAtom<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrAtomCas<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data.type_;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, instr.data.space};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrAtomCas<To>, Err> map_instr(InstrAtomCas<From> instr,
+                                          VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data.type_;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, instr.data.space};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return tl::unexpected(src3.error());
+  return InstrAtomCas<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBarWarp<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // bar.warp.sync membermask: src is b32 warp member mask, no dst
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBarWarp<To>, Err> map_instr(InstrBarWarp<From> instr,
+                                          VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return tl::unexpected(src.error());
+  return InstrBarWarp<To>{*src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBar<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (instr.src2) {
+    if (auto r = v.visit(*instr.src2, ts, false, false); !r)
+      return r;
+  }
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBar<To>, Err> map_instr(InstrBar<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  std::optional<To> src2;
+  if (instr.src2) {
+    auto r = v.visit(std::move(*instr.src2), ts, false, false);
+    if (!r)
+      return tl::unexpected(r.error());
+    src2 = std::move(*r);
+  }
+  return InstrBar<To>{instr.data, *src1, src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBarRed<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // dst type depends on reduction: popc → u32, and/or → pred
+  ScalarType dst_st = (instr.data.pred_reduction == Reduction::Popc)
+                          ? ScalarType::U32
+                          : ScalarType::Pred;
+  Type t_dst = make_scalar(dst_st);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+
+  if (auto r = v.visit(instr.dst1, ts_dst, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_barrier, ts_b32, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_predicate, ts_pred, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_negate_predicate, ts_pred, false, false); !r)
+    return r;
+  if (instr.src_threadcount) {
+    if (auto r = v.visit(*instr.src_threadcount, ts_b32, false, false); !r)
+      return r;
+  }
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBarRed<To>, Err> map_instr(InstrBarRed<From> instr,
+                                         VisitorMap<From, To, Err>& v) {
+  ScalarType dst_st = (instr.data.pred_reduction == Reduction::Popc)
+                          ? ScalarType::U32
+                          : ScalarType::Pred;
+  Type t_dst = make_scalar(dst_st);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+
+  auto dst1 = v.visit(std::move(instr.dst1), ts_dst, true, false);
+  if (!dst1)
+    return tl::unexpected(dst1.error());
+  auto src_barrier =
+      v.visit(std::move(instr.src_barrier), ts_b32, false, false);
+  if (!src_barrier)
+    return tl::unexpected(src_barrier.error());
+  auto src_predicate =
+      v.visit(std::move(instr.src_predicate), ts_pred, false, false);
+  if (!src_predicate)
+    return tl::unexpected(src_predicate.error());
+  auto src_negate_predicate =
+      v.visit(std::move(instr.src_negate_predicate), ts_pred, false, false);
+  if (!src_negate_predicate)
+    return tl::unexpected(src_negate_predicate.error());
+
+  std::optional<To> src_threadcount;
+  if (instr.src_threadcount) {
+    auto r = v.visit(std::move(*instr.src_threadcount), ts_b32, false, false);
+    if (!r)
+      return tl::unexpected(r.error());
+    src_threadcount = std::move(*r);
+  }
+  return InstrBarRed<To>{instr.data,
+                         *dst1,
+                         *src_barrier,
+                         *src_predicate,
+                         *src_negate_predicate,
+                         src_threadcount};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBfe<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBfe<To>, Err> map_instr(InstrBfe<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return tl::unexpected(src3.error());
+  return InstrBfe<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBfi<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, /*is_dst*/ false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, /*is_dst*/ false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src3, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return v.visit(instr.src4, ts, /*is_dst*/ false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBfi<To>, Err> map_instr(InstrBfi<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return tl::unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return tl::unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return tl::unexpected(src3.error());
+  auto src4 = v.visit(std::move(instr.src4), ts, false, false);
+  if (!src4)
+    return tl::unexpected(src4.error());
+  return InstrBfi<To>{instr.data, *dst, *src1, *src2, *src3, *src4};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBmsk<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_a, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src_b, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBmsk<To>, Err> map_instr(InstrBmsk<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src_a = v.visit(std::move(instr.src_a), ts, false, false);
+  if (!src_a)
+    return tl::unexpected(src_a.error());
+  auto src_b = v.visit(std::move(instr.src_b), ts, false, false);
+  if (!src_b)
+    return tl::unexpected(src_b.error());
+  return InstrBmsk<To>{instr.data, *dst, *src_a, *src_b};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBra<typename Op::id_type>& instr,
+                                Visitor<Op, Err>& v) {
+  return v.visit_ident(instr.src, std::nullopt, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBra<typename To::id_type>, Err> map_instr(
+    InstrBra<typename From::id_type> instr, VisitorMap<From, To, Err>& v) {
+  auto src = v.visit_ident(std::move(instr.src), std::nullopt, false, false);
+  if (!src)
+    return tl::unexpected(src.error());
+  return InstrBra<typename To::id_type>{*src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrBrev<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
+    return r;
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrBrev<To>, Err> map_instr(InstrBrev<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return tl::unexpected(src.error());
+  return InstrBrev<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCall<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // return arguments: Id → visit_ident as dst
+  for (size_t i = 0; i < instr.arguments.return_arguments.size(); ++i) {
+    Type t = instr.data.return_arguments[i].first;
+    VisitTypeSpace ts{&t, instr.data.return_arguments[i].second};
+    if (auto r =
+            v.visit_ident(instr.arguments.return_arguments[i], ts, true, false);
+        !r)
+      return r;
+  }
+  // func name: pure ident, no type
+  if (auto r = v.visit_ident(instr.arguments.func, std::nullopt, false, false);
+      !r)
+    return r;
+  // input arguments: full Op → visit as src
+  for (size_t i = 0; i < instr.arguments.input_arguments.size(); ++i) {
+    Type t = instr.data.input_arguments[i].first;
+    VisitTypeSpace ts{&t, instr.data.input_arguments[i].second};
+    if (auto r = v.visit(instr.arguments.input_arguments[i], ts, false, false);
+        !r)
+      return r;
+  }
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCall<To>, Err> map_instr(InstrCall<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  CallArgs<typename To::id_type> new_args;
+  new_args.is_external = instr.arguments.is_external;
+
+  for (size_t i = 0; i < instr.arguments.return_arguments.size(); ++i) {
+    Type t = instr.data.return_arguments[i].first;
+    VisitTypeSpace ts{&t, instr.data.return_arguments[i].second};
+    auto r = v.visit_ident(std::move(instr.arguments.return_arguments[i]), ts,
+                           true, false);
+    if (!r)
+      return tl::unexpected(r.error());
+    new_args.return_arguments.push_back(std::move(*r));
+  }
+
+  {
+    auto r = v.visit_ident(std::move(instr.arguments.func), std::nullopt, false,
+                           false);
+    if (!r)
+      return tl::unexpected(r.error());
+    new_args.func = std::move(*r);
+  }
+
+  for (size_t i = 0; i < instr.arguments.input_arguments.size(); ++i) {
+    Type t = instr.data.input_arguments[i].first;
+    VisitTypeSpace ts{&t, instr.data.input_arguments[i].second};
+    auto r = v.visit(std::move(instr.arguments.input_arguments[i]), ts, false,
+                     false);
+    if (!r)
+      return tl::unexpected(r.error());
+    new_args.input_arguments.push_back(std::move(*r));
+  }
+
+  return InstrCall<To>{instr.data, std::move(new_args)};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrClz<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = instr.data;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
+    return r;
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrClz<To>, Err> map_instr(InstrClz<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = instr.data;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return tl::unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return tl::unexpected(src.error());
+  return InstrClz<To>{instr.data, *dst, *src};
+}
+
+};  // namespace ptx_frontend

--- a/include/ptx_visit_dispatch.hpp
+++ b/include/ptx_visit_dispatch.hpp
@@ -4,6 +4,8 @@
 
 namespace ptx_frontend {
 
+using tl::unexpected;
+
 template <typename T>
 ScalarType get_scalar_type(const T& data);
 
@@ -18,6 +20,7 @@ expected<void, Err> visit_instr(const InstrAbs<Op>& instr,
     return r;
   if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
     return r;
+  return {};
 }
 
 template <OperandLike From, OperandLike To, typename Err>
@@ -28,10 +31,10 @@ expected<InstrAbs<To>, Err> map_instr(InstrAbs<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src = v.visit(std::move(instr.src), ts, false, false);
   if (!src)
-    return tl::unexpected(src.error());
+    return unexpected(src.error());
   return InstrAbs<To>{instr.data, *dst, *src};
 }
 
@@ -51,7 +54,7 @@ expected<InstrActivemask<To>, Err> map_instr(InstrActivemask<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   return InstrActivemask<To>{*dst};
 }
 
@@ -77,13 +80,13 @@ expected<InstrAdd<To>, Err> map_instr(InstrAdd<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   return InstrAdd<To>{instr.data, *dst, *src1, *src2};
 }
 
@@ -109,13 +112,13 @@ expected<InstrAddExtended<To>, Err> map_instr(InstrAddExtended<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   return InstrAddExtended<To>{instr.data, *dst, *src1, *src2};
 }
 
@@ -141,13 +144,13 @@ expected<InstrSubExtended<To>, Err> map_instr(InstrSubExtended<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   return InstrSubExtended<To>{instr.data, *dst, *src1, *src2};
 }
 
@@ -175,16 +178,16 @@ expected<InstrMadExtended<To>, Err> map_instr(InstrMadExtended<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   auto src3 = v.visit(std::move(instr.src3), ts, false, false);
   if (!src3)
-    return tl::unexpected(src3.error());
+    return unexpected(src3.error());
   return InstrMadExtended<To>{instr.data, *dst, *src1, *src2, *src3};
 }
 
@@ -210,13 +213,13 @@ expected<InstrAnd<To>, Err> map_instr(InstrAnd<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   return InstrAnd<To>{instr.data, *dst, *src1, *src2};
 }
 
@@ -239,13 +242,13 @@ expected<InstrAtom<To>, Err> map_instr(InstrAtom<From> instr,
   VisitTypeSpace ts{&t, instr.data.space};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   return InstrAtom<To>{instr.data, *dst, *src1, *src2};
 }
 
@@ -273,16 +276,16 @@ expected<InstrAtomCas<To>, Err> map_instr(InstrAtomCas<From> instr,
   VisitTypeSpace ts{&t, instr.data.space};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   auto src3 = v.visit(std::move(instr.src3), ts, false, false);
   if (!src3)
-    return tl::unexpected(src3.error());
+    return unexpected(src3.error());
   return InstrAtomCas<To>{instr.data, *dst, *src1, *src2, *src3};
 }
 
@@ -302,7 +305,7 @@ expected<InstrBarWarp<To>, Err> map_instr(InstrBarWarp<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto src = v.visit(std::move(instr.src), ts, false, false);
   if (!src)
-    return tl::unexpected(src.error());
+    return unexpected(src.error());
   return InstrBarWarp<To>{*src};
 }
 
@@ -317,6 +320,7 @@ expected<void, Err> visit_instr(const InstrBar<Op>& instr,
     if (auto r = v.visit(*instr.src2, ts, false, false); !r)
       return r;
   }
+  return {};
 }
 
 template <OperandLike From, OperandLike To, typename Err>
@@ -326,12 +330,12 @@ expected<InstrBar<To>, Err> map_instr(InstrBar<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   std::optional<To> src2;
   if (instr.src2) {
     auto r = v.visit(std::move(*instr.src2), ts, false, false);
     if (!r)
-      return tl::unexpected(r.error());
+      return unexpected(r.error());
     src2 = std::move(*r);
   }
   return InstrBar<To>{instr.data, *src1, src2};
@@ -383,25 +387,25 @@ expected<InstrBarRed<To>, Err> map_instr(InstrBarRed<From> instr,
 
   auto dst1 = v.visit(std::move(instr.dst1), ts_dst, true, false);
   if (!dst1)
-    return tl::unexpected(dst1.error());
+    return unexpected(dst1.error());
   auto src_barrier =
       v.visit(std::move(instr.src_barrier), ts_b32, false, false);
   if (!src_barrier)
-    return tl::unexpected(src_barrier.error());
+    return unexpected(src_barrier.error());
   auto src_predicate =
       v.visit(std::move(instr.src_predicate), ts_pred, false, false);
   if (!src_predicate)
-    return tl::unexpected(src_predicate.error());
+    return unexpected(src_predicate.error());
   auto src_negate_predicate =
       v.visit(std::move(instr.src_negate_predicate), ts_pred, false, false);
   if (!src_negate_predicate)
-    return tl::unexpected(src_negate_predicate.error());
+    return unexpected(src_negate_predicate.error());
 
   std::optional<To> src_threadcount;
   if (instr.src_threadcount) {
     auto r = v.visit(std::move(*instr.src_threadcount), ts_b32, false, false);
     if (!r)
-      return tl::unexpected(r.error());
+      return unexpected(r.error());
     src_threadcount = std::move(*r);
   }
   return InstrBarRed<To>{instr.data,
@@ -436,16 +440,16 @@ expected<InstrBfe<To>, Err> map_instr(InstrBfe<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   auto src3 = v.visit(std::move(instr.src3), ts, false, false);
   if (!src3)
-    return tl::unexpected(src3.error());
+    return unexpected(src3.error());
   return InstrBfe<To>{instr.data, *dst, *src1, *src2, *src3};
 }
 
@@ -475,19 +479,19 @@ expected<InstrBfi<To>, Err> map_instr(InstrBfi<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src1 = v.visit(std::move(instr.src1), ts, false, false);
   if (!src1)
-    return tl::unexpected(src1.error());
+    return unexpected(src1.error());
   auto src2 = v.visit(std::move(instr.src2), ts, false, false);
   if (!src2)
-    return tl::unexpected(src2.error());
+    return unexpected(src2.error());
   auto src3 = v.visit(std::move(instr.src3), ts, false, false);
   if (!src3)
-    return tl::unexpected(src3.error());
+    return unexpected(src3.error());
   auto src4 = v.visit(std::move(instr.src4), ts, false, false);
   if (!src4)
-    return tl::unexpected(src4.error());
+    return unexpected(src4.error());
   return InstrBfi<To>{instr.data, *dst, *src1, *src2, *src3, *src4};
 }
 
@@ -510,13 +514,13 @@ expected<InstrBmsk<To>, Err> map_instr(InstrBmsk<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src_a = v.visit(std::move(instr.src_a), ts, false, false);
   if (!src_a)
-    return tl::unexpected(src_a.error());
+    return unexpected(src_a.error());
   auto src_b = v.visit(std::move(instr.src_b), ts, false, false);
   if (!src_b)
-    return tl::unexpected(src_b.error());
+    return unexpected(src_b.error());
   return InstrBmsk<To>{instr.data, *dst, *src_a, *src_b};
 }
 
@@ -531,7 +535,7 @@ expected<InstrBra<typename To::id_type>, Err> map_instr(
     InstrBra<typename From::id_type> instr, VisitorMap<From, To, Err>& v) {
   auto src = v.visit_ident(std::move(instr.src), std::nullopt, false, false);
   if (!src)
-    return tl::unexpected(src.error());
+    return unexpected(src.error());
   return InstrBra<typename To::id_type>{*src};
 }
 
@@ -546,6 +550,7 @@ expected<void, Err> visit_instr(const InstrBrev<Op>& instr,
     return r;
   if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
     return r;
+  return {};
 }
 
 template <OperandLike From, OperandLike To, typename Err>
@@ -556,10 +561,10 @@ expected<InstrBrev<To>, Err> map_instr(InstrBrev<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src = v.visit(std::move(instr.src), ts, false, false);
   if (!src)
-    return tl::unexpected(src.error());
+    return unexpected(src.error());
   return InstrBrev<To>{instr.data, *dst, *src};
 }
 
@@ -602,7 +607,7 @@ expected<InstrCall<To>, Err> map_instr(InstrCall<From> instr,
     auto r = v.visit_ident(std::move(instr.arguments.return_arguments[i]), ts,
                            true, false);
     if (!r)
-      return tl::unexpected(r.error());
+      return unexpected(r.error());
     new_args.return_arguments.push_back(std::move(*r));
   }
 
@@ -610,7 +615,7 @@ expected<InstrCall<To>, Err> map_instr(InstrCall<From> instr,
     auto r = v.visit_ident(std::move(instr.arguments.func), std::nullopt, false,
                            false);
     if (!r)
-      return tl::unexpected(r.error());
+      return unexpected(r.error());
     new_args.func = std::move(*r);
   }
 
@@ -620,7 +625,7 @@ expected<InstrCall<To>, Err> map_instr(InstrCall<From> instr,
     auto r = v.visit(std::move(instr.arguments.input_arguments[i]), ts, false,
                      false);
     if (!r)
-      return tl::unexpected(r.error());
+      return unexpected(r.error());
     new_args.input_arguments.push_back(std::move(*r));
   }
 
@@ -638,6 +643,7 @@ expected<void, Err> visit_instr(const InstrClz<Op>& instr,
     return r;
   if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
     return r;
+  return {};
 }
 
 template <OperandLike From, OperandLike To, typename Err>
@@ -648,11 +654,1861 @@ expected<InstrClz<To>, Err> map_instr(InstrClz<From> instr,
   VisitTypeSpace ts{&t, StateSpace::Reg};
   auto dst = v.visit(std::move(instr.dst), ts, true, false);
   if (!dst)
-    return tl::unexpected(dst.error());
+    return unexpected(dst.error());
   auto src = v.visit(std::move(instr.src), ts, false, false);
   if (!src)
-    return tl::unexpected(src.error());
+    return unexpected(src.error());
   return InstrClz<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCos<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = ScalarType::B32;
+
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts, /*is_dst*/ false, false); !r)
+    return r;
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCos<To>, Err> map_instr(InstrCos<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = ScalarType::B32;
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrCos<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCpAsync<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  auto derive_scalarType = [&]() {
+    ScalarType st;
+    switch (instr.data.cp_size) {
+      case CpAsyncCpSize::Bytes4:
+        st = ScalarType::B32;
+        break;
+      case CpAsyncCpSize::Bytes8:
+        st = ScalarType::B64;
+        break;
+      case CpAsyncCpSize::Bytes16:
+        st = ScalarType::B128;
+        break;
+    }
+    return st;
+  };
+
+  ScalarType st = derive_scalarType();
+  Type t = make_scalar(st);
+  VisitTypeSpace ts_dst{&t, instr.data.space};
+  if (auto r = v.visit(instr.src_to, ts_dst, /*is_dst*/ true, false); !r)
+    return r;
+  auto ts_src = VisitTypeSpace{&t, StateSpace::Global};
+  if (auto r = v.visit(instr.src_from, ts_src, /*is_dst*/ false, false); !r)
+    return r;
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCpAsync<To>, Err> map_instr(InstrCpAsync<From> instr,
+                                          VisitorMap<From, To, Err>& v) {
+  auto derive_scalarType = [&]() {
+    ScalarType st;
+    switch (instr.data.cp_size) {
+      case CpAsyncCpSize::Bytes4:
+        st = ScalarType::B32;
+        break;
+      case CpAsyncCpSize::Bytes8:
+        st = ScalarType::B64;
+        break;
+      case CpAsyncCpSize::Bytes16:
+        st = ScalarType::B128;
+        break;
+    }
+    return st;
+  };
+
+  ScalarType st = derive_scalarType();
+  Type t = make_scalar(st);
+  VisitTypeSpace ts_dst{&t, instr.data.space};
+  auto dst = v.visit(std::move(instr.src_to), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+
+  auto ts_src = VisitTypeSpace{&t, StateSpace::Global};
+  auto src = v.visit(std::move(instr.src_from), ts_src, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrCpAsync<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCpAsyncCommitGroup& instr,
+                                Visitor<Op, Err>& v) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCpAsyncCommitGroup, Err> map_instr(InstrCpAsyncCommitGroup instr,
+                                                 VisitorMap<From, To, Err>& v) {
+  return InstrCpAsyncCommitGroup{};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCpAsyncWaitGroup<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  return v.visit(instr.src_group, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCpAsyncWaitGroup<To>, Err> map_instr(
+    InstrCpAsyncWaitGroup<From> instr, VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto src = v.visit(std::move(instr.src_group), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrCpAsyncWaitGroup<To>{*src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCpAsyncWaitAll& instr,
+                                Visitor<Op, Err>& v) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCpAsyncWaitAll, Err> map_instr(InstrCpAsyncWaitAll instr,
+                                             VisitorMap<From, To, Err>& v) {
+  return InstrCpAsyncWaitAll{};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCreatePolicyFractional<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  return v.visit(instr.dst_policy, ts, /*is_dst*/ true, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCreatePolicyFractional<To>, Err> map_instr(
+    InstrCreatePolicyFractional<From> instr, VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst_policy), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  return InstrCreatePolicyFractional<To>{instr.data, *dst};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCvt<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_dst = make_scalar(instr.data.to);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.from);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_dst, /*is_dst*/ true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts_src, /*is_dst*/ false, false); !r)
+    return r;
+  if (instr.src2) {
+    if (auto r = v.visit(*instr.src2, ts_src, /*is_dst*/ false, false); !r)
+      return r;
+  }
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCvt<To>, Err> map_instr(InstrCvt<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t_dst = make_scalar(instr.data.to);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.from);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts_src, false, false);
+  if (!src)
+    return unexpected(src.error());
+  std::optional<To> src2;
+  if (instr.src2) {
+    auto r = v.visit(std::move(*instr.src2), ts_src, false, false);
+    if (!r)
+      return unexpected(r.error());
+    src2 = std::move(*r);
+  }
+  return InstrCvt<To>{instr.data, *dst, *src, src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCvtPack<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_dst = make_scalar(ScalarType::B32);  // dst 固定 b32
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.from);  // src1/src2 用 from
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  Type t_acc = make_scalar(ScalarType::B32);  // src3 accumulator b32
+  VisitTypeSpace ts_acc{&t_acc, StateSpace::Reg};
+
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_src, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src3, ts_acc, false, false); !r)
+    return r;
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCvtPack<To>, Err> map_instr(InstrCvtPack<From> instr,
+                                          VisitorMap<From, To, Err>& v) {
+  Type t_dst = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.from);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  Type t_acc = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_acc{&t_acc, StateSpace::Reg};
+
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_acc, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+
+  return InstrCvtPack<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCvta<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // cvta 操作数是地址值寄存器，大小依赖目标位宽，用 relaxed=true
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, /*relaxed=*/true); !r)
+    return r;
+  return v.visit(instr.src, ts, false, /*relaxed=*/true);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCvta<To>, Err> map_instr(InstrCvta<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, true);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, true);
+  if (!src)
+    return unexpected(src.error());
+  return InstrCvta<To>{instr.data, *dst, *src};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrDiv<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrDiv<To>, Err> map_instr(InstrDiv<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrDiv<To>{instr.data, *dst, *src1, *src2};
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrDp4a<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_c = make_scalar(instr.data.ctype());  // dst / src3 都是 ctype
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  Type t_a = make_scalar(instr.data.atype);
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = make_scalar(instr.data.btype);
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_c, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_a, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_b, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_c, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrDp4a<To>, Err> map_instr(InstrDp4a<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t_c = make_scalar(instr.data.ctype());
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  Type t_a = make_scalar(instr.data.atype);
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = make_scalar(instr.data.btype);
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_c, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_a, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_b, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_c, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrDp4a<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrEx2 ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrEx2<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrEx2<To>, Err> map_instr(InstrEx2<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrEx2<To>{instr.data, *dst, *src};
+}
+
+// ── InstrFma ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrFma<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrFma<To>, Err> map_instr(InstrFma<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrFma<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrLd ────────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrLd<Op>& instr, Visitor<Op, Err>& v) {
+  // dst: register holding the loaded value
+  Type t_dst = instr.data.typ;
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  // src: address in the source state space
+  Type t_src = instr.data.typ;
+  VisitTypeSpace ts_src{&t_src, instr.data.state_space};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts_src, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrLd<To>, Err> map_instr(InstrLd<From> instr,
+                                     VisitorMap<From, To, Err>& v) {
+  Type t_dst = instr.data.typ;
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = instr.data.typ;
+  VisitTypeSpace ts_src{&t_src, instr.data.state_space};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts_src, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrLd<To>{instr.data, *dst, *src};
+}
+
+// ── InstrLg2 ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrLg2<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::F32);  // lg2 仅作用于 f32
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrLg2<To>, Err> map_instr(InstrLg2<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::F32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrLg2<To>{instr.data, *dst, *src};
+}
+
+// ── InstrMad ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMad<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMad<To>, Err> map_instr(InstrMad<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrMad<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrMax ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMax<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMax<To>, Err> map_instr(InstrMax<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrMax<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrMembar ────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMembar& /*instr*/,
+                                Visitor<Op, Err>& /*v*/) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMembar, Err> map_instr(InstrMembar instr,
+                                     VisitorMap<From, To, Err>& /*v*/) {
+  return instr;
+}
+
+// ── InstrMin ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMin<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMin<To>, Err> map_instr(InstrMin<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = std::visit([](const auto& d) { return d.type_; }, instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrMin<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrMov ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMov<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = instr.data.typ;
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  // relaxed=true：mov 可以携带立即数、地址标签等
+  if (auto r = v.visit(instr.dst, ts, true, /*relaxed=*/true); !r)
+    return r;
+  return v.visit(instr.src, ts, false, /*relaxed=*/true);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMov<To>, Err> map_instr(InstrMov<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = instr.data.typ;
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, true);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, true);
+  if (!src)
+    return unexpected(src.error());
+  return InstrMov<To>{instr.data, *dst, *src};
+}
+
+// ── InstrMul ───────────────────────────────────────────────────────────────
+// mul.wide 时 dst 是 src 类型的双倍宽度
+inline ScalarType mul_wide_dst_type(ScalarType t) {
+  switch (t) {
+    case ScalarType::U16:
+      return ScalarType::U32;
+    case ScalarType::U32:
+      return ScalarType::U64;
+    case ScalarType::S16:
+      return ScalarType::S32;
+    case ScalarType::S32:
+      return ScalarType::S64;
+    default:
+      return t;
+  }
+}
+
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMul<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  return std::visit(
+      [&](const auto& d) -> expected<void, Err> {
+        using D = std::decay_t<decltype(d)>;
+        if constexpr (std::is_same_v<D, MulInt>) {
+          Type t_src = make_scalar(d.type_);
+          VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+          if (d.control == MulIntControl::Wide) {
+            Type t_dst = make_scalar(mul_wide_dst_type(d.type_));
+            VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+            if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+              return r;
+          } else {
+            if (auto r = v.visit(instr.dst, ts_src, true, false); !r)
+              return r;
+          }
+          if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+            return r;
+          return v.visit(instr.src2, ts_src, false, false);
+        } else {  // ArithFloat
+          Type t = make_scalar(d.type_);
+          VisitTypeSpace ts{&t, StateSpace::Reg};
+          if (auto r = v.visit(instr.dst, ts, true, false); !r)
+            return r;
+          if (auto r = v.visit(instr.src1, ts, false, false); !r)
+            return r;
+          return v.visit(instr.src2, ts, false, false);
+        }
+      },
+      instr.data);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMul<To>, Err> map_instr(InstrMul<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  return std::visit(
+      [&](const auto& d) -> expected<InstrMul<To>, Err> {
+        using D = std::decay_t<decltype(d)>;
+        if constexpr (std::is_same_v<D, MulInt>) {
+          Type t_src = make_scalar(d.type_);
+          VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+          expected<To, Err> dst;
+          if (d.control == MulIntControl::Wide) {
+            Type t_dst = make_scalar(mul_wide_dst_type(d.type_));
+            VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+            dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+          } else {
+            dst = v.visit(std::move(instr.dst), ts_src, true, false);
+          }
+          if (!dst)
+            return unexpected(dst.error());
+          auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+          if (!src1)
+            return unexpected(src1.error());
+          auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+          if (!src2)
+            return unexpected(src2.error());
+          return InstrMul<To>{instr.data, *dst, *src1, *src2};
+        } else {
+          Type t = make_scalar(d.type_);
+          VisitTypeSpace ts{&t, StateSpace::Reg};
+          auto dst = v.visit(std::move(instr.dst), ts, true, false);
+          if (!dst)
+            return unexpected(dst.error());
+          auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+          if (!src1)
+            return unexpected(src1.error());
+          auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+          if (!src2)
+            return unexpected(src2.error());
+          return InstrMul<To>{instr.data, *dst, *src1, *src2};
+        }
+      },
+      instr.data);
+}
+
+// ── InstrMul24 ─────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMul24<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMul24<To>, Err> map_instr(InstrMul24<From> instr,
+                                        VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrMul24<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrNanosleep ─────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrNanosleep<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrNanosleep<To>, Err> map_instr(InstrNanosleep<From> instr,
+                                            VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrNanosleep<To>{*src};
+}
+
+// ── InstrNeg ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrNeg<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrNeg<To>, Err> map_instr(InstrNeg<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrNeg<To>{instr.data, *dst, *src};
+}
+
+// ── InstrNot ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrNot<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrNot<To>, Err> map_instr(InstrNot<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrNot<To>{instr.data, *dst, *src};
+}
+
+// ── InstrOr ────────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrOr<Op>& instr, Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrOr<To>, Err> map_instr(InstrOr<From> instr,
+                                     VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrOr<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrPopc ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrPopc<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_dst = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts_src, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrPopc<To>, Err> map_instr(InstrPopc<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t_dst = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts_src, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrPopc<To>{instr.data, *dst, *src};
+}
+
+// ── InstrPrmt ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrPrmt<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrPrmt<To>, Err> map_instr(InstrPrmt<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrPrmt<To>{*dst, *src1, *src2, *src3};
+}
+
+// ── InstrRcp ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrRcp<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrRcp<To>, Err> map_instr(InstrRcp<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrRcp<To>{instr.data, *dst, *src};
+}
+
+// ── InstrRem ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrRem<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrRem<To>, Err> map_instr(InstrRem<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrRem<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrRet ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrRet& /*instr*/,
+                                Visitor<Op, Err>& /*v*/) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrRet, Err> map_instr(InstrRet instr,
+                                  VisitorMap<From, To, Err>& /*v*/) {
+  return instr;
+}
+
+// ── InstrRsqrt ─────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrRsqrt<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrRsqrt<To>, Err> map_instr(InstrRsqrt<From> instr,
+                                        VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrRsqrt<To>{instr.data, *dst, *src};
+}
+
+// ── InstrSelp ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSelp<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_pred, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSelp<To>, Err> map_instr(InstrSelp<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_pred, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrSelp<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrSet ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSet<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_dst = make_scalar(instr.data.dtype);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_src, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSet<To>, Err> map_instr(InstrSet<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t_dst = make_scalar(instr.data.dtype);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrSet<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrSetBool ───────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSetBool<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_dst = make_scalar(instr.data.dtype);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_src, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_pred, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSetBool<To>, Err> map_instr(InstrSetBool<From> instr,
+                                          VisitorMap<From, To, Err>& v) {
+  Type t_dst = make_scalar(instr.data.dtype);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_pred, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrSetBool<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrSetp ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSetp<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst1, ts_pred, true, false); !r)
+    return r;
+  if (instr.dst2) {
+    if (auto r = v.visit(*instr.dst2, ts_pred, true, false); !r)
+      return r;
+  }
+  if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_src, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSetp<To>, Err> map_instr(InstrSetp<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  auto dst1 = v.visit(std::move(instr.dst1), ts_pred, true, false);
+  if (!dst1)
+    return unexpected(dst1.error());
+  std::optional<To> dst2;
+  if (instr.dst2) {
+    auto r = v.visit(std::move(*instr.dst2), ts_pred, true, false);
+    if (!r)
+      return unexpected(r.error());
+    dst2 = std::move(*r);
+  }
+  auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrSetp<To>{instr.data, *dst1, dst2, *src1, *src2};
+}
+
+// ── InstrSetpBool ──────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSetpBool<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst1, ts_pred, true, false); !r)
+    return r;
+  if (instr.dst2) {
+    if (auto r = v.visit(*instr.dst2, ts_pred, true, false); !r)
+      return r;
+  }
+  if (auto r = v.visit(instr.src1, ts_src, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_src, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_pred, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSetpBool<To>, Err> map_instr(InstrSetpBool<From> instr,
+                                           VisitorMap<From, To, Err>& v) {
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_src = make_scalar(instr.data.base.type_);
+  VisitTypeSpace ts_src{&t_src, StateSpace::Reg};
+  auto dst1 = v.visit(std::move(instr.dst1), ts_pred, true, false);
+  if (!dst1)
+    return unexpected(dst1.error());
+  std::optional<To> dst2;
+  if (instr.dst2) {
+    auto r = v.visit(std::move(*instr.dst2), ts_pred, true, false);
+    if (!r)
+      return unexpected(r.error());
+    dst2 = std::move(*r);
+  }
+  auto src1 = v.visit(std::move(instr.src1), ts_src, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_src, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_pred, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrSetpBool<To>{instr.data, *dst1, dst2, *src1, *src2, *src3};
+}
+
+// ── InstrShflSync ──────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrShflSync<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_b32, true, false); !r)
+    return r;
+  if (instr.dst_pred) {
+    if (auto r = v.visit(*instr.dst_pred, ts_pred, true, false); !r)
+      return r;
+  }
+  if (auto r = v.visit(instr.src, ts_b32, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_lane, ts_b32, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_opts, ts_b32, false, false); !r)
+    return r;
+  return v.visit(instr.src_membermask, ts_b32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrShflSync<To>, Err> map_instr(InstrShflSync<From> instr,
+                                           VisitorMap<From, To, Err>& v) {
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_b32, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  std::optional<To> dst_pred;
+  if (instr.dst_pred) {
+    auto r = v.visit(std::move(*instr.dst_pred), ts_pred, true, false);
+    if (!r)
+      return unexpected(r.error());
+    dst_pred = std::move(*r);
+  }
+  auto src = v.visit(std::move(instr.src), ts_b32, false, false);
+  if (!src)
+    return unexpected(src.error());
+  auto src_lane = v.visit(std::move(instr.src_lane), ts_b32, false, false);
+  if (!src_lane)
+    return unexpected(src_lane.error());
+  auto src_opts = v.visit(std::move(instr.src_opts), ts_b32, false, false);
+  if (!src_opts)
+    return unexpected(src_opts.error());
+  auto src_membermask =
+      v.visit(std::move(instr.src_membermask), ts_b32, false, false);
+  if (!src_membermask)
+    return unexpected(src_membermask.error());
+  return InstrShflSync<To>{instr.data, *dst,      dst_pred,       *src,
+                           *src_lane,  *src_opts, *src_membermask};
+}
+
+// ── InstrShf ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrShf<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_b32, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_a, ts_b32, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src_b, ts_b32, false, false); !r)
+    return r;
+  return v.visit(instr.src_c, ts_u32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrShf<To>, Err> map_instr(InstrShf<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t_b32 = make_scalar(ScalarType::B32);
+  VisitTypeSpace ts_b32{&t_b32, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_b32, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src_a = v.visit(std::move(instr.src_a), ts_b32, false, false);
+  if (!src_a)
+    return unexpected(src_a.error());
+  auto src_b = v.visit(std::move(instr.src_b), ts_b32, false, false);
+  if (!src_b)
+    return unexpected(src_b.error());
+  auto src_c = v.visit(std::move(instr.src_c), ts_u32, false, false);
+  if (!src_c)
+    return unexpected(src_c.error());
+  return InstrShf<To>{instr.data, *dst, *src_a, *src_b, *src_c};
+}
+
+// ── InstrShl ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrShl<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_u32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrShl<To>, Err> map_instr(InstrShl<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_u32, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrShl<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrShr ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrShr<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_u32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrShr<To>, Err> map_instr(InstrShr<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_u32, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrShr<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrSin ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSin<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(ScalarType::F32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSin<To>, Err> map_instr(InstrSin<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::F32);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrSin<To>{instr.data, *dst, *src};
+}
+
+// ── InstrSqrt ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSqrt<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSqrt<To>, Err> map_instr(InstrSqrt<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrSqrt<To>{instr.data, *dst, *src};
+}
+
+// ── InstrSt ────────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSt<Op>& instr, Visitor<Op, Err>& v) {
+  // src1: address operand in the target state space
+  Type t_addr = instr.data.typ;
+  VisitTypeSpace ts_addr{&t_addr, instr.data.state_space};
+  // src2: value operand held in a register
+  Type t_val = instr.data.typ;
+  VisitTypeSpace ts_val{&t_val, StateSpace::Reg};
+  if (auto r = v.visit(instr.src1, ts_addr, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_val, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSt<To>, Err> map_instr(InstrSt<From> instr,
+                                     VisitorMap<From, To, Err>& v) {
+  Type t_addr = instr.data.typ;
+  VisitTypeSpace ts_addr{&t_addr, instr.data.state_space};
+  Type t_val = instr.data.typ;
+  VisitTypeSpace ts_val{&t_val, StateSpace::Reg};
+  auto src1 = v.visit(std::move(instr.src1), ts_addr, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_val, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrSt<To>{instr.data, *src1, *src2};
+}
+
+// ── InstrSub ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSub<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  ScalarType st = get_scalar_type(instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSub<To>, Err> map_instr(InstrSub<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  ScalarType st = get_scalar_type(instr.data);
+  Type t = make_scalar(st);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrSub<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrTrap ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrTrap& /*instr*/,
+                                Visitor<Op, Err>& /*v*/) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrTrap, Err> map_instr(InstrTrap instr,
+                                   VisitorMap<From, To, Err>& /*v*/) {
+  return instr;
+}
+
+// ── InstrXor ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrXor<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrXor<To>, Err> map_instr(InstrXor<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrXor<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrTanh ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrTanh<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrTanh<To>, Err> map_instr(InstrTanh<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrTanh<To>{instr.data, *dst, *src};
+}
+
+// ── InstrVote ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrVote<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // Ballot → dst is b32; All/Any → dst is pred
+  ScalarType dst_st = (instr.data.mode == VoteMode::Ballot) ? ScalarType::B32
+                                                            : ScalarType::Pred;
+  Type t_dst = make_scalar(dst_st);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_pred, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts_u32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrVote<To>, Err> map_instr(InstrVote<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  ScalarType dst_st = (instr.data.mode == VoteMode::Ballot) ? ScalarType::B32
+                                                            : ScalarType::Pred;
+  Type t_dst = make_scalar(dst_st);
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_pred = make_scalar(ScalarType::Pred);
+  VisitTypeSpace ts_pred{&t_pred, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_pred, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_u32, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrVote<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrReduxSync ─────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrReduxSync<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src_membermask, ts_u32, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrReduxSync<To>, Err> map_instr(InstrReduxSync<From> instr,
+                                            VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data.type_);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  Type t_u32 = make_scalar(ScalarType::U32);
+  VisitTypeSpace ts_u32{&t_u32, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts, false, false);
+  if (!src)
+    return unexpected(src.error());
+  auto src_membermask =
+      v.visit(std::move(instr.src_membermask), ts_u32, false, false);
+  if (!src_membermask)
+    return unexpected(src_membermask.error());
+  return InstrReduxSync<To>{instr.data, *dst, *src, *src_membermask};
+}
+
+// ── InstrLdMatrix ──────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrLdMatrix<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // dst: loaded matrix fragment (vector of B32) in register file
+  Type t_dst = instr.data.get_loaded_type();
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  // src: shared memory address
+  Type t_src = instr.data.get_loaded_type();
+  VisitTypeSpace ts_src{&t_src, instr.data.state_space};
+  if (auto r = v.visit(instr.dst, ts_dst, true, false); !r)
+    return r;
+  return v.visit(instr.src, ts_src, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrLdMatrix<To>, Err> map_instr(InstrLdMatrix<From> instr,
+                                           VisitorMap<From, To, Err>& v) {
+  Type t_dst = instr.data.get_loaded_type();
+  VisitTypeSpace ts_dst{&t_dst, StateSpace::Reg};
+  Type t_src = instr.data.get_loaded_type();
+  VisitTypeSpace ts_src{&t_src, instr.data.state_space};
+  auto dst = v.visit(std::move(instr.dst), ts_dst, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src = v.visit(std::move(instr.src), ts_src, false, false);
+  if (!src)
+    return unexpected(src.error());
+  return InstrLdMatrix<To>{instr.data, *dst, *src};
+}
+
+// ── InstrGridDepControl ────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrGridDepControl& /*instr*/,
+                                Visitor<Op, Err>& /*v*/) {
+  return {};
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrGridDepControl, Err> map_instr(InstrGridDepControl instr,
+                                             VisitorMap<From, To, Err>& /*v*/) {
+  return instr;
+}
+
+// ── InstrMma ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrMma<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_d = instr.data.dtype();
+  VisitTypeSpace ts_d{&t_d, StateSpace::Reg};
+  Type t_a = instr.data.atype();
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = instr.data.btype();
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  Type t_c = instr.data.ctype();
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_d, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_a, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_b, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_c, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrMma<To>, Err> map_instr(InstrMma<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t_d = instr.data.dtype();
+  VisitTypeSpace ts_d{&t_d, StateSpace::Reg};
+  Type t_a = instr.data.atype();
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = instr.data.btype();
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  Type t_c = instr.data.ctype();
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_d, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_a, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_b, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_c, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrMma<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrCopysign ──────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrCopysign<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src2, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrCopysign<To>, Err> map_instr(InstrCopysign<From> instr,
+                                           VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  return InstrCopysign<To>{instr.data, *dst, *src1, *src2};
+}
+
+// ── InstrPrefetch ──────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrPrefetch<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  // src is a memory address; no data type — use relaxed check
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, instr.data.space};
+  return v.visit(instr.src, ts, false, true /*relaxed*/);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrPrefetch<To>, Err> map_instr(InstrPrefetch<From> instr,
+                                           VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(ScalarType::B64);
+  VisitTypeSpace ts{&t, instr.data.space};
+  auto src = v.visit(std::move(instr.src), ts, false, true /*relaxed*/);
+  if (!src)
+    return unexpected(src.error());
+  return InstrPrefetch<To>{instr.data, *src};
+}
+
+// ── InstrSad ───────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrSad<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrSad<To>, Err> map_instr(InstrSad<From> instr,
+                                      VisitorMap<From, To, Err>& v) {
+  Type t = make_scalar(instr.data);
+  VisitTypeSpace ts{&t, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrSad<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// ── InstrDp2a ──────────────────────────────────────────────────────────────
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instr(const InstrDp2a<Op>& instr,
+                                Visitor<Op, Err>& v) {
+  Type t_c = make_scalar(instr.data.ctype());
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  Type t_a = make_scalar(instr.data.atype);
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = make_scalar(instr.data.btype);
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  if (auto r = v.visit(instr.dst, ts_c, true, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src1, ts_a, false, false); !r)
+    return r;
+  if (auto r = v.visit(instr.src2, ts_b, false, false); !r)
+    return r;
+  return v.visit(instr.src3, ts_c, false, false);
+}
+
+template <OperandLike From, OperandLike To, typename Err>
+expected<InstrDp2a<To>, Err> map_instr(InstrDp2a<From> instr,
+                                       VisitorMap<From, To, Err>& v) {
+  Type t_c = make_scalar(instr.data.ctype());
+  VisitTypeSpace ts_c{&t_c, StateSpace::Reg};
+  Type t_a = make_scalar(instr.data.atype);
+  VisitTypeSpace ts_a{&t_a, StateSpace::Reg};
+  Type t_b = make_scalar(instr.data.btype);
+  VisitTypeSpace ts_b{&t_b, StateSpace::Reg};
+  auto dst = v.visit(std::move(instr.dst), ts_c, true, false);
+  if (!dst)
+    return unexpected(dst.error());
+  auto src1 = v.visit(std::move(instr.src1), ts_a, false, false);
+  if (!src1)
+    return unexpected(src1.error());
+  auto src2 = v.visit(std::move(instr.src2), ts_b, false, false);
+  if (!src2)
+    return unexpected(src2.error());
+  auto src3 = v.visit(std::move(instr.src3), ts_c, false, false);
+  if (!src3)
+    return unexpected(src3.error());
+  return InstrDp2a<To>{instr.data, *dst, *src1, *src2, *src3};
+}
+
+// Instruction<Op> variant entry point
+template <OperandLike Op, typename Err>
+expected<void, Err> visit_instruction(const Instruction<Op>& instr,
+                                      Visitor<Op, Err>& v) {
+  return std::visit([&](const auto& i) { return visit_instr(i, v); }, instr);
+}
+
+// map Instruction<From> → Instruction<To> entry point
+template <OperandLike From, OperandLike To, typename Err>
+expected<Instruction<To>, Err> map_instruction(Instruction<From> instr,
+                                               VisitorMap<From, To, Err>& v) {
+  return std::visit(
+      [&](auto&& i) -> expected<Instruction<To>, Err> {
+        auto r = map_instr(std::move(i), v);
+        if (!r)
+          return unexpected(r.error());
+        return Instruction<To>{std::move(*r)};
+      },
+      std::move(instr));
 }
 
 };  // namespace ptx_frontend

--- a/src/ptx_visit_dispatch.cpp
+++ b/src/ptx_visit_dispatch.cpp
@@ -1,0 +1,20 @@
+#include "ptx_visit_dispatch.hpp"
+#include "ptx_ir.hpp"
+
+namespace ptx_frontend {
+
+template <>
+ScalarType get_scalar_type(const ArithDetails& data) {
+  return std::visit(
+      [](auto&& item) -> ScalarType {
+        using T = std::decay_t<decltype(item)>;
+        if constexpr (std::is_same_v<T, ArithInteger>) {
+          return item.type_;
+        } else if constexpr (std::is_same_v<T, ArithFloat>) {
+          return item.type_;
+        }
+      },
+      data);
+}
+
+};  // namespace ptx_frontend

--- a/test/test_ptx_visit_dispatch.cpp
+++ b/test/test_ptx_visit_dispatch.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+#include <utility>
+#include <variant>
+#include "ptx_ir.hpp"
+#include "ptx_visit_dispatch.hpp"
+
+TEST(PtxVisitDispatch, VisitInstrAdd) {
+  using namespace ptx_frontend;
+
+  // Create a simple InstrAdd with dummy operands
+  InstrAdd<ParsedOperand<Ident>> instr{
+      .data = ArithInteger{ScalarType::U32},
+      .dst =
+          ParsedOperand<Ident>::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src1 =
+          ParsedOperand<Ident>::from_value(RegOrImmediate<Ident>::Reg("src1")),
+      .src2 =
+          ParsedOperand<Ident>::from_value(RegOrImmediate<Ident>::Reg("src2")),
+  };
+
+  // Create a Visitor that checks the visited operands
+  struct TestVisitor : Visitor<ParsedOperand<Ident>, std::string> {
+    expected<void, std::string> visit(const ParsedOperand<Ident>& op,
+                                      std::optional<VisitTypeSpace> ts,
+                                      bool is_dst, bool relaxed) override {
+      // Check that the operand is one of the expected ones
+      auto flag = std::visit(
+          [](auto&& item) -> std::pair<bool, std::string> {
+            using T = std::decay_t<decltype(item)>;
+            if constexpr (std::is_same_v<T, RegOrImmediate<Ident>>) {
+              if (std::holds_alternative<Ident>(item.value)) {
+                auto id = std::get<Ident>(item.value);
+                auto flag_r = id == "dst" || id == "src1" || id == "src2";
+                return {flag_r, std::string(id)};
+              } else {
+                return {false,
+                        ""};  // Immediate value should not appear in this test
+              }
+            } else {
+              return {false, ""};
+            }
+          },
+          op.value);
+
+      if (flag.first) {
+        return {};
+      } else {
+        return tl::unexpected("Unexpected operand: " + flag.second);
+      }
+    }
+
+    expected<void, std::string> visit_ident(const std::string_view& id,
+                                            std::optional<VisitTypeSpace> ts,
+                                            bool is_dst,
+                                            bool relaxed) override {
+      // This should not be called for this test
+      return tl::unexpected("visit_ident should not be called");
+    }
+  } visitor;
+
+  // Call the visit_instr function and check it succeeds
+  auto result = visit_instr(instr, visitor);
+  EXPECT_TRUE(result.has_value());
+}

--- a/test/test_ptx_visit_dispatch.cpp
+++ b/test/test_ptx_visit_dispatch.cpp
@@ -62,3 +62,2679 @@ TEST(PtxVisitDispatch, VisitInstrAdd) {
   auto result = visit_instr(instr, visitor);
   EXPECT_TRUE(result.has_value());
 }
+
+TEST(PtxVisitDispatch, VisitInstrCreatePolicyFractional) {
+  using namespace ptx_frontend;
+
+  InstrCreatePolicyFractional<ParsedOp> instr{
+      .data = CreatePolicyFractionalDetails{EvictionPriority::Normal, 0.5f},
+      .dst_policy = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("policy")),
+  };
+
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool is_dst,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 1u);
+  EXPECT_EQ(visited[0].first, "policy");
+  EXPECT_TRUE(visited[0].second);  // is_dst
+}
+
+TEST(PtxVisitDispatch, MapInstrCreatePolicyFractional) {
+  using namespace ptx_frontend;
+
+  InstrCreatePolicyFractional<ParsedOp> instr{
+      .data = CreatePolicyFractionalDetails{EvictionPriority::Normal, 0.5f},
+      .dst_policy = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("policy")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        // 模拟重命名
+        if (id == "policy")
+          return Ident{"policy_renamed"};
+        return tl::unexpected<std::string>("unknown id");
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto& roi = std::get<RegOrImmediate<Ident>>(r->dst_policy.value);
+  EXPECT_EQ(std::get<Ident>(roi.value), "policy_renamed");
+}
+
+TEST(PtxVisitDispatch, VisitInstrCvt_NoSrc2) {
+  using namespace ptx_frontend;
+
+  InstrCvt<ParsedOp> instr{
+      .data = CvtDetails{ScalarType::F32, ScalarType::S32,
+                         CvtModeFPFromSigned{RoundingMode::NearestEven, false}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+      .src2 = std::nullopt,
+  };
+
+  // collect (ident, is_dst) pairs in visit order
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace>, bool is_dst,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_TRUE(visited[0].second);
+  EXPECT_EQ(visited[1].first, "src");
+  EXPECT_FALSE(visited[1].second);
+}
+
+TEST(PtxVisitDispatch, VisitInstrCvt_WithSrc2) {
+  using namespace ptx_frontend;
+
+  InstrCvt<ParsedOp> instr{
+      .data = CvtDetails{ScalarType::F32, ScalarType::BF16x2,
+                         CvtModeFPTruncate{RoundingMode::NearestEven, false,
+                                           std::nullopt, false, false}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src1")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src2")),
+  };
+
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace>, bool is_dst,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 3u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_TRUE(visited[0].second);
+  EXPECT_EQ(visited[1].first, "src1");
+  EXPECT_FALSE(visited[1].second);
+  EXPECT_EQ(visited[2].first, "src2");
+  EXPECT_FALSE(visited[2].second);
+}
+
+TEST(PtxVisitDispatch, MapInstrCvt) {
+  using namespace ptx_frontend;
+
+  InstrCvt<ParsedOp> instr{
+      .data = CvtDetails{ScalarType::F32, ScalarType::S32,
+                         CvtModeFPFromSigned{RoundingMode::NearestEven, false}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+      .src2 = std::nullopt,
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "dst")
+          return Ident{"dst2"};
+        if (id == "src")
+          return Ident{"src2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto& dst_roi = std::get<RegOrImmediate<Ident>>(r->dst.value);
+  EXPECT_EQ(std::get<Ident>(dst_roi.value), "dst2");
+  auto& src_roi = std::get<RegOrImmediate<Ident>>(r->src.value);
+  EXPECT_EQ(std::get<Ident>(src_roi.value), "src2");
+  EXPECT_FALSE(r->src2.has_value());
+}
+
+TEST(PtxVisitDispatch, VisitInstrCvta) {
+  using namespace ptx_frontend;
+
+  InstrCvta<ParsedOp> instr{
+      .data = CvtaDetails{StateSpace::Global, CvtaDirection::GenericToExplicit},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace>, bool is_dst,
+          bool relaxed) -> expected<void, std::string> {
+        EXPECT_TRUE(relaxed);  // cvta 总是 relaxed
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_TRUE(visited[0].second);
+  EXPECT_EQ(visited[1].first, "src");
+  EXPECT_FALSE(visited[1].second);
+}
+
+TEST(PtxVisitDispatch, MapInstrCvta) {
+  using namespace ptx_frontend;
+
+  InstrCvta<ParsedOp> instr{
+      .data = CvtaDetails{StateSpace::Shared, CvtaDirection::ExplicitToGeneric},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "dst")
+          return Ident{"dst_r"};
+        if (id == "src")
+          return Ident{"src_r"};
+        return tl::unexpected<std::string>("unknown");
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->data.state_space, StateSpace::Shared);
+  auto& dst_roi = std::get<RegOrImmediate<Ident>>(r->dst.value);
+  EXPECT_EQ(std::get<Ident>(dst_roi.value), "dst_r");
+  auto& src_roi = std::get<RegOrImmediate<Ident>>(r->src.value);
+  EXPECT_EQ(std::get<Ident>(src_roi.value), "src_r");
+}
+
+TEST(PtxVisitDispatch, VisitInstrDiv_Int) {
+  using namespace ptx_frontend;
+
+  InstrDiv<ParsedOp> instr{
+      .data = DivInt{DivSign::Signed, ScalarType::S32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src1")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src2")),
+  };
+
+  std::vector<Ident> ids;
+  std::vector<ScalarType> types;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        types.push_back(std::get<ScalarTypeT>(*ts->type).type);
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "dst");
+  EXPECT_EQ(ids[1], "src1");
+  EXPECT_EQ(ids[2], "src2");
+
+  EXPECT_EQ(types[0], ScalarType::S32);
+  EXPECT_EQ(types[1], ScalarType::S32);
+  EXPECT_EQ(types[2], ScalarType::S32);
+}
+
+TEST(PtxVisitDispatch, MapInstrDiv) {
+  using namespace ptx_frontend;
+
+  InstrDiv<ParsedOp> instr{
+      .data = DivInt{DivSign::Unsigned, ScalarType::U32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        return Ident{id == "d" ? "d2" : id == "a" ? "a2" : "b2"};
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+TEST(PtxVisitDispatch, VisitInstrDp4a) {
+  using namespace ptx_frontend;
+
+  // atype=S32, btype=U32 → ctype()=S32
+  InstrDp4a<ParsedOp> instr{
+      .data = Dp4aDetails{ScalarType::S32, ScalarType::U32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src1")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src2")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src3")),
+  };
+
+  std::vector<std::pair<Ident, ScalarType>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value),
+                           std::get<ScalarTypeT>(*ts->type).type});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 4u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_EQ(visited[0].second, ScalarType::S32);  // ctype
+  EXPECT_EQ(visited[1].first, "src1");
+  EXPECT_EQ(visited[1].second, ScalarType::S32);  // atype
+  EXPECT_EQ(visited[2].first, "src2");
+  EXPECT_EQ(visited[2].second, ScalarType::U32);  // btype
+  EXPECT_EQ(visited[3].first, "src3");
+  EXPECT_EQ(visited[3].second, ScalarType::S32);  // ctype (acc)
+}
+
+TEST(PtxVisitDispatch, MapInstrDp4a) {
+  using namespace ptx_frontend;
+
+  InstrDp4a<ParsedOp> instr{
+      .data = Dp4aDetails{ScalarType::U32, ScalarType::U32},  // ctype=U32
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrEx2 ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrEx2) {
+  using namespace ptx_frontend;
+
+  InstrEx2<ParsedOp> instr{
+      .data = TypeFtz{std::nullopt, ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool is_dst,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::F32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_TRUE(visited[0].second);
+  EXPECT_EQ(visited[1].first, "src");
+  EXPECT_FALSE(visited[1].second);
+}
+
+TEST(PtxVisitDispatch, MapInstrEx2) {
+  using namespace ptx_frontend;
+
+  InstrEx2<ParsedOp> instr{
+      .data = TypeFtz{std::nullopt, ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("s")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        return id == "d" ? Ident{"d2"} : Ident{"s2"};
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "s2");
+}
+
+// ── InstrFma ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrFma) {
+  using namespace ptx_frontend;
+
+  InstrFma<ParsedOp> instr{
+      .data = ArithFloat{ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::F32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrFma) {
+  using namespace ptx_frontend;
+
+  InstrFma<ParsedOp> instr{
+      .data = ArithFloat{ScalarType::F64},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        std::string s(id);
+        return Ident{s + "2"};  // 注意：Ident = string_view，测试中用字面量
+      });
+
+  // 字面量版本（避免悬空 string_view）
+  auto vm2 = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+
+  auto r = map_instr(instr, vm2);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrLd ────────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrLd) {
+  using namespace ptx_frontend;
+
+  InstrLd<ParsedOp> instr{
+      .data =
+          LdDetails{
+              .qualifier = LdStQualifierData{LdStQualifier::Weak},
+              .state_space = StateSpace::Global,
+              .caching = LdCacheOperator::Cached,
+              .typ = make_scalar(ScalarType::F32),
+          },
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+  };
+
+  std::vector<std::tuple<Ident, StateSpace, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool is_dst,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), ts->space, is_dst});
+        return {};
+      });
+
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  // dst: Reg 空间
+  EXPECT_EQ(std::get<0>(visited[0]), "dst");
+  EXPECT_EQ(std::get<1>(visited[0]), StateSpace::Reg);
+  EXPECT_TRUE(std::get<2>(visited[0]));
+  // src: Global 地址
+  EXPECT_EQ(std::get<0>(visited[1]), "addr");
+  EXPECT_EQ(std::get<1>(visited[1]), StateSpace::Global);
+  EXPECT_FALSE(std::get<2>(visited[1]));
+}
+
+TEST(PtxVisitDispatch, MapInstrLd) {
+  using namespace ptx_frontend;
+
+  InstrLd<ParsedOp> instr{
+      .data =
+          LdDetails{
+              .qualifier = LdStQualifierData{LdStQualifier::Weak},
+              .state_space = StateSpace::Shared,
+              .typ = make_scalar(ScalarType::U32),
+          },
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("ptr")),
+  };
+
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "dst")
+          return Ident{"dst2"};
+        if (id == "ptr")
+          return Ident{"ptr2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "dst2");
+  EXPECT_EQ(get_id(r->src), "ptr2");
+  EXPECT_EQ(r->data.state_space, StateSpace::Shared);
+}
+
+// ── InstrLg2 ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrLg2) {
+  using namespace ptx_frontend;
+  InstrLg2<ParsedOp> instr{
+      .data = FlushToZero{false},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+  std::vector<std::pair<Ident, ScalarType>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value),
+                           std::get<ScalarTypeT>(*ts->type).type});
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_EQ(visited[0].second, ScalarType::F32);
+  EXPECT_EQ(visited[1].first, "src");
+  EXPECT_EQ(visited[1].second, ScalarType::F32);
+}
+
+// ── InstrMad ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMad_Int) {
+  using namespace ptx_frontend;
+  InstrMad<ParsedOp> instr{
+      .data = MadInt{MulIntControl::Low, false, ScalarType::S32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::S32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrMad) {
+  using namespace ptx_frontend;
+  InstrMad<ParsedOp> instr{
+      .data = MadInt{MulIntControl::Low, false, ScalarType::U32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrMax / InstrMin ─────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMax) {
+  using namespace ptx_frontend;
+  InstrMax<ParsedOp> instr{
+      .data = MinMaxInt{MinMaxSign::Signed, ScalarType::S32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::S32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, VisitInstrMin) {
+  using namespace ptx_frontend;
+  InstrMin<ParsedOp> instr{
+      .data = MinMaxFloat{std::nullopt, false, ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+// ── InstrMembar ────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMembar) {
+  using namespace ptx_frontend;
+  InstrMembar instr{MemScope::Gpu};
+  int call_count = 0;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp&, std::optional<VisitTypeSpace>, bool,
+          bool) -> expected<void, std::string> {
+        ++call_count;
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  EXPECT_EQ(call_count, 0);  // no operands
+}
+
+TEST(PtxVisitDispatch, MapInstrMembar) {
+  using namespace ptx_frontend;
+  InstrMembar instr{MemScope::Sys};
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        return tl::unexpected<std::string>("should not be called");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->data, MemScope::Sys);
+}
+
+// ── InstrMov ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMov) {
+  using namespace ptx_frontend;
+  InstrMov<ParsedOp> instr{
+      .data = MovDetails{make_scalar(ScalarType::B32)},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace>, bool is_dst,
+          bool relaxed) -> expected<void, std::string> {
+        EXPECT_TRUE(relaxed);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  EXPECT_TRUE(r.has_value());
+  ASSERT_EQ(visited.size(), 2u);
+  EXPECT_EQ(visited[0].first, "dst");
+  EXPECT_TRUE(visited[0].second);
+  EXPECT_EQ(visited[1].first, "src");
+  EXPECT_FALSE(visited[1].second);
+}
+
+TEST(PtxVisitDispatch, MapInstrMov) {
+  using namespace ptx_frontend;
+  InstrMov<ParsedOp> instr{
+      .data = MovDetails{make_scalar(ScalarType::U64)},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("s")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        return id == "d" ? Ident{"d2"} : Ident{"s2"};
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "s2");
+}
+
+// ── InstrMul ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMul_Wide) {
+  using namespace ptx_frontend;
+  // mul.wide.s32: src=S32, dst=S64
+  InstrMul<ParsedOp> instr{
+      .data = MulInt{ScalarType::S32, MulIntControl::Wide},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::pair<Ident, ScalarType>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value),
+                           std::get<ScalarTypeT>(*ts->type).type});
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(visited.size(), 3u);
+  EXPECT_EQ(visited[0].first, "d");
+  EXPECT_EQ(visited[0].second, ScalarType::S64);  // widened
+  EXPECT_EQ(visited[1].first, "a");
+  EXPECT_EQ(visited[1].second, ScalarType::S32);
+  EXPECT_EQ(visited[2].first, "b");
+  EXPECT_EQ(visited[2].second, ScalarType::S32);
+}
+
+TEST(PtxVisitDispatch, MapInstrMul) {
+  using namespace ptx_frontend;
+  InstrMul<ParsedOp> instr{
+      .data = MulInt{ScalarType::U32, MulIntControl::Low},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrMul24 ─────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMul24) {
+  using namespace ptx_frontend;
+  InstrMul24<ParsedOp> instr{
+      .data = Mul24Details{ScalarType::S32, Mul24Control::Lo},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::S32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+// ── InstrNanosleep ─────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrNanosleep) {
+  using namespace ptx_frontend;
+  InstrNanosleep<ParsedOp> instr{
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("delay")),
+  };
+  std::vector<std::pair<Ident, bool>> visited;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool is_dst,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::U32);
+        EXPECT_FALSE(is_dst);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        visited.push_back({std::get<Ident>(roi.value), is_dst});
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(visited.size(), 1u);
+  EXPECT_EQ(visited[0].first, "delay");
+}
+
+TEST(PtxVisitDispatch, MapInstrNanosleep) {
+  using namespace ptx_frontend;
+  InstrNanosleep<ParsedOp> instr{
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto& roi = std::get<RegOrImmediate<Ident>>(r->src.value);
+  EXPECT_EQ(std::get<Ident>(roi.value), "d2");
+}
+
+// ── InstrNeg ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrNeg) {
+  using namespace ptx_frontend;
+  InstrNeg<ParsedOp> instr{
+      .data = TypeFtz{true, ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::F32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "dst");
+  EXPECT_EQ(ids[1], "src");
+}
+
+// ── InstrNot ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrNot) {
+  using namespace ptx_frontend;
+  InstrNot<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("dst")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("src")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::B32);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "dst");
+  EXPECT_EQ(ids[1], "src");
+}
+
+// ── InstrOr ────────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrOr) {
+  using namespace ptx_frontend;
+  InstrOr<ParsedOp> instr{
+      .data = ScalarType::B64,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<Ident> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&](const ParsedOp& op, std::optional<VisitTypeSpace> ts, bool,
+          bool) -> expected<void, std::string> {
+        EXPECT_EQ(std::get<ScalarTypeT>(*ts->type).type, ScalarType::B64);
+        auto& roi = std::get<RegOrImmediate<Ident>>(op.value);
+        ids.push_back(std::get<Ident>(roi.value));
+        return {};
+      });
+  EXPECT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrOr) {
+  using namespace ptx_frontend;
+  InstrOr<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrPopc ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrPopc) {
+  using namespace ptx_frontend;
+  InstrPopc<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrPopc) {
+  using namespace ptx_frontend;
+  InstrPopc<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrPrmt ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrPrmt) {
+  using namespace ptx_frontend;
+  InstrPrmt<ParsedOp> instr{
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrPrmt) {
+  using namespace ptx_frontend;
+  InstrPrmt<ParsedOp> instr{
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrRcp ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrRcp) {
+  using namespace ptx_frontend;
+  InstrRcp<ParsedOp> instr{
+      .data = RcpData{.kind = RcpKind{std::monostate{}},
+                      .flush_to_zero = std::nullopt,
+                      .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrRcp) {
+  using namespace ptx_frontend;
+  InstrRcp<ParsedOp> instr{
+      .data = RcpData{.kind = RcpKind{std::monostate{}},
+                      .flush_to_zero = std::nullopt,
+                      .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrRem ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrRem) {
+  using namespace ptx_frontend;
+  InstrRem<ParsedOp> instr{
+      .data = ScalarType::S32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrRem) {
+  using namespace ptx_frontend;
+  InstrRem<ParsedOp> instr{
+      .data = ScalarType::S32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrRet ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrRet) {
+  using namespace ptx_frontend;
+  InstrRet instr{.data = RetData{.uniform = false}};
+  auto v = make_visitor<ParsedOp, std::string>(
+      [](const ParsedOp&, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<void, std::string> { return {}; });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+}
+
+TEST(PtxVisitDispatch, MapInstrRet) {
+  using namespace ptx_frontend;
+  InstrRet instr{.data = RetData{.uniform = true}};
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> { return id; });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->data.uniform, true);
+}
+
+// ── InstrRsqrt ─────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrRsqrt) {
+  using namespace ptx_frontend;
+  InstrRsqrt<ParsedOp> instr{
+      .data = TypeFtz{.flush_to_zero = false, .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instr(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrRsqrt) {
+  using namespace ptx_frontend;
+  InstrRsqrt<ParsedOp> instr{
+      .data = TypeFtz{.flush_to_zero = false, .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrSelp ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSelp) {
+  using namespace ptx_frontend;
+  InstrSelp<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "p");
+}
+
+TEST(PtxVisitDispatch, MapInstrSelp) {
+  using namespace ptx_frontend;
+  InstrSelp<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "p")
+          return Ident{"p2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "p2");
+}
+
+// ── InstrSet ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSet) {
+  using namespace ptx_frontend;
+  InstrSet<ParsedOp> instr{
+      .data = SetData{.dtype = ScalarType::U32,
+                      .base = SetpData{.type_ = ScalarType::F32,
+                                       .flush_to_zero = std::nullopt,
+                                       .cmp_op = SetpCompareFloat::Less}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrSet) {
+  using namespace ptx_frontend;
+  InstrSet<ParsedOp> instr{
+      .data = SetData{.dtype = ScalarType::U32,
+                      .base = SetpData{.type_ = ScalarType::F32,
+                                       .flush_to_zero = std::nullopt,
+                                       .cmp_op = SetpCompareFloat::Less}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrSetBool ───────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSetBool) {
+  using namespace ptx_frontend;
+  InstrSetBool<ParsedOp> instr{
+      .data =
+          SetBoolData{
+              .dtype = ScalarType::U32,
+              .base =
+                  SetpBoolData{
+                      .base = SetpData{.type_ = ScalarType::S32,
+                                       .flush_to_zero = std::nullopt,
+                                       .cmp_op = SetpCompareInt::SignedLess},
+                      .bool_op = SetpBoolPostOp::And,
+                      .negate_src3 = false}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "p");
+}
+
+TEST(PtxVisitDispatch, MapInstrSetBool) {
+  using namespace ptx_frontend;
+  InstrSetBool<ParsedOp> instr{
+      .data =
+          SetBoolData{
+              .dtype = ScalarType::U32,
+              .base =
+                  SetpBoolData{
+                      .base = SetpData{.type_ = ScalarType::S32,
+                                       .flush_to_zero = std::nullopt,
+                                       .cmp_op = SetpCompareInt::SignedLess},
+                      .bool_op = SetpBoolPostOp::And,
+                      .negate_src3 = false}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "p")
+          return Ident{"p2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "p2");
+}
+
+// ── InstrSetp ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSetp) {
+  using namespace ptx_frontend;
+  InstrSetp<ParsedOp> instr{
+      .data = SetpData{.type_ = ScalarType::S32,
+                       .flush_to_zero = std::nullopt,
+                       .cmp_op = SetpCompareInt::SignedLess},
+      .dst1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p1")),
+      .dst2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p2")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "p1");
+  EXPECT_EQ(ids[1], "p2");
+  EXPECT_EQ(ids[2], "a");
+  EXPECT_EQ(ids[3], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrSetp) {
+  using namespace ptx_frontend;
+  InstrSetp<ParsedOp> instr{
+      .data = SetpData{.type_ = ScalarType::S32,
+                       .flush_to_zero = std::nullopt,
+                       .cmp_op = SetpCompareInt::SignedLess},
+      .dst1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p1")),
+      .dst2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p2")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "p1")
+          return Ident{"p1x"};
+        if (id == "p2")
+          return Ident{"p2x"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst1), "p1x");
+  ASSERT_TRUE(r->dst2.has_value());
+  EXPECT_EQ(get_id(*r->dst2), "p2x");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrSetpBool ──────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSetpBool) {
+  using namespace ptx_frontend;
+  InstrSetpBool<ParsedOp> instr{
+      .data =
+          SetpBoolData{.base = SetpData{.type_ = ScalarType::S32,
+                                        .flush_to_zero = std::nullopt,
+                                        .cmp_op = SetpCompareInt::SignedLess},
+                       .bool_op = SetpBoolPostOp::And,
+                       .negate_src3 = false},
+      .dst1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p1")),
+      .dst2 = std::nullopt,
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("q")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);  // dst2 absent
+  EXPECT_EQ(ids[0], "p1");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "q");
+}
+
+TEST(PtxVisitDispatch, MapInstrSetpBool) {
+  using namespace ptx_frontend;
+  InstrSetpBool<ParsedOp> instr{
+      .data =
+          SetpBoolData{.base = SetpData{.type_ = ScalarType::S32,
+                                        .flush_to_zero = std::nullopt,
+                                        .cmp_op = SetpCompareInt::SignedLess},
+                       .bool_op = SetpBoolPostOp::And,
+                       .negate_src3 = false},
+      .dst1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p1")),
+      .dst2 = std::nullopt,
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("q")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "p1")
+          return Ident{"p1x"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "q")
+          return Ident{"q2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst1), "p1x");
+  EXPECT_FALSE(r->dst2.has_value());
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "q2");
+}
+
+// ── InstrShflSync ──────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrShflSync) {
+  using namespace ptx_frontend;
+  InstrShflSync<ParsedOp> instr{
+      .data = ShflSyncDetails{.mode = ShuffleMode::Idx},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .dst_pred = std::nullopt,
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_lane = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("lane")),
+      .src_opts = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("opts")),
+      .src_membermask =
+          ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 5u);  // dst_pred absent
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "lane");
+  EXPECT_EQ(ids[3], "opts");
+  EXPECT_EQ(ids[4], "mask");
+}
+
+TEST(PtxVisitDispatch, MapInstrShflSync) {
+  using namespace ptx_frontend;
+  InstrShflSync<ParsedOp> instr{
+      .data = ShflSyncDetails{.mode = ShuffleMode::Idx},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .dst_pred = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_lane = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("lane")),
+      .src_opts = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("opts")),
+      .src_membermask =
+          ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        std::string s(id);
+        return Ident{
+            (s + "2").c_str()};  // NOTE: dangling — use arena in real code
+      });
+  // Use simpler identity rename for test correctness
+  auto vm2 = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "p")
+          return Ident{"p2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "lane")
+          return Ident{"lane2"};
+        if (id == "opts")
+          return Ident{"opts2"};
+        if (id == "mask")
+          return Ident{"mask2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm2);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  ASSERT_TRUE(r->dst_pred.has_value());
+  EXPECT_EQ(get_id(*r->dst_pred), "p2");
+  EXPECT_EQ(get_id(r->src), "a2");
+  EXPECT_EQ(get_id(r->src_lane), "lane2");
+  EXPECT_EQ(get_id(r->src_opts), "opts2");
+  EXPECT_EQ(get_id(r->src_membermask), "mask2");
+}
+
+// ── InstrShf ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrShf) {
+  using namespace ptx_frontend;
+  InstrShf<ParsedOp> instr{
+      .data = ShfDetails{.direction = ShiftDirection::Left,
+                         .mode = FunnelShiftMode::Clamp},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src_a = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_b = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src_c = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrShf) {
+  using namespace ptx_frontend;
+  InstrShf<ParsedOp> instr{
+      .data = ShfDetails{.direction = ShiftDirection::Left,
+                         .mode = FunnelShiftMode::Clamp},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src_a = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_b = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src_c = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src_a), "a2");
+  EXPECT_EQ(get_id(r->src_b), "b2");
+  EXPECT_EQ(get_id(r->src_c), "c2");
+}
+
+// ── InstrShl ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrShl) {
+  using namespace ptx_frontend;
+  InstrShl<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("n")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "n");
+}
+
+TEST(PtxVisitDispatch, MapInstrShl) {
+  using namespace ptx_frontend;
+  InstrShl<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("n")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "n")
+          return Ident{"n2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "n2");
+}
+
+// ── InstrShr ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrShr) {
+  using namespace ptx_frontend;
+  InstrShr<ParsedOp> instr{
+      .data =
+          ShrData{.type_ = ScalarType::S32, .kind = RightShiftKind::Arithmetic},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("n")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "n");
+}
+
+TEST(PtxVisitDispatch, MapInstrShr) {
+  using namespace ptx_frontend;
+  InstrShr<ParsedOp> instr{
+      .data =
+          ShrData{.type_ = ScalarType::S32, .kind = RightShiftKind::Arithmetic},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("n")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "n")
+          return Ident{"n2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "n2");
+}
+
+// ── InstrSin ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSin) {
+  using namespace ptx_frontend;
+  InstrSin<ParsedOp> instr{
+      .data = FlushToZero{.flush_to_zero = false},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrSin) {
+  using namespace ptx_frontend;
+  InstrSin<ParsedOp> instr{
+      .data = FlushToZero{.flush_to_zero = false},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrSqrt ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSqrt) {
+  using namespace ptx_frontend;
+  InstrSqrt<ParsedOp> instr{
+      .data = RcpData{.kind = RcpKind{std::monostate{}},
+                      .flush_to_zero = std::nullopt,
+                      .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrSqrt) {
+  using namespace ptx_frontend;
+  InstrSqrt<ParsedOp> instr{
+      .data = RcpData{.kind = RcpKind{std::monostate{}},
+                      .flush_to_zero = std::nullopt,
+                      .type_ = ScalarType::F32},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrSt ────────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSt) {
+  using namespace ptx_frontend;
+  InstrSt<ParsedOp> instr{
+      .data = StData{.qualifier = LdStQualifierData{},
+                     .state_space = StateSpace::Global,
+                     .caching = StCacheOperator::Writeback,
+                     .typ = make_scalar(ScalarType::F32)},
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("val")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "addr");
+  EXPECT_EQ(ids[1], "val");
+}
+
+TEST(PtxVisitDispatch, MapInstrSt) {
+  using namespace ptx_frontend;
+  InstrSt<ParsedOp> instr{
+      .data = StData{.qualifier = LdStQualifierData{},
+                     .state_space = StateSpace::Global,
+                     .caching = StCacheOperator::Writeback,
+                     .typ = make_scalar(ScalarType::F32)},
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("val")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "addr")
+          return Ident{"addr2"};
+        if (id == "val")
+          return Ident{"val2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->src1), "addr2");
+  EXPECT_EQ(get_id(r->src2), "val2");
+}
+
+// ── InstrSub ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSub) {
+  using namespace ptx_frontend;
+  InstrSub<ParsedOp> instr{
+      .data = ArithDetails{ArithInteger{.type_ = ScalarType::S32}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrSub) {
+  using namespace ptx_frontend;
+  InstrSub<ParsedOp> instr{
+      .data = ArithDetails{ArithInteger{.type_ = ScalarType::S32}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrTrap ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrTrap) {
+  using namespace ptx_frontend;
+  InstrTrap instr{};
+  auto v = make_visitor<ParsedOp, std::string>(
+      [](const ParsedOp&, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<void, std::string> { return {}; });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+}
+
+TEST(PtxVisitDispatch, MapInstrTrap) {
+  using namespace ptx_frontend;
+  InstrTrap instr{};
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> { return id; });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+}
+
+// ── InstrXor ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrXor) {
+  using namespace ptx_frontend;
+  InstrXor<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrXor) {
+  using namespace ptx_frontend;
+  InstrXor<ParsedOp> instr{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrTanh ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrTanh) {
+  using namespace ptx_frontend;
+  InstrTanh<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+}
+
+TEST(PtxVisitDispatch, MapInstrTanh) {
+  using namespace ptx_frontend;
+  InstrTanh<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+}
+
+// ── InstrVote ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrVote) {
+  using namespace ptx_frontend;
+  // Ballot mode: dst is b32
+  InstrVote<ParsedOp> instr{
+      .data = VoteDetails{.mode = VoteMode::Ballot, .negate = false},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "p");
+  EXPECT_EQ(ids[2], "mask");
+}
+
+TEST(PtxVisitDispatch, MapInstrVote) {
+  using namespace ptx_frontend;
+  InstrVote<ParsedOp> instr{
+      .data = VoteDetails{.mode = VoteMode::Ballot, .negate = false},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("p")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "p")
+          return Ident{"p2"};
+        if (id == "mask")
+          return Ident{"mask2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "p2");
+  EXPECT_EQ(get_id(r->src2), "mask2");
+}
+
+// ── InstrReduxSync ─────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrReduxSync) {
+  using namespace ptx_frontend;
+  InstrReduxSync<ParsedOp> instr{
+      .data =
+          ReduxSyncData{.type_ = ScalarType::U32, .reduction = Reduction::And},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_membermask =
+          ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "mask");
+}
+
+TEST(PtxVisitDispatch, MapInstrReduxSync) {
+  using namespace ptx_frontend;
+  InstrReduxSync<ParsedOp> instr{
+      .data =
+          ReduxSyncData{.type_ = ScalarType::U32, .reduction = Reduction::And},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src_membermask =
+          ParsedOp::from_value(RegOrImmediate<Ident>::Reg("mask")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "mask")
+          return Ident{"mask2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "a2");
+  EXPECT_EQ(get_id(r->src_membermask), "mask2");
+}
+
+// ── InstrLdMatrix ──────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrLdMatrix) {
+  using namespace ptx_frontend;
+  InstrLdMatrix<ParsedOp> instr{
+      .data = LdMatrixDetails{.shape = MatrixShape::M8N8,
+                              .number = MatrixNumber::X1,
+                              .transpose = false,
+                              .state_space = StateSpace::Shared,
+                              .type_ = ScalarType::B16},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 2u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "addr");
+}
+
+TEST(PtxVisitDispatch, MapInstrLdMatrix) {
+  using namespace ptx_frontend;
+  InstrLdMatrix<ParsedOp> instr{
+      .data = LdMatrixDetails{.shape = MatrixShape::M8N8,
+                              .number = MatrixNumber::X1,
+                              .transpose = false,
+                              .state_space = StateSpace::Shared,
+                              .type_ = ScalarType::B16},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "addr")
+          return Ident{"addr2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src), "addr2");
+}
+
+// ── InstrGridDepControl ────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrGridDepControl) {
+  using namespace ptx_frontend;
+  InstrGridDepControl instr{.data = GridDepControlAction::LaunchDependents};
+  auto v = make_visitor<ParsedOp, std::string>(
+      [](const ParsedOp&, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<void, std::string> { return {}; });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+}
+
+TEST(PtxVisitDispatch, MapInstrGridDepControl) {
+  using namespace ptx_frontend;
+  InstrGridDepControl instr{.data = GridDepControlAction::WaitOnDependent};
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> { return id; });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  EXPECT_EQ(r->data, GridDepControlAction::WaitOnDependent);
+}
+
+// ── InstrMma ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrMma) {
+  using namespace ptx_frontend;
+  InstrMma<ParsedOp> instr{
+      .data = MmaDetails{.alayout = MatrixLayout::RowMajor,
+                         .blayout = MatrixLayout::ColMajor,
+                         .cd_type_scalar = ScalarType::F32,
+                         .ab_type_scalar = ScalarType::F16},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrMma) {
+  using namespace ptx_frontend;
+  InstrMma<ParsedOp> instr{
+      .data = MmaDetails{.alayout = MatrixLayout::RowMajor,
+                         .blayout = MatrixLayout::ColMajor,
+                         .cd_type_scalar = ScalarType::F32,
+                         .ab_type_scalar = ScalarType::F16},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrCopysign ──────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrCopysign) {
+  using namespace ptx_frontend;
+  InstrCopysign<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstrCopysign) {
+  using namespace ptx_frontend;
+  InstrCopysign<ParsedOp> instr{
+      .data = ScalarType::F32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+}
+
+// ── InstrPrefetch ──────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrPrefetch) {
+  using namespace ptx_frontend;
+  InstrPrefetch<ParsedOp> instr{
+      .data =
+          PrefetchData{.space = StateSpace::Global, .level = CacheLevel::L1},
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 1u);
+  EXPECT_EQ(ids[0], "addr");
+}
+
+TEST(PtxVisitDispatch, MapInstrPrefetch) {
+  using namespace ptx_frontend;
+  InstrPrefetch<ParsedOp> instr{
+      .data =
+          PrefetchData{.space = StateSpace::Global, .level = CacheLevel::L1},
+      .src = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("addr")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "addr")
+          return Ident{"addr2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->src), "addr2");
+}
+
+// ── InstrSad ───────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrSad) {
+  using namespace ptx_frontend;
+  InstrSad<ParsedOp> instr{
+      .data = ScalarType::U32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrSad) {
+  using namespace ptx_frontend;
+  InstrSad<ParsedOp> instr{
+      .data = ScalarType::U32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── InstrDp2a ──────────────────────────────────────────────────────────────
+TEST(PtxVisitDispatch, VisitInstrDp2a) {
+  using namespace ptx_frontend;
+  InstrDp2a<ParsedOp> instr{
+      .data = Dp2aData{.atype = ScalarType::U32,
+                       .btype = ScalarType::U32,
+                       .control = Dp2aControl::Low},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  ASSERT_TRUE(visit_instr(instr, v).has_value());
+  ASSERT_EQ(ids.size(), 4u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+  EXPECT_EQ(ids[3], "c");
+}
+
+TEST(PtxVisitDispatch, MapInstrDp2a) {
+  using namespace ptx_frontend;
+  InstrDp2a<ParsedOp> instr{
+      .data = Dp2aData{.atype = ScalarType::U32,
+                       .btype = ScalarType::U32,
+                       .control = Dp2aControl::Low},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+      .src3 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("c")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        if (id == "c")
+          return Ident{"c2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instr(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(r->dst), "d2");
+  EXPECT_EQ(get_id(r->src1), "a2");
+  EXPECT_EQ(get_id(r->src2), "b2");
+  EXPECT_EQ(get_id(r->src3), "c2");
+}
+
+// ── visit_instruction / map_instruction (unified variant entry points) ─────
+TEST(PtxVisitDispatch, VisitInstruction) {
+  using namespace ptx_frontend;
+  // Use InstrAdd wrapped in Instruction<ParsedOp> to exercise the unified
+  // std::visit dispatch.
+  Instruction<ParsedOp> instr = InstrAdd<ParsedOp>{
+      .data = ArithDetails{ArithInteger{.type_ = ScalarType::S32}},
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  std::vector<std::string> ids;
+  auto v = make_visitor<ParsedOp, std::string>(
+      [&ids](const ParsedOp& op, std::optional<VisitTypeSpace>, bool,
+             bool) -> expected<void, std::string> {
+        ids.push_back(std::string(
+            std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value)));
+        return {};
+      });
+  auto r = visit_instruction(instr, v);
+  ASSERT_TRUE(r.has_value());
+  ASSERT_EQ(ids.size(), 3u);
+  EXPECT_EQ(ids[0], "d");
+  EXPECT_EQ(ids[1], "a");
+  EXPECT_EQ(ids[2], "b");
+}
+
+TEST(PtxVisitDispatch, MapInstruction) {
+  using namespace ptx_frontend;
+  // Use InstrOr wrapped in Instruction<ParsedOp> to exercise the unified
+  // map dispatch, verifying the result is held as InstrOr<ParsedOp>.
+  Instruction<ParsedOp> instr = InstrOr<ParsedOp>{
+      .data = ScalarType::B32,
+      .dst = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("d")),
+      .src1 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("a")),
+      .src2 = ParsedOp::from_value(RegOrImmediate<Ident>::Reg("b")),
+  };
+  auto vm = make_visitor_map<ParsedOp, ParsedOp, std::string>(
+      [](Ident id, std::optional<VisitTypeSpace>, bool,
+         bool) -> expected<Ident, std::string> {
+        if (id == "d")
+          return Ident{"d2"};
+        if (id == "a")
+          return Ident{"a2"};
+        if (id == "b")
+          return Ident{"b2"};
+        return tl::unexpected<std::string>("unknown");
+      });
+  auto r = map_instruction(instr, vm);
+  ASSERT_TRUE(r.has_value());
+  // The result variant must hold InstrOr<ParsedOp>
+  ASSERT_TRUE(std::holds_alternative<InstrOr<ParsedOp>>(*r));
+  const auto& result = std::get<InstrOr<ParsedOp>>(*r);
+  auto get_id = [](const ParsedOp& op) {
+    return std::get<Ident>(std::get<RegOrImmediate<Ident>>(op.value).value);
+  };
+  EXPECT_EQ(get_id(result.dst), "d2");
+  EXPECT_EQ(get_id(result.src1), "a2");
+  EXPECT_EQ(get_id(result.src2), "b2");
+}


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the PTX frontend's C++ codebase, focusing on enhancing type safety, extensibility, and maintainability. The most significant changes include enforcing the `OperandLike` concept for instruction templates, improving the visitor pattern infrastructure, and adding support for unit testing with GoogleTest.

**Type Safety and Template Constraints:**

* All instruction and related template structs in `ptx_ir.hpp` now require their operand type parameter to satisfy the `OperandLike` concept, improving type safety and clarity throughout the IR definitions. [[1]](diffhunk://#diff-90a840733aa99dccb6db01de96120eb0a5d6f4b49a2524973c9e51c17f4a457bL802-R872) [[2]](diffhunk://#diff-90a840733aa99dccb6db01de96120eb0a5d6f4b49a2524973c9e51c17f4a457bL1236-R1240) [[3]](diffhunk://#diff-90a840733aa99dccb6db01de96120eb0a5d6f4b49a2524973c9e51c17f4a457bL1304-R1308)

* Introduced a `CvtPackDetails` struct and updated `InstrCvtPack` to use it instead of a single `ScalarType`, making the conversion semantics clearer and more extensible.

**Visitor Pattern Improvements:**

* Enhanced the visitor infrastructure in `ptx_visit.hpp`:
  - Improved documentation and comments for clarity, especially regarding lambda visitor usage. [[1]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL34-R35) [[2]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL47-R55)
  - Updated the default `visit_ident` implementation to wrap raw IDs as `RegOrImmediate` operands for consistency.
  - Removed the unused `VisitorMut` interface to simplify the codebase.
  - Improved template usage in `VisitorMap` and `LambdaVisitorMap` for better type inference and error handling. [[1]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL88-R75) [[2]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL108-R95)

**Testing Infrastructure:**

* Added a test target `ptx_frontend_test` in `CMakeLists.txt`, linking against GoogleTest and the main library, enabling unit testing for the PTX frontend.

**Miscellaneous:**

* Added a specialization of `get_scalar_type` for `ArithDetails` in `ptx_visit_dispatch.cpp` to facilitate type extraction from variant types.
* Minor documentation and comment improvements throughout for better readability and maintainability. [[1]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL34-R35) [[2]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL47-R55) [[3]](diffhunk://#diff-ebbcbc83af858b3b272ac41c2c8895efb5e01dd95990e484b9441d6cb61a14ddL88-R75)

These changes collectively improve the robustness, clarity, and testability of the PTX frontend codebase.