### PR TITLE
feat: add ld/st memory consistency qualifiers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ When delegating:
 
 These files define project-wide delegation behavior.
 
+## Required skill: Ponytail
+
+Ponytail is mandatory for every coding, design, refactoring, debugging, dependency-selection, and code-review task in this repository.
+
+- Before substantive work, actually load the upstream `ponytail` skill in `full` mode (the default) and keep it active for the task. A link or this summary is not activation. Never claim Ponytail was used or active unless its `SKILL.md` was genuinely loaded; if it is unavailable, say so explicitly and apply these constraints directly.
+- Canonical source and Codex installation: [`DietrichGebert/ponytail`](https://github.com/DietrichGebert/ponytail) — run `codex plugin marketplace add DietrichGebert/ponytail`, then `codex plugin add ponytail@ponytail`; review and trust its hooks in `/hooks`, then start a new thread. Do not vendor a copy into this repository.
+- Minimize only after understanding: read the affected code and trace the real flow end to end, then choose the smallest root-cause solution. Never minimize away required validation, data-loss-preventing error handling, security controls, accessibility, or tests/checks for changed non-trivial behavior.
+
 ## Primary agent responsibilities
 
 The primary Sol agent is responsible for:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ The frontend currently provides:
   `.ca/.cg/.cs/.lu/.cv`, legacy `st` cache operators
   `.wb/.cg/.cs/.wt`, explicit `.const/.global/.local/.param/.shared` loads,
   and explicit `.global/.local/.param/.shared` stores, including data-driven
+  `.weak/.volatile/.relaxed.scope/.acquire.scope/.release.scope` consistency
+  qualifiers and PTX 8.2 `.mmio.relaxed.sys` (legacy vectors intentionally
+  exclude mmio),
   generic bound-space policies, exact explicit bound-symbol address-space
   checks, and input/return direction checks for bound `.param` addresses;
   operand register compatibility permits PTX's wider load destination/store

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -24,8 +24,9 @@ plus legacy `.v2/.v4` vector `ld`/`st` exercise the dereferenced-address path
 for 14 bit-size, integer, and floating-point types from 8 through 64 bits.
 Legacy memory-vector payloads are capped at 128 bits: `.v2` accepts modeled
 types through 64 bits, `.v4` through 32 bits, and `.v4` 64-bit remains deferred.
-Other source forms, modern memory vectors, complete memory qualifiers, `call`
-groups, CFG/SSA, and target lowering remain later work.
+Other source forms, modern memory vectors, remaining qualifier extensions,
+static address alignment, `call` groups, CFG/SSA, and target lowering remain
+later work.
 
 The generated public layer also provides an opcode-independent boundary:
 
@@ -219,6 +220,16 @@ the ISA still makes omitted `ld` behave as `.ca` and omitted `st` behave as
 `.wb`, while the IR preserves `Unspecified` so omitted source does not masquerade
 as an explicit modifier and does not trigger cache-value availability checks.
 
+Memory consistency is a generated cross-modifier descriptor, not a Cartesian
+set of `ld/st` variants. `MemoryConsistency::Omitted` (empty `locs`) remains
+distinct from explicit `.weak`; `.volatile`, `.relaxed`, `.acquire`, and
+`.release` retain their modifier locations. The checker requires scope only
+for relaxed/acquire/release, rejects cache with volatile/ordered/mmio forms,
+uses known address-space identity without guessing unknown generic addresses,
+and applies the global/shared, `volatile.local` PTX 9.1, and scalar
+`.mmio.relaxed.sys` rules. Modern vector forms and static alignment checks are
+still deferred.
+
 `ResolvedAddress` separately records the enclosing function kind. Generated
 address views derive an optional parameter direction only from a bound
 `InputParameter` or `ReturnParameter`; they do not infer it from spelling.
@@ -398,6 +409,7 @@ Implementation entry points are `submod/resolved_ir/include/ptx_resolved_ir.hpp`
 
 Function-local call-argument `.param` memory, qualified `::entry`/`::func`
 forms, call adjacency/predication constraints, modern memory vector forms,
-`.b128`, declaration-type availability for wider `.b128` registers, and memory
-consistency qualifiers remain outside this slice. Legacy scalar/vector `ld/st`
-cache operators and legacy `.v2/.v4` braced memory vectors are covered here.
+`.b128`, declaration-type availability for wider `.b128` registers, modern
+memory vector forms, and static memory-address alignment checks remain outside
+this slice. Legacy scalar/vector `ld/st` cache operators, legacy `.v2/.v4`
+braced memory vectors, and memory-consistency qualifiers are covered here.

--- a/docs/us-en/syntax_coverage.md
+++ b/docs/us-en/syntax_coverage.md
@@ -22,7 +22,7 @@ PTX ISA support. The reference grammar is NVIDIA's
 | Other directives | Not supported (rejected) | Debug, section, pragma, module variable, and structured kernel-tuning directives; unmodeled function-header tokens never silently enter the AST |
 | Structured control syntax | Not supported | Nested scopes and directive-driven control-flow metadata |
 | Recovery/editing | Not supported | Missing tokens, recovery nodes, multi-error parsing, and token edits |
-| Resolved opcodes | Partial | Only opcodes present in the YAML database; currently `add`, `sub`, `bar`, `bra`, selected scalar/vector `mov`, and generic/basic-explicit scalar plus legacy `.v2/.v4` braced-vector `ld`/`st` for `.b8/.b16/.b32/.b64`, `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`, and `.f32/.f64`; legacy vector payloads are at most 128 bits (`.v2` through 64-bit types, `.v4` through 32-bit types; `.v4` 64-bit is deferred); generic loads accept known `.const/.global/.local/.shared` spaces (`.const` requires PTX 3.1), generic stores accept `.global/.local/.shared`, and explicit forms require an exact runtime-modifier match; bound `.param` loads require input parameters and stores require return parameters, with function-context PTX/SM checks; load destination/store source registers and vector elements may be wider under the bit/integer/float kind rules, while other typed operands remain same-width and unknown address identity is not inferred |
+| Resolved opcodes | Partial | Only opcodes present in the YAML database; currently `add`, `sub`, `bar`, `bra`, selected scalar/vector `mov`, and generic/basic-explicit scalar plus legacy `.v2/.v4` braced-vector `ld`/`st` for `.b8/.b16/.b32/.b64`, `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`, and `.f32/.f64`; `ld/st` support omitted/explicit `.weak`, `.volatile`, scoped relaxed/acquire/release, and PTX 8.2 scalar `.mmio.relaxed.sys`, with generated cross-modifier checks; modern vectors and static alignment checking remain deferred; legacy vector payloads are at most 128 bits (`.v2` through 64-bit types, `.v4` through 32-bit types; `.v4` 64-bit is deferred); generic loads accept known `.const/.global/.local/.shared` spaces (`.const` requires PTX 3.1), generic stores accept `.global/.local/.shared`, and explicit forms require an exact runtime-modifier match; bound `.param` loads require input parameters and stores require return parameters, with function-context PTX/SM checks; load destination/store source registers and vector elements may be wider under the bit/integer/float kind rules, while other typed operands remain same-width and unknown address identity is not inferred |
 
 The lexer may tokenize source outside this matrix, and Syntax AST may retain an
 unknown opcode as text. Neither behavior means that the construct can be
@@ -30,8 +30,8 @@ lowered to Resolved IR.
 
 ## Near-term order
 
-1. Extend `ld/st` with memory consistency qualifiers, modern vector forms, and
-   cross-modifier rules. `.b128` is not part of the current
+1. Extend `ld/st` with modern vector forms, static alignment checks, and the
+   remaining cross-modifier rules. `.b128` is not part of the current
    scalar family. Function-local call argument `.param`, `::entry`/`::func`,
    and call adjacency/predication remain part of the later call-context work.
 2. Add a non-`Flat` descriptor layout algorithm for call groups and variadic operands, then integrate `call`.

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -131,6 +131,13 @@ a diagnostic falls back to the whole instruction range. Legacy `cache` is the
 exception: `unspecified` is a source-absence sentinel rather than a spellable
 PTX value, so it never triggers modifier-value availability.
 
+`constraints` may carry the typed `memory_consistency` descriptor. It names
+the generated semantics, scope, cache, and address fields (and optionally
+mmio/state-space fields); normalization rejects inactive or
+unknown references. This keeps memory qualifiers independent in syntax while
+the descriptor-backed checker owns their cross rules. `omitted` and `none` are
+source-absence defaults, not spellable modifier values.
+
 `flag` normally provides `token: ".sat"`; a type token is normally derived
 from `value` or `values`. `name` is the modifier-slot ID local to one variant,
 while `kind` determines the resolved value type. The same spelling may bind a

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -21,8 +21,8 @@ generic 与 basic explicit-space scalar 以及 legacy `.v2/.v4` braced-vector `l
 14 种 8--64-bit bit-size、integer 与 floating-point type 接入解引用 address operand。
 legacy memory-vector payload 最多 128 bit：`.v2` 到 64-bit type，`.v4` 到
 32-bit type，`.v4` 64-bit 仍是尚待实现的 modern form。
-其余 source form、modern vector memory operation、完整 memory qualifier、
-`call` group、CFG、SSA 和目标 lowering 仍是后续 pass，不应改变此层的结构。
+其余 source form、modern vector memory operation、其余 memory qualifier extension、
+静态 address alignment、`call` group、CFG、SSA 和目标 lowering 仍是后续 pass，不应改变此层的结构。
 
 生成的公共层还提供了一个与具体 opcode 无关的边界：
 
@@ -172,6 +172,14 @@ modifier-value availability。源码省略 cache 时，Resolved IR 保存
 元数据，不表示 PTX 没有实际硬件默认语义：ISA 仍规定省略时 `ld` 按 `.ca`、`st` 按 `.wb`
 生效；IR 保留 `Unspecified`，是为了不把“源码未写”伪装成“显式写了默认值”，也避免它触发
 cache value availability 检查。
+
+memory consistency 采用生成的 cross-modifier descriptor，而不是把每种 qualifier
+组合展开成 `ld/st` variant。`MemoryConsistency::Omitted`（空 `locs`）与显式
+`.weak` 保持不同；`.volatile/.relaxed/.acquire/.release` 保留 modifier location。
+checker 只允许 relaxed/acquire/release 携带 scope，拒绝 volatile/ordered/mmio 与
+cache 的组合；对已知 address space 执行 global/shared、PTX 9.1 的
+`volatile.local` 及 scalar `.mmio.relaxed.sys` 规则，而不猜测 unknown generic
+address。modern vector form 与静态地址 alignment 检查仍留作后续。
 
 `ResolvedAddress` 另行记录 enclosing function kind。generated address view 仅从已绑定的
 `InputParameter`/`ReturnParameter` 推导可选 parameter direction，不根据 spelling 猜测。
@@ -330,5 +338,6 @@ instruction 约束仍不属于当前 ABI。
 
 function-local call-argument `.param` memory、带限定的 `::entry`/`::func` form、call
 adjacency/predication constraint、modern memory vector form、`.b128`、wider `.b128` register
-所需的 declaration-type availability，以及 memory consistency qualifier 仍不在本切片范围内。
-legacy scalar/vector `ld/st` cache operator 与 legacy `.v2/.v4` braced memory vector 已纳入本切片。
+所需的 declaration-type availability 与静态地址 alignment 检查仍不在本切片范围内。
+legacy scalar/vector `ld/st` cache operator、legacy `.v2/.v4` braced memory vector 与
+memory consistency qualifier 已纳入本切片。

--- a/docs/zh-han/syntax_coverage.md
+++ b/docs/zh-han/syntax_coverage.md
@@ -21,14 +21,14 @@
 | 其他 directive | 尚未支持（直接拒绝） | debug、section、pragma、module variable 与结构化 kernel-tuning directive；未建模 function-header token 不会静默进入 AST |
 | 结构化控制语法 | 尚未支持 | nested scope 与由 directive 驱动的 control-flow metadata |
 | 恢复与编辑 | 尚未支持 | missing token、recovery node、多错误解析与 token edit |
-| Resolved opcode | 部分支持 | 仅支持 YAML database 中存在的 opcode；当前为 `add`、`sub`、`bar`、`bra`、部分 scalar/vector `mov`，以及 `.b8/.b16/.b32/.b64`、`.u8/.u16/.u32/.u64`、`.s8/.s16/.s32/.s64`、`.f32/.f64` 的 generic/basic-explicit scalar 与 legacy `.v2/.v4` braced-vector `ld`/`st`；legacy vector payload 最多 128 bit（`.v2` 到 64-bit type，`.v4` 到 32-bit type；`.v4` 64-bit 尚待实现）；generic load 接受已知 `.const/.global/.local/.shared` space（`.const` 要求 PTX 3.1），generic store 接受 `.global/.local/.shared`，explicit form 要求精确匹配 runtime modifier；绑定的 `.param` load 要求 input parameter，store 要求 return parameter，并按 function context 检查 PTX/SM；load destination/store source register 以及 vector element 可在 bit/integer/float kind rule 下使用更宽声明，其余 typed operand 仍要求 same-width，未知 address identity 不推断 |
+| Resolved opcode | 部分支持 | 仅支持 YAML database 中存在的 opcode；当前为 `add`、`sub`、`bar`、`bra`、部分 scalar/vector `mov`，以及 `.b8/.b16/.b32/.b64`、`.u8/.u16/.u32/.u64`、`.s8/.s16/.s32/.s64`、`.f32/.f64` 的 generic/basic-explicit scalar 与 legacy `.v2/.v4` braced-vector `ld`/`st`；`ld/st` 支持 omission/显式 `.weak`、`.volatile`、带 scope 的 relaxed/acquire/release，以及 PTX 8.2 scalar `.mmio.relaxed.sys`，并由生成的 cross-modifier checker 约束；modern vector 与静态 alignment 检查仍待后续；legacy vector payload 最多 128 bit（`.v2` 到 64-bit type，`.v4` 到 32-bit type；`.v4` 64-bit 尚待实现）；generic load 接受已知 `.const/.global/.local/.shared` space（`.const` 要求 PTX 3.1），generic store 接受 `.global/.local/.shared`，explicit form 要求精确匹配 runtime modifier；绑定的 `.param` load 要求 input parameter，store 要求 return parameter，并按 function context 检查 PTX/SM；load destination/store source register 以及 vector element 可在 bit/integer/float kind rule 下使用更宽声明，其余 typed operand 仍要求 same-width，未知 address identity 不推断 |
 
 Lexer 能切分矩阵以外的源码，Syntax AST 也可能以文本形式保留未知 opcode；这两种情况
 都不表示该结构能够 lower 到 Resolved IR。
 
 ## 近期实现顺序
 
-1. 扩展 `ld/st` 的 memory consistency qualifier、modern vector form 与跨 modifier
+1. 扩展 `ld/st` 的 modern vector form、静态 alignment 检查与其余跨 modifier
    规则；`.b128` 不属于当前 scalar family；
    function-local call-argument `.param`、`::entry`/`::func` 以及 call
    adjacency/predication 留到后续 call-context 工作；

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -121,6 +121,12 @@ source-absence sentinel `unspecified`。
 `cache` 是例外：`unspecified` 不是可拼写的 PTX value，而是 source absence sentinel，
 因此不会触发 modifier-value availability。
 
+`constraints` 可携带 typed `memory_consistency` descriptor。它引用生成后的
+semantics、scope、cache 与 address field（也可引用 mmio/state-space field）；
+normalization 会拒绝未激活或未知的引用。memory qualifier 在 syntax 中保持独立，而
+descriptor-backed checker 统一执行 cross rule。`omitted` 与 `none` 是 source-absence
+default，不是可拼写的 modifier value。
+
 `flag` 通常给出 `token: ".sat"`；`type` 的 token 通常从 `value` 或 `values` 推导。
 `name` 是当前 variant 内的 modifier slot ID，`kind` 决定解析后的值类型。同一个
 spelling 可以在不同 variant 绑定不同 slot，例如 `.f32` 在普通 Add 中绑定 `type`，在

--- a/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
+++ b/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
@@ -79,6 +79,29 @@ domains:
       wb: CacheOperator::Wb
       wt: CacheOperator::Wt
 
+  memory_consistencies:
+    cpp_type: MemoryConsistency
+    default: MemoryConsistency::Omitted
+    runtime_lookup: ptx_suffix
+    values:
+      omitted: MemoryConsistency::Omitted
+      weak: MemoryConsistency::Weak
+      volatile: MemoryConsistency::Volatile
+      relaxed: MemoryConsistency::Relaxed
+      acquire: MemoryConsistency::Acquire
+      release: MemoryConsistency::Release
+
+  memory_scopes:
+    cpp_type: MemoryScope
+    default: MemoryScope::None
+    runtime_lookup: ptx_suffix
+    values:
+      none: MemoryScope::None
+      cta: MemoryScope::Cta
+      cluster: MemoryScope::Cluster
+      gpu: MemoryScope::Gpu
+      sys: MemoryScope::Sys
+
   vector_arities:
     cpp_type: VectorArity
     default: VectorArity::Invalid
@@ -120,6 +143,8 @@ domains:
       type: ScalarType
       rounding: RoundingMode
       cache: CacheOperator
+      semantics: MemoryConsistency
+      scope: MemoryScope
       vector: VectorArity
       state_space: MemoryStateSpace
 
@@ -145,6 +170,8 @@ domains:
       ScalarType: ScalarType
       RoundingMode: RoundingMode
       CacheOperator: CacheOperator
+      MemoryConsistency: MemoryConsistency
+      MemoryScope: MemoryScope
       VectorArity: VectorArity
       MemoryStateSpace: MemoryStateSpace
       Register: ResolvedRegisterRef
@@ -202,6 +229,8 @@ domains:
       ScalarType: check_end::ResolvedValueKind::ScalarType
       RoundingMode: check_end::ResolvedValueKind::RoundingMode
       CacheOperator: check_end::ResolvedValueKind::CacheOperator
+      MemoryConsistency: check_end::ResolvedValueKind::MemoryConsistency
+      MemoryScope: check_end::ResolvedValueKind::MemoryScope
       VectorArity: check_end::ResolvedValueKind::VectorArity
       MemoryStateSpace: check_end::ResolvedValueKind::MemoryStateSpace
       Register: check_end::ResolvedValueKind::Register
@@ -260,6 +289,8 @@ domains:
       ScalarType: check_end::ResolvedModifierDefaultKind::ScalarType
       RoundingMode: check_end::ResolvedModifierDefaultKind::RoundingMode
       CacheOperator: check_end::ResolvedModifierDefaultKind::CacheOperator
+      MemoryConsistency: check_end::ResolvedModifierDefaultKind::MemoryConsistency
+      MemoryScope: check_end::ResolvedModifierDefaultKind::MemoryScope
       MemoryStateSpace: check_end::ResolvedModifierDefaultKind::MemoryStateSpace
 
   checker_modifier_value_kinds:
@@ -269,6 +300,8 @@ domains:
       ScalarType: checker::ModifierValueKind::ScalarType
       RoundingMode: checker::ModifierValueKind::RoundingMode
       CacheOperator: checker::ModifierValueKind::CacheOperator
+      MemoryConsistency: checker::ModifierValueKind::MemoryConsistency
+      MemoryScope: checker::ModifierValueKind::MemoryScope
       VectorArity: checker::ModifierValueKind::VectorArity
       MemoryStateSpace: checker::ModifierValueKind::MemoryStateSpace
 

--- a/instructions/ptx_spec/data_movement.yaml
+++ b/instructions/ptx_spec/data_movement.yaml
@@ -409,6 +409,45 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - &ld_semantics
+            name: semantics
+            kind: semantics
+            domain: memory_consistencies
+            presence: optional
+            values:
+              - value: weak
+                availability: {ptx: "6.0", sm: 70}
+              - value: volatile
+                availability: {ptx: "1.1"}
+              - value: relaxed
+                availability: {ptx: "6.0", sm: 70}
+              - value: acquire
+                availability: {ptx: "6.0", sm: 70}
+            default: omitted
+          - &memory_scope
+            name: scope
+            kind: scope
+            domain: memory_scopes
+            presence: optional
+            values:
+              - value: cta
+                availability: {ptx: "6.0", sm: 70}
+              - value: cluster
+                availability: {ptx: "7.8", sm: 90}
+              - value: gpu
+                availability: {ptx: "6.0", sm: 70}
+              - value: sys
+                availability: {ptx: "6.0", sm: 70}
+            default: none
+          - &memory_mmio
+            name: mmio
+            kind: flag
+            presence: optional
+            values:
+              - value: true
+                token: .mmio
+                availability: {ptx: "8.2", sm: 70}
+            default: false
           - name: cache
             kind: cache
             domain: cache_operators
@@ -426,6 +465,13 @@ instructions:
               - f64
         operands: $ld_scalar
         rule: data_movement.ld_generic
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            mmio_modifier: mmio
+            cache_modifier: cache
+            address_operand: address
 
         examples:
           - ptx: "ld.u32 %r0, [%rd0+4];"
@@ -451,6 +497,9 @@ instructions:
               - value: $ld_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
+          - *ld_semantics
+          - *memory_scope
+          - *memory_mmio
           - name: type
             kind: type
             domain: scalar_types
@@ -463,6 +512,14 @@ instructions:
                   sm: 13
         operands: $ld_explicit_scalar
         rule: data_movement.ld_explicit
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            mmio_modifier: mmio
+            cache_modifier: cache
+            address_operand: address
+            state_space_modifier: state_space
 
         examples:
           - ptx: "ld.global.u32 %r0, [global_value];"
@@ -475,6 +532,8 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - *ld_semantics
+          - *memory_scope
           - name: cache
             kind: cache
             domain: cache_operators
@@ -497,6 +556,12 @@ instructions:
               - f64
         operands: $ld_vector
         rule: data_movement.ld_generic
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            cache_modifier: cache
+            address_operand: address
 
         examples:
           - ptx: "ld.v2.u32 {%r0, %r1}, [%rd0];"
@@ -522,6 +587,8 @@ instructions:
               - value: $ld_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
+          - *ld_semantics
+          - *memory_scope
           - name: vector
             kind: vector
             domain: vector_arities
@@ -539,6 +606,13 @@ instructions:
                   sm: 13
         operands: $ld_explicit_vector
         rule: data_movement.ld_explicit
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            cache_modifier: cache
+            address_operand: address
+            state_space_modifier: state_space
 
         examples:
           - ptx: "ld.global.v2.u32 {%r0, %r1}, [global_value];"
@@ -561,6 +635,15 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - &st_semantics
+            name: semantics
+            kind: semantics
+            domain: memory_consistencies
+            presence: optional
+            values: [{value: weak, availability: {ptx: "6.0", sm: 70}}, {value: volatile, availability: {ptx: "1.1"}}, {value: relaxed, availability: {ptx: "6.0", sm: 70}}, {value: release, availability: {ptx: "6.0", sm: 70}}]
+            default: omitted
+          - *memory_scope
+          - *memory_mmio
           - name: cache
             kind: cache
             domain: cache_operators
@@ -578,6 +661,13 @@ instructions:
               - f64
         operands: $st_scalar
         rule: data_movement.st_generic
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            mmio_modifier: mmio
+            cache_modifier: cache
+            address_operand: address
 
         examples:
           - ptx: "st.u32 [%rd0+4], %r0;"
@@ -601,6 +691,9 @@ instructions:
               - value: $st_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
+          - *st_semantics
+          - *memory_scope
+          - *memory_mmio
           - name: type
             kind: type
             domain: scalar_types
@@ -613,6 +706,14 @@ instructions:
                   sm: 13
         operands: $st_explicit_scalar
         rule: data_movement.st_explicit
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            mmio_modifier: mmio
+            cache_modifier: cache
+            address_operand: address
+            state_space_modifier: state_space
 
         examples:
           - ptx: "st.global.u32 [global_value], %r0;"
@@ -625,6 +726,8 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - *st_semantics
+          - *memory_scope
           - name: cache
             kind: cache
             domain: cache_operators
@@ -647,6 +750,12 @@ instructions:
               - f64
         operands: $st_vector
         rule: data_movement.st_generic
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            cache_modifier: cache
+            address_operand: address
 
         examples:
           - ptx: "st.v2.u32 [%rd0], {%r0, %r1};"
@@ -672,6 +781,8 @@ instructions:
               - value: $st_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
+          - *st_semantics
+          - *memory_scope
           - name: vector
             kind: vector
             domain: vector_arities
@@ -689,6 +800,13 @@ instructions:
                   sm: 13
         operands: $st_explicit_vector
         rule: data_movement.st_explicit
+        constraints:
+          - kind: memory_consistency
+            semantics_modifier: semantics
+            scope_modifier: scope
+            cache_modifier: cache
+            address_operand: address
+            state_space_modifier: state_space
 
         examples:
           - ptx: "st.global.v2.u32 [global_value], {%r0, %r1};"

--- a/instructions/schemas/ptx-instr-v1.schema.yaml
+++ b/instructions/schemas/ptx-instr-v1.schema.yaml
@@ -1002,6 +1002,7 @@ $defs:
           - mutually_exclusive_modifiers
           - implies_modifier
           - custom
+          - memory_consistency
 
       operands:
         type: array
@@ -1023,6 +1024,24 @@ $defs:
 
       message:
         type: string
+
+      semantics_modifier:
+        $ref: "#/$defs/schema_identifier"
+
+      scope_modifier:
+        $ref: "#/$defs/schema_identifier"
+
+      mmio_modifier:
+        $ref: "#/$defs/schema_identifier"
+
+      cache_modifier:
+        $ref: "#/$defs/schema_identifier"
+
+      address_operand:
+        $ref: "#/$defs/schema_identifier"
+
+      state_space_modifier:
+        $ref: "#/$defs/schema_identifier"
 
   example:
     description: "Positive or negative PTX example for an instruction or variant."

--- a/next_step.md
+++ b/next_step.md
@@ -413,8 +413,11 @@ auto result = ptx_frontend::resolved_ir::resolveModule(module);
 
 `bra`、special-register consumer 与首个 address/symbol consumer 已完成闭环；剩余顺序是：
 
-1. 为 `ld/st` 增加 memory consistency qualifier、modern vector form、alignment 与跨 modifier
-   规则；
+1. 为 `ld/st` 增加 modern vector form、alignment 与其余跨 modifier 规则；已完成
+   PTX ≤9.2 的 omission/`.weak`/`.volatile`/scoped
+   `.relaxed/.acquire/.release` 及 PTX 8.2 scalar `.mmio.relaxed.sys` consistency
+   qualifier。legacy `.v2/.v4` 明确不接受 mmio；static address-alignment checking 与
+   modern vector extension 仍保留为后续工作；
    function-local call-argument `.param` 及相关 call-context 规则留到 `call` 阶段；
 2. 为 `call` group/variadic operand 增加非 `Flat` descriptor layout algorithm，再将 `call`
    接入统一 dispatch/checker；

--- a/python/code_gen/cpp_backend.py
+++ b/python/code_gen/cpp_backend.py
@@ -41,6 +41,8 @@ class CppDomain(str, Enum):
     SCALAR_TYPES = "scalar_types"  # YAML: domains.scalar_types
     ROUNDING_MODES = "rounding_modes"  # YAML: domains.rounding_modes
     CACHE_OPERATORS = "cache_operators"  # YAML: domains.cache_operators
+    MEMORY_CONSISTENCIES = "memory_consistencies"
+    MEMORY_SCOPES = "memory_scopes"
     VECTOR_ARITIES = "vector_arities"
     MEMORY_STATE_SPACES = (  # YAML: domains.memory_state_spaces
         "memory_state_spaces"

--- a/python/code_gen/gen_resolved_checker_descriptor.py
+++ b/python/code_gen/gen_resolved_checker_descriptor.py
@@ -111,6 +111,18 @@ def _emit_variant_descriptor(variant: ResolvedVariant) -> str:
     minimum_sm = int(availability.get("sm", 0))
     family = str(availability.get("family", ""))
     rule_id = variant.rule or ""
+    consistency = variant.memory_consistency
+    memory_consistency = ""
+    if consistency is not None:
+        memory_consistency = f'''
+              .memory_consistency = {{
+                  .semantics_field_id = "{consistency.semantics_field_id}",
+                  .scope_field_id = "{consistency.scope_field_id}",
+                  .mmio_field_id = "{consistency.mmio_field_id}",
+                  .cache_field_id = "{consistency.cache_field_id}",
+                  .address_field_id = "{consistency.address_field_id}",
+                  .state_space_field_id = "{consistency.state_space_field_id or ""}",
+              }},'''
     return f"""          checker::VariantDescriptor{{
               .variant_name = "{variant.cpp_name}",
               .availability = {{
@@ -124,6 +136,7 @@ def _emit_variant_descriptor(variant: ResolvedVariant) -> str:
               .operand_type_compatibilities =
                   {variant.cpp_name}_operand_type_compatibilities,
               .rule_id = "{rule_id}",
+{memory_consistency}
           }}"""
 
 
@@ -184,6 +197,22 @@ def _emit_modifier_value_descriptor(
         rounding_mode = cpp_default(CppDomain.ROUNDING_MODES)
         cache_operator = cpp_default(CppDomain.CACHE_OPERATORS)
         vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
+    elif entry.value_cpp_type == "MemoryConsistency":
+        memory_consistency = cpp_value(
+            CppDomain.MEMORY_CONSISTENCIES, str(entry.value)
+        )
+        bool_value = "false"
+        scalar_type = cpp_default(CppDomain.SCALAR_TYPES)
+        rounding_mode = cpp_default(CppDomain.ROUNDING_MODES)
+        cache_operator = cpp_default(CppDomain.CACHE_OPERATORS)
+        vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
+    elif entry.value_cpp_type == "MemoryScope":
+        memory_scope = cpp_value(CppDomain.MEMORY_SCOPES, str(entry.value))
+        bool_value = "false"
+        scalar_type = cpp_default(CppDomain.SCALAR_TYPES)
+        rounding_mode = cpp_default(CppDomain.ROUNDING_MODES)
+        cache_operator = cpp_default(CppDomain.CACHE_OPERATORS)
+        vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
     else:
         raise ValueError(
             f"unsupported modifier availability value type {entry.value_cpp_type!r}"
@@ -197,6 +226,8 @@ def _emit_modifier_value_descriptor(
               .cache_operator = {cache_operator},
               .vector_arity = {vector_arity},
               .memory_state_space = {memory_state_space if entry.value_cpp_type == "MemoryStateSpace" else cpp_default(CppDomain.MEMORY_STATE_SPACES)},
+              .memory_consistency = {memory_consistency if entry.value_cpp_type == "MemoryConsistency" else cpp_default(CppDomain.MEMORY_CONSISTENCIES)},
+              .memory_scope = {memory_scope if entry.value_cpp_type == "MemoryScope" else cpp_default(CppDomain.MEMORY_SCOPES)},
               .availability = {{
                   .minimum_ptx_version = {{{minimum_ptx[0]}, {minimum_ptx[1]}}},
                   .minimum_sm_version = {minimum_sm},

--- a/python/code_gen/gen_resolved_descriptor.py
+++ b/python/code_gen/gen_resolved_descriptor.py
@@ -226,6 +226,20 @@ def _emit_modifier_default_descriptor(binding: ResolvedModifierBinding) -> str:
                   .cache_operator = {cpp_default(CppDomain.CACHE_OPERATORS)},
                   .memory_state_space = {memory_state_space},
               }}"""
+    if default.value_cpp_type == "MemoryConsistency" and isinstance(
+        default.value, str
+    ):
+        value = cpp_value(CppDomain.MEMORY_CONSISTENCIES, default.value)
+        return f"""check_end::ResolvedModifierDefaultDescriptor{{
+                  .kind = {cpp_value(CppDomain.RESOLVED_MODIFIER_DEFAULT_KINDS, "MemoryConsistency")},
+                  .memory_consistency = {value},
+              }}"""
+    if default.value_cpp_type == "MemoryScope" and isinstance(default.value, str):
+        value = cpp_value(CppDomain.MEMORY_SCOPES, default.value)
+        return f"""check_end::ResolvedModifierDefaultDescriptor{{
+                  .kind = {cpp_value(CppDomain.RESOLVED_MODIFIER_DEFAULT_KINDS, "MemoryScope")},
+                  .memory_scope = {value},
+              }}"""
     raise ValueError(
         f"unsupported modifier default {default.value!r} for "
         f"{default.value_cpp_type}"

--- a/python/code_gen/gen_resolved_ir.py
+++ b/python/code_gen/gen_resolved_ir.py
@@ -465,6 +465,15 @@ def _emit_check_operand_dispatch(
     checker_variant_expr = (
         f"{instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]"
     )
+    consistency_check = ""
+    if variant.memory_consistency is not None:
+        consistency_check = f"""            const auto consistency_check = check_memory_consistency(
+                {checker_variant_expr}.memory_consistency, fields, operands, context);
+            if (!consistency_check) {{
+              diagnostics.insert(diagnostics.end(), consistency_check.error().begin(),
+                                 consistency_check.error().end());
+            }}
+"""
     if len(variant.operand_layouts) == 1:
         operand_views = ",\n".join(
             _emit_check_operand_view(field, "selected")
@@ -494,7 +503,7 @@ def _emit_check_operand_dispatch(
               diagnostics.insert(diagnostics.end(), operand_check.error().begin(),
                                  operand_check.error().end());
             }}
-          }}"""
+{consistency_check}          }}"""
 
     layout_lambdas = "\n\n".join(
         _emit_check_multi_layout_lambda(
@@ -542,6 +551,31 @@ def _emit_check_multi_layout_lambda(
     operand_views = ",\n".join(
         _emit_check_operand_view(field, "payload") for field in layout.fields
     )
+    consistency_return = f"""
+            return check_operands(
+                {instruction.cpp_name}::get_resolved_descriptor().variants[{variant_index}]
+                    .operand_layouts[{layout_index}]
+                    .bindings,
+                fields, operands,
+                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                    .operand_type_compatibilities,
+                context);"""
+    if variant.memory_consistency is not None:
+        consistency_return = f"""
+            const auto operand_check = check_operands(
+                {instruction.cpp_name}::get_resolved_descriptor().variants[{variant_index}]
+                    .operand_layouts[{layout_index}]
+                    .bindings,
+                fields, operands,
+                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                    .operand_type_compatibilities,
+                context);
+            if (!operand_check)
+              return operand_check;
+            return check_memory_consistency(
+                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                    .memory_consistency,
+                fields, operands, context);"""
     return f"""          const auto {lambda_name} =
               [&](const {instruction.cpp_name}::{variant.cpp_name}::{layout.cpp_name}Operands& payload)
                   -> CheckResult {{
@@ -554,15 +588,7 @@ def _emit_check_multi_layout_lambda(
             }}
             const std::array<OperandView, {len(layout.fields)}> operands = {{{{
 {operand_views}
-            }}}};
-            return check_operands(
-                {instruction.cpp_name}::get_resolved_descriptor().variants[{variant_index}]
-                    .operand_layouts[{layout_index}]
-                    .bindings,
-                fields, operands,
-                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
-                    .operand_type_compatibilities,
-                context);
+            }}}};{consistency_return}
           }};
           static_assert(detail::VariantCheckFunction<
               decltype({lambda_name}),
@@ -588,6 +614,10 @@ def _emit_check_modifier_view(
     field: ResolvedField,
 ) -> str:
     if field.storage is ResolvedFieldStorage.STATIC_CONSTANT:
+        bool_value = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.value_cpp_type == "bool" else "std::nullopt"
+        )
         scalar_type = (
             f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
             if field.value_cpp_type == "ScalarType"
@@ -602,9 +632,25 @@ def _emit_check_modifier_view(
             f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
             if field.value_cpp_type == "MemoryStateSpace"
             else "std::nullopt"
+        )
+        memory_consistency = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.value_cpp_type == "MemoryConsistency" else "std::nullopt"
+        )
+        memory_scope = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.value_cpp_type == "MemoryScope" else "std::nullopt"
+        )
+        cache_operator = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.value_cpp_type == "CacheOperator" else "std::nullopt"
         )
         locations = "std::span<const SourceRange>{}"
     else:
+        bool_value = (
+            f"selected.{field.name}.value"
+            if field.value_cpp_type == "bool" else "std::nullopt"
+        )
         scalar_type = (
             f"selected.{field.name}.value"
             if field.value_cpp_type == "ScalarType"
@@ -619,13 +665,29 @@ def _emit_check_modifier_view(
             f"selected.{field.name}.value"
             if field.value_cpp_type == "MemoryStateSpace"
             else "std::nullopt"
+        )
+        memory_consistency = (
+            f"selected.{field.name}.value"
+            if field.value_cpp_type == "MemoryConsistency" else "std::nullopt"
+        )
+        memory_scope = (
+            f"selected.{field.name}.value"
+            if field.value_cpp_type == "MemoryScope" else "std::nullopt"
+        )
+        cache_operator = (
+            f"selected.{field.name}.value"
+            if field.value_cpp_type == "CacheOperator" else "std::nullopt"
         )
         locations = f"selected.{field.name}.locs"
     return f"""              FieldView{{
                   .field_id = "{field.name}",
+                  .bool_value = {bool_value},
+                  .cache_operator = {cache_operator},
                   .scalar_type = {scalar_type},
                   .vector_arity = {vector_arity},
                   .memory_state_space = {memory_state_space},
+                  .memory_consistency = {memory_consistency},
+                  .memory_scope = {memory_scope},
                   .locations = {locations},
               }}"""
 
@@ -716,6 +778,34 @@ def _emit_check_modifier_value_view(
             if field.storage is ResolvedFieldStorage.STATIC_CONSTANT
             else f"selected.{field.name}.value"
         )
+    elif field.value_cpp_type == "MemoryConsistency":
+        value_kind = cpp_value(
+            CppDomain.CHECKER_MODIFIER_VALUE_KINDS, "MemoryConsistency"
+        )
+        bool_value = "false"
+        scalar_type = cpp_default(CppDomain.SCALAR_TYPES)
+        rounding_mode = cpp_default(CppDomain.ROUNDING_MODES)
+        cache_operator = cpp_default(CppDomain.CACHE_OPERATORS)
+        vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
+        memory_state_space = cpp_default(CppDomain.MEMORY_STATE_SPACES)
+        memory_consistency = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.storage is ResolvedFieldStorage.STATIC_CONSTANT
+            else f"selected.{field.name}.value"
+        )
+    elif field.value_cpp_type == "MemoryScope":
+        value_kind = cpp_value(CppDomain.CHECKER_MODIFIER_VALUE_KINDS, "MemoryScope")
+        bool_value = "false"
+        scalar_type = cpp_default(CppDomain.SCALAR_TYPES)
+        rounding_mode = cpp_default(CppDomain.ROUNDING_MODES)
+        cache_operator = cpp_default(CppDomain.CACHE_OPERATORS)
+        vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
+        memory_state_space = cpp_default(CppDomain.MEMORY_STATE_SPACES)
+        memory_scope = (
+            f"{instruction.cpp_name}::{variant.cpp_name}::{field.name}"
+            if field.storage is ResolvedFieldStorage.STATIC_CONSTANT
+            else f"selected.{field.name}.value"
+        )
     else:
         raise ValueError(
             f"modifier field {field.name!r}: unsupported availability view type "
@@ -744,6 +834,10 @@ def _emit_check_modifier_value_view(
         vector_arity = cpp_default(CppDomain.VECTOR_ARITIES)
     if field.value_cpp_type != "MemoryStateSpace":
         memory_state_space = cpp_default(CppDomain.MEMORY_STATE_SPACES)
+    if field.value_cpp_type != "MemoryConsistency":
+        memory_consistency = cpp_default(CppDomain.MEMORY_CONSISTENCIES)
+    if field.value_cpp_type != "MemoryScope":
+        memory_scope = cpp_default(CppDomain.MEMORY_SCOPES)
     return f"""              ModifierValueView{{
                   .kind_id = "{field.source_name}",
                   .value_kind = {value_kind},
@@ -753,6 +847,8 @@ def _emit_check_modifier_value_view(
                   .cache_operator = {cache_operator},
                   .vector_arity = {vector_arity},
                   .memory_state_space = {memory_state_space},
+                  .memory_consistency = {memory_consistency},
+                  .memory_scope = {memory_scope},
                   .is_present = {is_present},
                   .locations = {locations},
               }}"""

--- a/python/code_gen/model.py
+++ b/python/code_gen/model.py
@@ -58,6 +58,18 @@ class OperandParameterConstraint:
     function_availability: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class MemoryConsistencyConstraint:
+    """Typed cross-modifier rule for a family of ld/st variants."""
+
+    semantics_modifier: str
+    scope_modifier: str
+    cache_modifier: str
+    address_operand: str
+    mmio_modifier: str | None = None
+    state_space_modifier: str | None = None
+
+
 class RuntimeLookupKind(str, Enum):
     """Runtime C++ lookup forms emitted for backend value domains."""
 
@@ -167,6 +179,7 @@ class VariantSpec:
     operand_layouts: tuple[OperandLayoutSpec, ...]
     rule: str | None = None
     operand_type_compatibilities: tuple[OperandTypeCompatibilitySpec, ...] = ()
+    memory_consistency: MemoryConsistencyConstraint | None = None
 
 
 @dataclass(frozen=True)

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -8,6 +8,7 @@ from typing import Any
 from code_gen.load_yaml import expand_value_refs
 from code_gen.model import (
     InstructionSpec,
+    MemoryConsistencyConstraint,
     ModifierSpec,
     ModifierValueSpec,
     OperandLayoutSpec,
@@ -390,6 +391,21 @@ def _validate_modifier_default(
                 "default 'unspecified'"
             )
         return
+    if kind in {"semantics", "scope"}:
+        if not isinstance(default, str):
+            raise ValueError(
+                f"optional {kind} modifier {raw['name']!r} must have a string "
+                "default"
+            )
+        allowed_values = {value.value for value in values}
+        # Omission sentinels intentionally are not spellable modifier values.
+        sentinel = "omitted" if kind == "semantics" else "none"
+        if default != sentinel and default not in allowed_values:
+            raise ValueError(
+                f"optional {kind} modifier {raw['name']!r} has default "
+                f"{default!r} outside its allowed values"
+            )
+        return
 
 
 def _normalize_modifier_values(
@@ -604,6 +620,104 @@ def _normalize_operand_type_compatibilities(
     return tuple(result)
 
 
+def _normalize_memory_consistency_constraint(
+    raw_variant: dict[str, Any], modifiers: tuple[ModifierSpec, ...],
+    layouts: tuple[OperandLayoutSpec, ...]
+) -> MemoryConsistencyConstraint | None:
+    """Lower the one typed ld/st cross-modifier constraint, if present."""
+
+    matches = [
+        item for item in raw_variant.get("constraints", ())
+        if item.get("kind") == "memory_consistency"
+    ]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: at most one memory_consistency "
+            "constraint is supported"
+        )
+    raw = matches[0]
+    required = {
+        "semantics_modifier", "scope_modifier", "cache_modifier",
+        "address_operand",
+    }
+    missing = required - raw.keys()
+    if missing:
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: memory_consistency constraint "
+            f"is missing {sorted(missing)}"
+        )
+    modifiers_by_name = {modifier.name: modifier for modifier in modifiers}
+    modifier_names = set(modifiers_by_name)
+    for key in required - {"address_operand"}:
+        value = raw[key]
+        if value not in modifier_names:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_consistency {key} "
+                f"references inactive modifier {value!r}"
+            )
+    operand_names = {operand.name for layout in layouts for operand in layout.operands}
+    if raw["address_operand"] not in operand_names:
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: memory_consistency address "
+            f"references unknown operand {raw['address_operand']!r}"
+        )
+    if any(
+        operand.name == raw["address_operand"] and operand.kind != "addr"
+        for layout in layouts for operand in layout.operands
+    ):
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: memory_consistency address "
+            "operand must have kind 'addr'"
+        )
+    expected_kinds = {
+        "semantics_modifier": "semantics",
+        "scope_modifier": "scope",
+        "cache_modifier": "cache",
+    }
+    for key, expected_kind in expected_kinds.items():
+        if modifiers_by_name[raw[key]].kind != expected_kind:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_consistency {key} "
+                f"must name a {expected_kind!r} modifier"
+            )
+    mmio_modifier = raw.get("mmio_modifier")
+    if mmio_modifier is not None:
+        if mmio_modifier not in modifier_names:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_consistency "
+                f"mmio_modifier references inactive modifier {mmio_modifier!r}"
+            )
+        if modifiers_by_name[mmio_modifier].kind != "flag":
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_consistency "
+                "mmio_modifier must name a 'flag' modifier"
+            )
+    for key in ("state_space_modifier",):
+        value = raw.get(key)
+        if value is not None and value not in modifier_names:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_consistency {key} "
+                f"references inactive modifier {value!r}"
+            )
+    if raw.get("state_space_modifier") is not None and (
+        modifiers_by_name[raw["state_space_modifier"]].kind != "state_space"
+    ):
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: memory_consistency "
+            "state_space_modifier must name a state_space modifier"
+        )
+    return MemoryConsistencyConstraint(
+        semantics_modifier=raw["semantics_modifier"],
+        scope_modifier=raw["scope_modifier"],
+        cache_modifier=raw["cache_modifier"],
+        address_operand=raw["address_operand"],
+        mmio_modifier=mmio_modifier,
+        state_space_modifier=raw.get("state_space_modifier"),
+    )
+
+
 def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, ...]:
     """Normalize all instruction definitions in one PTX ISA YAML file."""
 
@@ -653,6 +767,9 @@ def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, .
                         _normalize_operand_type_compatibilities(
                             raw_variant, operand_layouts
                         )
+                    ),
+                    memory_consistency=_normalize_memory_consistency_constraint(
+                        raw_variant, modifiers, operand_layouts
                     ),
                 )
             )

--- a/python/ir/resolved_ir.py
+++ b/python/ir/resolved_ir.py
@@ -20,6 +20,7 @@ from code_gen.cpp_backend import (
 )
 from code_gen.model import (
     InstructionSpec,
+    MemoryConsistencyConstraint,
     ModifierSpec,
     ModifierValueSpec,
     OperandParameterConstraint,
@@ -50,6 +51,8 @@ class ResolvedValueKind(Enum):
     SCALAR_TYPE = "ScalarType"
     ROUNDING_MODE = "RoundingMode"
     CACHE_OPERATOR = "CacheOperator"
+    MEMORY_CONSISTENCY = "MemoryConsistency"
+    MEMORY_SCOPE = "MemoryScope"
     VECTOR_ARITY = "VectorArity"
     MEMORY_STATE_SPACE = "MemoryStateSpace"
     REGISTER = "Register"
@@ -153,6 +156,18 @@ class ResolvedParameterAddressConstraint:
 
 
 @dataclass(frozen=True)
+class ResolvedMemoryConsistencyConstraint:
+    """Generated field identities for the typed ld/st cross-rule checker."""
+
+    semantics_field_id: str
+    scope_field_id: str
+    mmio_field_id: str
+    cache_field_id: str
+    address_field_id: str
+    state_space_field_id: str | None = None
+
+
+@dataclass(frozen=True)
 class ResolvedField:
     """One provenance-carrying field in a resolved variant struct."""
 
@@ -211,6 +226,12 @@ class ResolvedField:
             self.constant_value, str
         ):
             return cpp_value(CppDomain.MEMORY_STATE_SPACES, self.constant_value)
+        if self.value_cpp_type == "MemoryConsistency" and isinstance(
+            self.constant_value, str
+        ):
+            return cpp_value(CppDomain.MEMORY_CONSISTENCIES, self.constant_value)
+        if self.value_cpp_type == "MemoryScope" and isinstance(self.constant_value, str):
+            return cpp_value(CppDomain.MEMORY_SCOPES, self.constant_value)
         raise ValueError(
             f"field {self.name!r}: unsupported fixed value "
             f"{self.constant_value!r} for {self.value_cpp_type}"
@@ -228,6 +249,7 @@ class ResolvedVariant:
     operand_layouts: tuple["ResolvedOperandLayout", ...]
     modifier_value_availabilities: tuple["ResolvedModifierValueAvailability", ...]
     operand_type_compatibilities: tuple["ResolvedOperandTypeCompatibility", ...]
+    memory_consistency: ResolvedMemoryConsistencyConstraint | None
     availability: tuple[tuple[str, Any], ...]
     rule: str | None
 
@@ -423,8 +445,35 @@ def _build_variant(opcode: str, variant: VariantSpec) -> ResolvedVariant:
             for compatibility in variant.operand_type_compatibilities
             for value in compatibility.values
         ),
+        memory_consistency=_build_memory_consistency_constraint(
+            variant.memory_consistency,
+            {field.source_name: field.name for field in modifier_fields},
+        ),
         availability=tuple(variant.availability.items()),
         rule=variant.rule,
+    )
+
+
+def _build_memory_consistency_constraint(
+    constraint: MemoryConsistencyConstraint | None,
+    modifier_field_ids: dict[str, str],
+) -> ResolvedMemoryConsistencyConstraint | None:
+    if constraint is None:
+        return None
+    return ResolvedMemoryConsistencyConstraint(
+        semantics_field_id=modifier_field_ids[constraint.semantics_modifier],
+        scope_field_id=modifier_field_ids[constraint.scope_modifier],
+        mmio_field_id=(
+            modifier_field_ids[constraint.mmio_modifier]
+            if constraint.mmio_modifier is not None
+            else ""
+        ),
+        cache_field_id=modifier_field_ids[constraint.cache_modifier],
+        address_field_id=constraint.address_operand,
+        state_space_field_id=(
+            modifier_field_ids[constraint.state_space_modifier]
+            if constraint.state_space_modifier is not None else None
+        ),
     )
 
 
@@ -497,6 +546,22 @@ def _build_modifier_default(
                 f"optional state-space modifier {modifier.name!r} has "
                 f"unsupported default {modifier.default!r}"
             )
+    if value_cpp_type == "MemoryConsistency":
+        if not isinstance(modifier.default, str) or modifier.default not in cpp_domain(
+            CppDomain.MEMORY_CONSISTENCIES
+        ).values:
+            raise ValueError(
+                f"optional semantics modifier {modifier.name!r} has unsupported "
+                f"default {modifier.default!r}"
+            )
+    if value_cpp_type == "MemoryScope":
+        if not isinstance(modifier.default, str) or modifier.default not in cpp_domain(
+            CppDomain.MEMORY_SCOPES
+        ).values:
+            raise ValueError(
+                f"optional scope modifier {modifier.name!r} has unsupported "
+                f"default {modifier.default!r}"
+            )
     return ResolvedModifierDefault(
         value_cpp_type=value_cpp_type,
         value=modifier.default,
@@ -561,6 +626,22 @@ def _build_modifier_value_availability(
         if value.value not in cpp_domain(CppDomain.MEMORY_STATE_SPACES).values:
             raise ValueError(
                 f"modifier {modifier.name!r}: unsupported state-space value "
+                f"{value.value!r}"
+            )
+    if value_cpp_type == "MemoryConsistency":
+        if not isinstance(value.value, str) or value.value not in cpp_domain(
+            CppDomain.MEMORY_CONSISTENCIES
+        ).values:
+            raise ValueError(
+                f"modifier {modifier.name!r}: unsupported memory consistency "
+                f"value {value.value!r}"
+            )
+    if value_cpp_type == "MemoryScope":
+        if not isinstance(value.value, str) or value.value not in cpp_domain(
+            CppDomain.MEMORY_SCOPES
+        ).values:
+            raise ValueError(
+                f"modifier {modifier.name!r}: unsupported memory scope value "
                 f"{value.value!r}"
             )
     return ResolvedModifierValueAvailability(

--- a/python/tests/code_gen/test_backend_model.py
+++ b/python/tests/code_gen/test_backend_model.py
@@ -111,6 +111,26 @@ class BackendModelTests(unittest.TestCase):
             "CacheOperator::Unspecified",
         )
         self.assertEqual(
+            unit.domains[CppDomain.MEMORY_CONSISTENCIES.value].values["weak"],
+            "MemoryConsistency::Weak",
+        )
+        self.assertEqual(
+            unit.domains[CppDomain.MEMORY_SCOPES.value].default,
+            "MemoryScope::None",
+        )
+        self.assertEqual(
+            unit.domains[CppDomain.RESOLVED_VALUE_CPP_TYPES.value].values[
+                "MemoryConsistency"
+            ],
+            "MemoryConsistency",
+        )
+        self.assertEqual(
+            unit.domains[CppDomain.RESOLVED_VALUE_CPP_TYPES.value].values[
+                "MemoryScope"
+            ],
+            "MemoryScope",
+        )
+        self.assertEqual(
             unit.domains[CppDomain.REGISTER_WIDTH_POLICIES.value].values[
                 "equal_or_wider"
             ],

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -651,6 +651,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             [(field.name, field.cpp_type) for field in variant.fields],
             [
+                ("semantics", "WithLocs<MemoryConsistency>"),
+                ("scope", "WithLocs<MemoryScope>"),
+                ("mmio", "WithLocs<bool>"),
                 ("cache", "WithLocs<CacheOperator>"),
                 ("type", "WithLocs<ScalarType>"),
                 ("dst", "WithLocs<ResolvedRegisterRef>"),
@@ -658,17 +661,30 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
-            variant.modifier_bindings[0].default_value.value_cpp_type,
+            next(binding for binding in variant.modifier_bindings
+                 if binding.source_kind_id == "cache").default_value.value_cpp_type,
             "CacheOperator",
         )
         self.assertEqual(
-            variant.modifier_bindings[0].default_value.value,
+            next(binding for binding in variant.modifier_bindings
+                 if binding.source_kind_id == "cache").default_value.value,
             "unspecified",
+        )
+        self.assertEqual(
+            next(binding for binding in variant.modifier_bindings
+                 if binding.source_kind_id == "semantics").default_value.value,
+            "omitted",
+        )
+        self.assertEqual(
+            next(binding for binding in variant.modifier_bindings
+                 if binding.source_kind_id == "scope").default_value.value,
+            "none",
         )
         self.assertEqual(
             [
                 (entry.source_kind_id, entry.value_cpp_type, entry.value)
                 for entry in variant.modifier_value_availabilities
+                if entry.source_kind_id == "cache"
             ],
             [
                 ("cache", "CacheOperator", "ca"),
@@ -678,6 +694,26 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 ("cache", "CacheOperator", "cv"),
             ],
         )
+        self.assertEqual(
+            [
+                (entry.source_kind_id, entry.value_cpp_type, entry.value)
+                for entry in variant.modifier_value_availabilities
+                if entry.source_kind_id == "semantics"
+            ],
+            [
+                ("semantics", "MemoryConsistency", "weak"),
+                ("semantics", "MemoryConsistency", "volatile"),
+                ("semantics", "MemoryConsistency", "relaxed"),
+                ("semantics", "MemoryConsistency", "acquire"),
+            ],
+        )
+        self.assertIn(
+            ("mmio", "bool", True),
+            [(entry.source_kind_id, entry.value_cpp_type, entry.value)
+             for entry in variant.modifier_value_availabilities],
+        )
+        self.assertEqual(variant.memory_consistency.semantics_field_id, "semantics")
+        self.assertEqual(variant.memory_consistency.address_field_id, "address")
         self.assertEqual(
             variant.operand_layouts[0].bindings[0].type_expression,
             ResolvedOperandTypeExpression(
@@ -759,11 +795,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertEqual(
             [
-                (
-                    availability.value,
-                    dict(availability.availability),
-                )
-                for availability in explicit_variant.modifier_value_availabilities
+                (entry.value, dict(entry.availability))
+                for entry in explicit_variant.modifier_value_availabilities
+                if entry.source_kind_id in {"cache", "type"}
             ],
             [
                 ("ca", {"ptx": "2.0", "sm": 20}),
@@ -785,10 +819,11 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(vector_variant.cpp_name, "GenericVector")
         self.assertEqual(
             [field.name for field in vector_variant.fields],
-            ["cache", "vector", "type", "dst", "address"],
+            ["semantics", "scope", "cache", "vector", "type", "dst", "address"],
         )
+        self.assertEqual(vector_variant.memory_consistency.mmio_field_id, "")
         self.assertEqual(
-            [value.value for value in ld.variants[2].modifiers[1].values],
+            [value.value for value in next(modifier for modifier in ld.variants[2].modifiers if modifier.name == "vector").values],
             ["v2", "v4"],
         )
         vector_binding = vector_variant.operand_layouts[0].bindings[0]
@@ -842,16 +877,18 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
         self.assertEqual(
             [field.name for field in store.variants[0].fields],
-            ["cache", "type", "address", "src"],
+            ["semantics", "scope", "mmio", "cache", "type", "address", "src"],
         )
         self.assertEqual(
-            store.variants[0].modifier_bindings[0].default_value.value,
+            next(binding for binding in store.variants[0].modifier_bindings
+                 if binding.source_kind_id == "cache").default_value.value,
             "unspecified",
         )
         self.assertEqual(
             [
                 availability.value
                 for availability in store.variants[0].modifier_value_availabilities
+                if availability.source_kind_id == "cache"
             ],
             ["wb", "cg", "cs", "wt"],
         )
@@ -899,11 +936,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertEqual(
             [
-                (
-                    availability.value,
-                    dict(availability.availability),
-                )
-                for availability in store.variants[1].modifier_value_availabilities
+                (entry.value, dict(entry.availability))
+                for entry in store.variants[1].modifier_value_availabilities
+                if entry.source_kind_id in {"cache", "type"}
             ],
             [
                 ("wb", {"ptx": "2.0", "sm": 20}),
@@ -924,10 +959,11 @@ class ResolvedIrBuildTest(unittest.TestCase):
         store_vector = store.variants[2]
         self.assertEqual(
             [field.name for field in store_vector.fields],
-            ["cache", "vector", "type", "address", "src"],
+            ["semantics", "scope", "cache", "vector", "type", "address", "src"],
         )
+        self.assertEqual(store_vector.memory_consistency.mmio_field_id, "")
         self.assertEqual(
-            [value.value for value in st.variants[2].modifiers[1].values],
+            [value.value for value in next(modifier for modifier in st.variants[2].modifiers if modifier.name == "vector").values],
             ["v2", "v4"],
         )
         store_vector_binding = store_vector.operand_layouts[0].bindings[1]
@@ -1170,6 +1206,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn(".enclosing_function_kind =", source)
         self.assertIn(".parameter_direction = parameter_direction", source)
         self.assertIn("CheckResult check<Ld>(", source)
+        self.assertIn("check_memory_consistency(", source)
 
     def test_generate_category_resolved_ir_source(self) -> None:
         database = load_codegen_database(
@@ -1213,6 +1250,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("const auto operand_check = check_operands(", source)
         self.assertIn("const auto layout_check = check_operand_layout_tag(", source)
         self.assertIn("check_modifier_value_availability(", source)
+        self.assertNotIn("check_memory_consistency(", source)
         self.assertIn("Add::get_checker_descriptor(), \"IntegerNoSat\"", source)
         self.assertNotIn("struct Bar {", source)
 
@@ -1313,6 +1351,8 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("checker::VariantDescriptor", source)
         self.assertIn("checker::OperandLayoutDescriptor", source)
         self.assertIn("checker::OperandTypeCompatibilityDescriptor", source)
+        self.assertIn(".memory_consistency = {", source)
+        self.assertIn(".semantics_field_id = \"semantics\",", source)
         self.assertIn(
             ".special_register_kind = base::SpecialRegisterKind::Tid,",
             source,

--- a/submod/base/include/base.hpp
+++ b/submod/base/include/base.hpp
@@ -69,6 +69,27 @@ enum class CacheOperator : uint8_t {
   Wt,
 };
 
+/** Source-level memory-consistency qualifier for ld/st.  Omitted is kept
+ * distinct from explicit .weak so target availability and source provenance
+ * remain observable in Resolved IR. */
+enum class MemoryConsistency : uint8_t {
+  Omitted = 0,
+  Weak,
+  Volatile,
+  Relaxed,
+  Acquire,
+  Release,
+};
+
+/** Scope carried by memory-consistency operations; None represents omission. */
+enum class MemoryScope : uint8_t {
+  None = 0,
+  Cta,
+  Cluster,
+  Gpu,
+  Sys,
+};
+
 template <typename Enum>
   requires std::is_enum_v<Enum>
 std::string to_string(Enum e) {

--- a/submod/cst/src/ptx_cst_parser.cpp
+++ b/submod/cst/src/ptx_cst_parser.cpp
@@ -56,7 +56,8 @@ bool isImmediate(TokenKind kind) {
 bool isModifier(TokenKind kind) {
   return kind == TokenKind::DotIdent || kind == TokenKind::DotGlobal ||
          kind == TokenKind::DotConst || kind == TokenKind::DotShared ||
-         kind == TokenKind::DotLocal || kind == TokenKind::DotParam;
+         kind == TokenKind::DotLocal || kind == TokenKind::DotParam ||
+         kind == TokenKind::DotWeak;
 }
 
 bool isModuleDirective(TokenKind kind) {

--- a/submod/cst/test/test_ptx_cst_parser.cpp
+++ b/submod/cst/test/test_ptx_cst_parser.cpp
@@ -46,6 +46,19 @@ TEST(PtxCstParser, RoundTripsInstructionWithAllTriviaAndPunctuation) {
   EXPECT_EQ(eof.leading_trivia[1].kind, TriviaKind::LineComment);
 }
 
+TEST(PtxCstParser, AcceptsWeakAsAnInstructionModifier) {
+  PtxCstParser parser("ld.weak.u32 %r0, [%rd0];");
+
+  const auto result = parser.parseInstruction();
+
+  ASSERT_TRUE(result.has_value()) << result.error().message;
+  const auto* instruction = result->instruction();
+  ASSERT_NE(instruction, nullptr);
+  ASSERT_EQ(instruction->modifiers.size(), 2u);
+  EXPECT_EQ(result->token(instruction->modifiers[0]).kind, TokenKind::DotWeak);
+  EXPECT_EQ(result->token(instruction->modifiers[0]).text, ".weak");
+}
+
 TEST(PtxCstParser, RetainsStructuredOperandDelimiterTokens) {
   PtxCstParser parser("mov.b32 [%rd1-4], %r2.x, {%r3, 1};");
 

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -23,6 +23,8 @@ namespace ptx_frontend::resolved_ir {
 using base::ScalarType;
 using base::RoundingMode;
 using base::CacheOperator;
+using base::MemoryConsistency;
+using base::MemoryScope;
 namespace check_end {
 
 using OperandShape = checker::OperandShape;
@@ -64,6 +66,8 @@ enum class ResolvedValueKind : uint8_t {
   ScalarType,
   RoundingMode,
   CacheOperator,
+  MemoryConsistency,
+  MemoryScope,
   VectorArity,
   MemoryStateSpace,
   Register,
@@ -131,6 +135,8 @@ enum class ResolvedModifierDefaultKind : uint8_t {
   ScalarType,
   RoundingMode,
   CacheOperator,
+  MemoryConsistency,
+  MemoryScope,
   MemoryStateSpace,
 };
 
@@ -141,6 +147,8 @@ struct ResolvedModifierDefaultDescriptor {
   RoundingMode rounding_mode = RoundingMode::Invalid;
   CacheOperator cache_operator = CacheOperator::Unspecified;
   MemoryStateSpace memory_state_space = MemoryStateSpace::Invalid;
+  MemoryConsistency memory_consistency = MemoryConsistency::Omitted;
+  MemoryScope memory_scope = MemoryScope::None;
 };
 
 struct ResolvedModifierBindingDescriptor {
@@ -313,7 +321,8 @@ using ResolvedMovSource =
 
 using ResolvedFieldValue =
     std::variant<WithLocs<bool>, WithLocs<ScalarType>, WithLocs<RoundingMode>,
-                 WithLocs<CacheOperator>, WithLocs<VectorArity>,
+                 WithLocs<CacheOperator>, WithLocs<MemoryConsistency>,
+                 WithLocs<MemoryScope>, WithLocs<VectorArity>,
                  WithLocs<MemoryStateSpace>,
                  WithLocs<ResolvedRegisterRef>, WithLocs<ResolvedImmediate>,
                  WithLocs<RegOrImm>, WithLocs<ResolvedMovSource>,

--- a/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
@@ -68,6 +68,8 @@ namespace checker {
 using base::ScalarType;
 using base::RoundingMode;
 using base::CacheOperator;
+using base::MemoryConsistency;
+using base::MemoryScope;
 namespace detail {
 
 /** Combine variant-specific lambdas into the visitor accepted by std::visit. */
@@ -200,9 +202,13 @@ struct OperandDescriptor {
 /** A non-owning semantic view of one resolved modifier field. */
 struct FieldView {
   std::string_view field_id;
+  std::optional<bool> bool_value;
+  std::optional<CacheOperator> cache_operator;
   std::optional<ScalarType> scalar_type;
   std::optional<VectorArity> vector_arity;
   std::optional<MemoryStateSpace> memory_state_space;
+  std::optional<MemoryConsistency> memory_consistency;
+  std::optional<MemoryScope> memory_scope;
   std::span<const SourceRange> locations;
 };
 
@@ -265,6 +271,8 @@ enum class ModifierValueKind : uint8_t {
   CacheOperator,
   VectorArity,
   MemoryStateSpace,
+  MemoryConsistency,
+  MemoryScope,
 };
 
 /** Target requirement attached to one legal semantic modifier value. */
@@ -277,6 +285,8 @@ struct ModifierValueAvailabilityDescriptor {
   CacheOperator cache_operator = CacheOperator::Unspecified;
   VectorArity vector_arity = VectorArity::Invalid;
   MemoryStateSpace memory_state_space = MemoryStateSpace::Invalid;
+  MemoryConsistency memory_consistency = MemoryConsistency::Omitted;
+  MemoryScope memory_scope = MemoryScope::None;
   AvailabilityDescriptor availability;
 };
 
@@ -290,6 +300,8 @@ struct ModifierValueView {
   CacheOperator cache_operator = CacheOperator::Unspecified;
   VectorArity vector_arity = VectorArity::Invalid;
   MemoryStateSpace memory_state_space = MemoryStateSpace::Invalid;
+  MemoryConsistency memory_consistency = MemoryConsistency::Omitted;
+  MemoryScope memory_scope = MemoryScope::None;
   bool is_present = false;
   std::span<const SourceRange> locations;
 };
@@ -311,6 +323,15 @@ struct VariantDescriptor {
   std::span<const OperandTypeCompatibilityDescriptor>
       operand_type_compatibilities;
   std::string_view rule_id;
+  /** Empty field IDs mean this variant has no memory-consistency rule. */
+  struct MemoryConsistencyDescriptor {
+    std::string_view semantics_field_id;
+    std::string_view scope_field_id;
+    std::string_view mmio_field_id;
+    std::string_view cache_field_id;
+    std::string_view address_field_id;
+    std::string_view state_space_field_id;
+  } memory_consistency;
 };
 
 /** Checker metadata for all variants of one resolved instruction. */
@@ -336,6 +357,7 @@ enum class CheckDiagnosticKind : uint8_t {
   AddressStateSpaceMismatch,
   ParameterDirectionMismatch,
   InvalidVectorOperand,
+  MemoryConsistencyViolation,
   RuleViolation,
 };
 
@@ -427,6 +449,12 @@ CheckResult check_operand_layout_availability(const VariantDescriptor& variant,
 CheckResult check_modifier_value_availability(
     std::span<const ModifierValueAvailabilityDescriptor> descriptors,
     std::span<const ModifierValueView> actual_values, const Context& context);
+
+/** Check generated ld/st memory-order and address-space cross constraints. */
+CheckResult check_memory_consistency(
+    const VariantDescriptor::MemoryConsistencyDescriptor& descriptor,
+    std::span<const FieldView> fields, std::span<const OperandView> operands,
+    const Context& context);
 
 /**
  * Check one generated resolved instruction.

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -278,6 +278,41 @@ std::expected<WithLocs<CacheOperator>, ResolveDiagnostic> resolve_cache_operator
   return WithLocs<CacheOperator>{*cache_operator, modifier.syntax.range};
 }
 
+std::optional<MemoryConsistency> memory_consistency_from_ptx_name(
+    std::string_view spelling) {
+  return lookup_ptx_suffix(generated_detail::kMemoryConsistencies, spelling);
+}
+
+std::expected<WithLocs<MemoryConsistency>, ResolveDiagnostic>
+resolve_memory_consistency(const syntax_ast::AstModifier& modifier) {
+  const auto value = memory_consistency_from_ptx_name(modifier.syntax.text);
+  if (!value) {
+    return std::unexpected(ResolveDiagnostic{
+        .range = modifier.syntax.range,
+        .message = fmt::format("Unknown memory consistency '{}'.",
+                               modifier.syntax.text),
+    });
+  }
+  return WithLocs<MemoryConsistency>{*value, modifier.syntax.range};
+}
+
+std::optional<MemoryScope> memory_scope_from_ptx_name(
+    std::string_view spelling) {
+  return lookup_ptx_suffix(generated_detail::kMemoryScopes, spelling);
+}
+
+std::expected<WithLocs<MemoryScope>, ResolveDiagnostic> resolve_memory_scope(
+    const syntax_ast::AstModifier& modifier) {
+  const auto value = memory_scope_from_ptx_name(modifier.syntax.text);
+  if (!value) {
+    return std::unexpected(ResolveDiagnostic{
+        .range = modifier.syntax.range,
+        .message = fmt::format("Unknown memory scope '{}'.", modifier.syntax.text),
+    });
+  }
+  return WithLocs<MemoryScope>{*value, modifier.syntax.range};
+}
+
 std::optional<VectorArity> vector_arity_from_ptx_name(
     std::string_view spelling) {
   return lookup_ptx_suffix(generated_detail::kVectorArities, spelling);
@@ -1633,6 +1668,8 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
     case ResolvedValueKind::ScalarType:
     case ResolvedValueKind::RoundingMode:
     case ResolvedValueKind::CacheOperator:
+    case ResolvedValueKind::MemoryConsistency:
+    case ResolvedValueKind::MemoryScope:
     case ResolvedValueKind::VectorArity:
     case ResolvedValueKind::MemoryStateSpace:
       throw ResolveException(fmt::format(
@@ -1684,6 +1721,21 @@ ResolvedFieldValue resolve_default_modifier_value(
       }
       return ResolvedFieldValue{WithLocs<CacheOperator>{
           default_value.cache_operator}};
+    case ResolvedValueKind::MemoryConsistency:
+      if (default_value.kind != ResolvedModifierDefaultKind::MemoryConsistency) {
+        throw ResolveException(fmt::format(
+            "Optional modifier '{}' requires a memory-consistency default for "
+            "resolved field '{}'.", binding.source_kind_id, field.field_id));
+      }
+      return ResolvedFieldValue{WithLocs<MemoryConsistency>{
+          default_value.memory_consistency}};
+    case ResolvedValueKind::MemoryScope:
+      if (default_value.kind != ResolvedModifierDefaultKind::MemoryScope) {
+        throw ResolveException(fmt::format(
+            "Optional modifier '{}' requires a memory-scope default for "
+            "resolved field '{}'.", binding.source_kind_id, field.field_id));
+      }
+      return ResolvedFieldValue{WithLocs<MemoryScope>{default_value.memory_scope}};
     case ResolvedValueKind::MemoryStateSpace:
       if (default_value.kind !=
               ResolvedModifierDefaultKind::MemoryStateSpace ||
@@ -1904,6 +1956,18 @@ std::expected<ResolvedInstructionFields, ResolveDiagnostic> resolve_fields(
       } break;
       case ResolvedValueKind::CacheOperator: {
         auto value = resolve_cache_operator(*actual->second);
+        if (!value)
+          return std::unexpected(value.error());
+        fields.modifiers.emplace(field.field_id, std::move(*value));
+      } break;
+      case ResolvedValueKind::MemoryConsistency: {
+        auto value = resolve_memory_consistency(*actual->second);
+        if (!value)
+          return std::unexpected(value.error());
+        fields.modifiers.emplace(field.field_id, std::move(*value));
+      } break;
+      case ResolvedValueKind::MemoryScope: {
+        auto value = resolve_memory_scope(*actual->second);
         if (!value)
           return std::unexpected(value.error());
         fields.modifiers.emplace(field.field_id, std::move(*value));

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -108,6 +108,10 @@ bool matches_modifier_value(
       return descriptor.vector_arity == actual.vector_arity;
     case ModifierValueKind::MemoryStateSpace:
       return descriptor.memory_state_space == actual.memory_state_space;
+    case ModifierValueKind::MemoryConsistency:
+      return descriptor.memory_consistency == actual.memory_consistency;
+    case ModifierValueKind::MemoryScope:
+      return descriptor.memory_scope == actual.memory_scope;
   }
   return false;
 }
@@ -777,6 +781,97 @@ CheckResult check_modifier_value_availability(
           .message = fmt::format("Modifier '{}' requires target family '{}'.",
                                  actual.kind_id, availability.required_family),
       });
+    }
+  }
+
+  if (diagnostics.empty())
+    return {};
+  return std::unexpected(std::move(diagnostics));
+}
+
+CheckResult check_memory_consistency(
+    const VariantDescriptor::MemoryConsistencyDescriptor& descriptor,
+    std::span<const FieldView> fields, std::span<const OperandView> operands,
+    const Context& context) {
+  if (descriptor.semantics_field_id.empty())
+    return {};
+
+  const FieldView* semantics_field =
+      find_field(fields, descriptor.semantics_field_id);
+  const FieldView* scope_field = find_field(fields, descriptor.scope_field_id);
+  const FieldView* mmio_field = descriptor.mmio_field_id.empty()
+                                    ? nullptr
+                                    : find_field(fields, descriptor.mmio_field_id);
+  const FieldView* cache_field = find_field(fields, descriptor.cache_field_id);
+  const OperandView* address = find_operand(operands, descriptor.address_field_id);
+  if (semantics_field == nullptr || scope_field == nullptr ||
+      cache_field == nullptr || address == nullptr ||
+      !semantics_field->memory_consistency || !scope_field->memory_scope ||
+      !cache_field->cache_operator ||
+      (mmio_field != nullptr && !mmio_field->bool_value)) {
+    return std::unexpected(CheckDiagnostics{CheckDiagnostic{
+        .kind = CheckDiagnosticKind::RuleViolation,
+        .range = context.instruction_range,
+        .message = "Generated memory-consistency descriptor has missing fields.",
+    }});
+  }
+
+  const MemoryConsistency semantics = *semantics_field->memory_consistency;
+  const MemoryScope scope = *scope_field->memory_scope;
+  const bool mmio = mmio_field != nullptr && *mmio_field->bool_value;
+  const bool cached = *cache_field->cache_operator != CacheOperator::Unspecified;
+  CheckDiagnostics diagnostics;
+  const auto violation = [&](const FieldView& field, std::string_view message) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::MemoryConsistencyViolation,
+        .range = diagnostic_range(field.locations, context),
+        .message = std::string(message),
+    });
+  };
+
+  const bool scoped = semantics == MemoryConsistency::Relaxed ||
+                      semantics == MemoryConsistency::Acquire ||
+                      semantics == MemoryConsistency::Release;
+  if (scoped != (scope != MemoryScope::None)) {
+    violation(scoped ? *semantics_field : *scope_field,
+              scoped ? "Memory semantics requires an explicit scope."
+                     : "Memory scope is only valid with relaxed, acquire, or release semantics.");
+  }
+  if (cached && (semantics == MemoryConsistency::Volatile || scoped || mmio)) {
+    violation(*cache_field,
+              "Cache operator is not valid with volatile, ordered, or mmio memory semantics.");
+  }
+
+  std::optional<MemoryStateSpace> state_space = address->address_state_space;
+  if (!descriptor.state_space_field_id.empty()) {
+    const FieldView* field = find_field(fields, descriptor.state_space_field_id);
+    if (field != nullptr && field->memory_state_space)
+      state_space = *field->memory_state_space;
+  }
+  const bool known_global_or_shared =
+      state_space == MemoryStateSpace::Global || state_space == MemoryStateSpace::Shared;
+  const bool volatile_local = semantics == MemoryConsistency::Volatile &&
+                              state_space == MemoryStateSpace::Local;
+  const bool strong = scoped || semantics == MemoryConsistency::Volatile;
+  if (strong && state_space && !known_global_or_shared && !volatile_local) {
+    violation(*semantics_field,
+              "Strong memory semantics require a global or shared address space.");
+  }
+  if (volatile_local && context.target.ptx_version < PtxVersion{9, 1}) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::UnsupportedPtxVersion,
+        .range = diagnostic_range(semantics_field->locations, context),
+        .message = fmt::format("volatile.local requires PTX ISA >= 9.1, but target PTX ISA is {}.",
+                               format_version(context.target.ptx_version)),
+    });
+  }
+  if (mmio) {
+    if (semantics != MemoryConsistency::Relaxed || scope != MemoryScope::Sys) {
+      violation(*mmio_field, "mmio requires .relaxed.sys semantics.");
+    }
+    if (state_space && *state_space != MemoryStateSpace::Global) {
+      violation(*mmio_field,
+                "mmio requires a global address space when the address space is known.");
     }
   }
 

--- a/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
@@ -913,5 +913,60 @@ TEST(ResolvedIrChecker, GeneratedBarWrapperChecksLayoutAvailability) {
   EXPECT_TRUE(check(*register_barrier, sm20_context).has_value());
 }
 
+TEST(ResolvedIrChecker, ChecksGeneratedMemoryConsistencyCrossRules) {
+  constexpr VariantDescriptor::MemoryConsistencyDescriptor descriptor{
+      .semantics_field_id = "semantics",
+      .scope_field_id = "scope",
+      .mmio_field_id = "mmio",
+      .cache_field_id = "cache",
+      .address_field_id = "address",
+  };
+  const Context context{
+      .target = {.ptx_version = {9, 2}, .sm_version = 90},
+      .instruction_range = kInstructionRange,
+  };
+  const FieldView invalid_fields[] = {
+      {.field_id = "semantics", .memory_consistency = MemoryConsistency::Relaxed},
+      {.field_id = "scope", .memory_scope = MemoryScope::None},
+      {.field_id = "mmio", .bool_value = false},
+      {.field_id = "cache", .cache_operator = CacheOperator::Unspecified},
+  };
+  const OperandView global_address[] = {{
+      .field_id = "address",
+      .actual_shape = OperandShape::Address,
+      .address_state_space = MemoryStateSpace::Global,
+  }};
+  const auto missing_scope = check_memory_consistency(
+      descriptor, invalid_fields, global_address, context);
+  ASSERT_FALSE(missing_scope.has_value());
+  EXPECT_EQ(missing_scope.error().front().kind,
+            CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const FieldView valid_fields[] = {
+      {.field_id = "semantics", .memory_consistency = MemoryConsistency::Relaxed},
+      {.field_id = "scope", .memory_scope = MemoryScope::Sys},
+      {.field_id = "mmio", .bool_value = true},
+      {.field_id = "cache", .cache_operator = CacheOperator::Unspecified},
+  };
+  EXPECT_TRUE(check_memory_consistency(descriptor, valid_fields, global_address,
+                                       context)
+                  .has_value());
+
+  constexpr VariantDescriptor::MemoryConsistencyDescriptor vector_descriptor{
+      .semantics_field_id = "semantics",
+      .scope_field_id = "scope",
+      .cache_field_id = "cache",
+      .address_field_id = "address",
+  };
+  const FieldView vector_fields[] = {
+      {.field_id = "semantics", .memory_consistency = MemoryConsistency::Relaxed},
+      {.field_id = "scope", .memory_scope = MemoryScope::Cta},
+      {.field_id = "cache", .cache_operator = CacheOperator::Unspecified},
+  };
+  EXPECT_TRUE(check_memory_consistency(vector_descriptor, vector_fields,
+                                       global_address, context)
+                  .has_value());
+}
+
 }  // namespace
 }  // namespace ptx_frontend::resolved_ir::checker

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -205,6 +205,13 @@ TEST(SelectVariantLoadStore, SelectsLegalCacheOperatorsAndRejectsWrongOnes) {
   const auto invalid_vector_selected = selectVariant<Ld>(invalid_vector);
   ASSERT_FALSE(invalid_vector_selected.has_value());
   EXPECT_EQ(invalid_vector_selected.error().message, "Unknown modifier '.v8'.");
+
+  const auto vector_mmio = parse_instruction(
+      "ld.mmio.relaxed.sys.v2.u32 {%r0, %r1}, [%rd0];");
+  const auto vector_mmio_selected = selectVariant<Ld>(vector_mmio);
+  ASSERT_FALSE(vector_mmio_selected.has_value());
+  EXPECT_EQ(vector_mmio_selected.error().message,
+            "No variant of instruction 'ld' accepts this modifier combination.");
 }
 
 TEST(SelectVariantAdd, ReportsUnknownModifier) {
@@ -304,6 +311,72 @@ TEST(ResolveLoadStore, PreservesCacheValuesAndOmittedSentinel) {
   ASSERT_NE(omitted_store_variant, nullptr);
   EXPECT_EQ(omitted_store_variant->cache.value, CacheOperator::Unspecified);
   EXPECT_TRUE(omitted_store_variant->cache.locs.empty());
+}
+
+TEST(ResolveLoadStore, PreservesMemoryConsistencyDefaultsAndExplicitWeak) {
+  const auto omitted_ast = parse_instruction("ld.u32 %r0, [%rd0];");
+  const auto omitted = resolve<Ld>(omitted_ast);
+  ASSERT_TRUE(omitted.has_value()) << omitted.error().message;
+  const auto* omitted_variant = std::get_if<Ld::GenericScalar>(&omitted->variant);
+  ASSERT_NE(omitted_variant, nullptr);
+  EXPECT_EQ(omitted_variant->semantics.value, MemoryConsistency::Omitted);
+  EXPECT_TRUE(omitted_variant->semantics.locs.empty());
+  EXPECT_EQ(omitted_variant->scope.value, MemoryScope::None);
+  EXPECT_TRUE(omitted_variant->scope.locs.empty());
+
+  const auto weak_ast = parse_instruction("ld.weak.u32 %r0, [%rd0];");
+  const auto weak = resolve<Ld>(weak_ast);
+  ASSERT_TRUE(weak.has_value()) << weak.error().message;
+  const auto* weak_variant = std::get_if<Ld::GenericScalar>(&weak->variant);
+  ASSERT_NE(weak_variant, nullptr);
+  EXPECT_EQ(weak_variant->semantics.value, MemoryConsistency::Weak);
+  ASSERT_EQ(weak_variant->semantics.locs.size(), 1U);
+  EXPECT_EQ(weak_variant->semantics.locs.front(),
+            weak_ast.modifiers.front().syntax.range);
+
+  const auto acquire = selectVariant<Ld>(
+      parse_instruction("ld.acquire.gpu.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(acquire.has_value()) << acquire.error().message;
+  EXPECT_EQ(*acquire, Ld::VariantType::GenericScalar);
+  const auto release = selectVariant<St>(
+      parse_instruction("st.release.sys.u32 [%rd0], %r0;"));
+  ASSERT_TRUE(release.has_value()) << release.error().message;
+  EXPECT_EQ(*release, St::VariantType::GenericScalar);
+}
+
+TEST(ResolveLoadStore, ChecksMemoryConsistencyCrossRules) {
+  const checker::Context context{
+      .target = {.ptx_version = {9, 2}, .sm_version = 90},
+      .instruction_range = SourceRange{},
+  };
+  const auto missing_scope = resolve<Ld>(
+      parse_instruction("ld.relaxed.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(missing_scope.has_value()) << missing_scope.error().message;
+  const auto missing_scope_check = checker::check(*missing_scope, context);
+  ASSERT_FALSE(missing_scope_check.has_value());
+  EXPECT_EQ(missing_scope_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const auto conflicting_cache = resolve<Ld>(
+      parse_instruction("ld.ca.volatile.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(conflicting_cache.has_value()) << conflicting_cache.error().message;
+  const auto cache_check = checker::check(*conflicting_cache, context);
+  ASSERT_FALSE(cache_check.has_value());
+  EXPECT_EQ(cache_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const auto relaxed_local = resolve<Ld>(
+      parse_instruction("ld.local.relaxed.cta.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(relaxed_local.has_value()) << relaxed_local.error().message;
+  const auto relaxed_local_check = checker::check(*relaxed_local, context);
+  ASSERT_FALSE(relaxed_local_check.has_value());
+  EXPECT_EQ(relaxed_local_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const auto unknown_generic = resolve<Ld>(
+      parse_instruction("ld.acquire.gpu.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(unknown_generic.has_value()) << unknown_generic.error().message;
+  EXPECT_TRUE(checker::check(*unknown_generic, context).has_value());
 }
 
 TEST(CollectActualModifiersAdd, BindsSpellingsToSelectedVariantSlots) {


### PR DESCRIPTION
## Summary

- add PTX <= 9.2 `ld/st` memory-consistency qualifiers: omitted/explicit `.weak`, `.volatile`, scoped `.relaxed/.acquire/.release`, and scalar `.mmio.relaxed.sys`
- preserve qualifier provenance in Resolved IR and enforce scope/cache/address-space cross-rules through one generated typed descriptor
- reject legacy vector `.mmio` during variant selection and keep non-memory instructions free of empty consistency checks
- update schema, generators, C++ checker, regression tests, and bilingual documentation

## Validation

- [Linux CI run #6](https://github.com/endingly/ptx_frontend/actions/runs/32866039580): Debug and Release passed the full CMake workflow and all 185 CTests
- Python unit tests: 57 passed
- all 5 PTX specs and the C++ backend spec passed schema validation
- generated-source checks passed; data-movement emits consistency checks while unrelated categories do not
- `git diff --check` passed

The initial CI run exposed that the lexer classifies `.weak` as the dedicated linking token `DotWeak`; the instruction parser now accepts that token in modifier position and has a direct CST regression test.