### PR TITLE
feat: add PTX 8.8 modern ld/st vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ The frontend currently provides:
 - generated resolution and checking for YAML-modelled `bra`, `add`, `sub`,
   `bar`, selected `mov` forms, generic/basic-explicit scalar `ld`/`st` across
   the 14 `.b8/.b16/.b32/.b64`, `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`,
-  `.f32/.f64` types, plus legacy `.v2/.v4` braced-vector `ld`/`st` with a
-  128-bit payload maximum (`.v2` through 64-bit types and `.v4` through
-  32-bit types; `.v4` 64-bit remains deferred), legacy `ld` cache operators
+  `.f32/.f64` types, plus legacy `.v2/.v4` braced-vector `ld`/`st` and the
+  PTX 8.8/SM 100 256-bit modern forms (`.v8` × 32-bit or `.v4` × 64-bit);
+  modern vectors require global space when known and permit partial `_` sinks,
+  while legacy vectors remain limited to 128 bits and reject sinks. Legacy `ld`
+  cache operators
   `.ca/.cg/.cs/.lu/.cv`, legacy `st` cache operators
   `.wb/.cg/.cs/.wt`, explicit `.const/.global/.local/.param/.shared` loads,
   and explicit `.global/.local/.param/.shared` stores, including data-driven

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -20,11 +20,12 @@ type families accept register, immediate, and special-register sources; the
 legal formal-parameter-address sources. Bit-size forms also support two/four-
 element vector pack/unpack; `.b128` is vector-only. `mov.pred` reuses the declaration-aware
 `ResolvedPredicate` representation. Generic and basic explicit-space scalar
-plus legacy `.v2/.v4` vector `ld`/`st` exercise the dereferenced-address path
+plus braced-vector `ld`/`st` exercise the dereferenced-address path
 for 14 bit-size, integer, and floating-point types from 8 through 64 bits.
 Legacy memory-vector payloads are capped at 128 bits: `.v2` accepts modeled
-types through 64 bits, `.v4` through 32 bits, and `.v4` 64-bit remains deferred.
-Other source forms, modern memory vectors, remaining qualifier extensions,
+types through 64 bits and `.v4` through 32 bits. PTX 8.8/SM 100 additionally
+accepts exactly 256-bit `.v8` × 32-bit and `.v4` × 64-bit forms. Other source forms,
+remaining qualifier extensions,
 static address alignment, `call` groups, CFG/SSA, and target lowering remain
 later work.
 
@@ -170,19 +171,19 @@ A `ResolvedAddress` base is a variant of `ResolvedRegisterRef`,
 add/subtract operator and a parsed signed 64-bit value.
 A 32/64-bit integer or bit-size `mov d, symbol+offset` uses an unbracketed
 address value restricted to an addressable data-symbol or formal-parameter
-base. Scalar and legacy `.v2/.v4` `ld`/`st` require bracketed dereference and
+base. Scalar and braced-vector `ld`/`st` require bracketed dereference and
 cover register, immediate, and bound-symbol bases. Each opcode uses
 `GenericScalar`, `ExplicitScalar`, `GenericVector`, and `ExplicitVector`
 variants. Their runtime type field accepts `.b8/.b16/.b32/.b64`,
 `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`, and `.f32/.f64`; `.b128` is not a
 memory type in the current model. Vector variants add a required runtime
-`.v2/.v4` field, and the register-vector operand descriptor links its expected
+`.v2/.v4/.v8` field, and the register-vector operand descriptor links its expected
 element count to that field rather than duplicating variants per arity. Memory
 vectors use element type policy: each register element is checked against the
-instruction type, with `EqualOrWider` register width accepted and `_` sinks
-rejected. Their payload is capped at 128 bits: `.v2` accepts modeled types
-through 64 bits and `.v4` through 32 bits; `.v4` 64-bit remains deferred. The
-default register-width policy is `SameWidth`, preserving
+instruction type, with `EqualOrWider` register width accepted. Legacy payloads
+are capped at 128 bits; the generated cross constraint adds only exact 256-bit
+`.v8` × 32-bit and `.v4` × 64-bit forms at PTX 8.8/SM 100, global when known,
+with partial sinks. The default register-width policy is `SameWidth`, preserving
 `mov/add/sub`, immediate, and special-register behavior. Only `ld` destination
 and `st` source register descriptors select `EqualOrWider`, so the declared
 register may be at least as wide as the instruction type. After that size
@@ -227,8 +228,11 @@ distinct from explicit `.weak`; `.volatile`, `.relaxed`, `.acquire`, and
 for relaxed/acquire/release, rejects cache with volatile/ordered/mmio forms,
 uses known address-space identity without guessing unknown generic addresses,
 and applies the global/shared, `volatile.local` PTX 9.1, and scalar
-`.mmio.relaxed.sys` rules. Modern vector forms and static alignment checks are
-still deferred.
+`.mmio.relaxed.sys` rules. A generated `memory_vector` cross constraint detects
+arity > 4, payload > 128, or sinks; it requires a 256-bit payload, global space
+when known, and PTX 8.8/SM 100. Partial sinks are valid only for those modern
+load/store vectors; all-sink and legacy sinks remain invalid. Static alignment
+checks are still deferred.
 
 `ResolvedAddress` separately records the enclosing function kind. Generated
 address views derive an optional parameter direction only from a bound
@@ -408,8 +412,7 @@ Implementation entry points are `submod/resolved_ir/include/ptx_resolved_ir.hpp`
 `resolved_ir.gen.hpp`.
 
 Function-local call-argument `.param` memory, qualified `::entry`/`::func`
-forms, call adjacency/predication constraints, modern memory vector forms,
-`.b128`, declaration-type availability for wider `.b128` registers, modern
-memory vector forms, and static memory-address alignment checks remain outside
-this slice. Legacy scalar/vector `ld/st` cache operators, legacy `.v2/.v4`
-braced memory vectors, and memory-consistency qualifiers are covered here.
+forms, call adjacency/predication constraints, scalar `.b128`, declaration-type
+availability for wider `.b128` registers, and static memory-address alignment checks remain outside
+this slice. Legacy scalar/vector `ld/st` cache operators, PTX 8.8 modern memory
+vectors, and memory-consistency qualifiers are covered here.

--- a/docs/us-en/syntax_coverage.md
+++ b/docs/us-en/syntax_coverage.md
@@ -22,7 +22,7 @@ PTX ISA support. The reference grammar is NVIDIA's
 | Other directives | Not supported (rejected) | Debug, section, pragma, module variable, and structured kernel-tuning directives; unmodeled function-header tokens never silently enter the AST |
 | Structured control syntax | Not supported | Nested scopes and directive-driven control-flow metadata |
 | Recovery/editing | Not supported | Missing tokens, recovery nodes, multi-error parsing, and token edits |
-| Resolved opcodes | Partial | Only opcodes present in the YAML database; currently `add`, `sub`, `bar`, `bra`, selected scalar/vector `mov`, and generic/basic-explicit scalar plus legacy `.v2/.v4` braced-vector `ld`/`st` for `.b8/.b16/.b32/.b64`, `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`, and `.f32/.f64`; `ld/st` support omitted/explicit `.weak`, `.volatile`, scoped relaxed/acquire/release, and PTX 8.2 scalar `.mmio.relaxed.sys`, with generated cross-modifier checks; modern vectors and static alignment checking remain deferred; legacy vector payloads are at most 128 bits (`.v2` through 64-bit types, `.v4` through 32-bit types; `.v4` 64-bit is deferred); generic loads accept known `.const/.global/.local/.shared` spaces (`.const` requires PTX 3.1), generic stores accept `.global/.local/.shared`, and explicit forms require an exact runtime-modifier match; bound `.param` loads require input parameters and stores require return parameters, with function-context PTX/SM checks; load destination/store source registers and vector elements may be wider under the bit/integer/float kind rules, while other typed operands remain same-width and unknown address identity is not inferred |
+| Resolved opcodes | Partial | Only opcodes present in the YAML database; currently `add`, `sub`, `bar`, `bra`, selected scalar/vector `mov`, and generic/basic-explicit scalar plus braced-vector `ld`/`st` for `.b8/.b16/.b32/.b64`, `.u8/.u16/.u32/.u64`, `.s8/.s16/.s32/.s64`, and `.f32/.f64`; PTX 8.8/SM 100 modern vectors accept only `.v8` × 32-bit or `.v4` × 64-bit 256-bit payloads, require global space when known, and allow partial `_` sinks. Legacy vectors remain at most 128 bits and reject sinks. `ld/st` support omitted/explicit `.weak`, `.volatile`, scoped relaxed/acquire/release, and PTX 8.2 scalar `.mmio.relaxed.sys`, with generated cross-modifier checks; static alignment checking remains deferred; generic loads accept known `.const/.global/.local/.shared` spaces (`.const` requires PTX 3.1), generic stores accept `.global/.local/.shared`, and explicit forms require an exact runtime-modifier match; bound `.param` loads require input parameters and stores require return parameters, with function-context PTX/SM checks; load destination/store source registers and vector elements may be wider under the bit/integer/float kind rules, while other typed operands remain same-width and unknown address identity is not inferred |
 
 The lexer may tokenize source outside this matrix, and Syntax AST may retain an
 unknown opcode as text. Neither behavior means that the construct can be
@@ -30,7 +30,7 @@ lowered to Resolved IR.
 
 ## Near-term order
 
-1. Extend `ld/st` with modern vector forms, static alignment checks, and the
+1. Extend `ld/st` with static alignment checks and the
    remaining cross-modifier rules. `.b128` is not part of the current
    scalar family. Function-local call argument `.param`, `::entry`/`::func`,
    and call adjacency/predication remain part of the later call-context work.

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -277,7 +277,9 @@ availability; generic `.f64` does not duplicate it because the generic variant
 already requires SM 20. Data operands use `type: {expr: modifier(type)}`, so
 the runtime modifier and its location drive the common fundamental-type check.
 Legacy memory-vector payloads are capped at 128 bits: `.v2` accepts modeled
-types through 64 bits and `.v4` through 32 bits; `.v4` 64-bit is deferred.
+types through 64 bits and `.v4` through 32 bits. A generated `memory_vector`
+constraint additionally permits only 256-bit `.v8` × 32-bit and `.v4` × 64-bit
+forms at PTX 8.8/SM 100, with global space when known.
 A register operand may also select an explicit width policy:
 
 ```yaml
@@ -300,8 +302,8 @@ instruction size, after which either-side bit types and signed/unsigned integer
 pairs are compatible, floats require exact type/size, and integer/float pairs
 remain incompatible. Immediate and special-register checks stay same-width.
 Wider actual registers are currently limited to 64 bits; `.b128` remains
-rejected until declaration-type target availability is checked. `.b128`
-instruction types and modern vector forms remain outside this set.
+rejected until declaration-type target availability is checked. Scalar `.b128`
+instruction types remain outside this set.
 
 A `reg_vector` operand must declare legal element counts through
 `vector.arity`. Static forms use an integer or list:
@@ -309,8 +311,8 @@ A `reg_vector` operand must declare legal element counts through
 ```yaml
 vector: {arity: [2, 4], type_policy: aggregate, allow_sink: true}
 ```
-This sink support is additionally constrained by write access in the operand
-descriptor.
+For memory vectors, the generated cross rule permits partial sinks only for an
+exact 256-bit modern payload; legacy vectors and all-sink forms remain invalid.
 
 Legacy memory vectors instead link arity to the required runtime vector
 modifier:
@@ -328,8 +330,9 @@ modifier:
 `type_policy: aggregate` checks a vector payload against the whole instruction
 bit width and is used by `mov` pack/unpack. `type_policy: element` checks each
 element against the instruction type and is used by legacy memory vectors.
-Those memory vectors are limited to a 128-bit payload: `.v2` through 64-bit
-types and `.v4` through 32-bit types; `.v4` 64-bit remains deferred.
+Those memory vectors retain their 128-bit legacy forms (`.v2` through 64-bit
+types and `.v4` through 32-bit types) and add only the PTX 8.8 256-bit forms
+described above.
 `VectorArity` is a required modifier domain; it has no optional/default form.
 
 Use semantic roles such as `dst`, `src1`, `barrier`, and `thread_count` rather

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -17,11 +17,11 @@ lexical symbol binding 与 module resolution 已接通，execution predicate 会
 32/64-bit form 还接入 data-symbol、`symbol+offset`、function-address 与合法 formal parameter
 地址；bit-size form 还支持 2/4-element vector pack/unpack，`.b128` 仅用于 vector form；
 `mov.pred` 复用 declaration-aware `ResolvedPredicate` 表示；
-generic 与 basic explicit-space scalar 以及 legacy `.v2/.v4` braced-vector `ld`/`st` 已为
+generic 与 basic explicit-space scalar 以及 braced-vector `ld`/`st` 已为
 14 种 8--64-bit bit-size、integer 与 floating-point type 接入解引用 address operand。
 legacy memory-vector payload 最多 128 bit：`.v2` 到 64-bit type，`.v4` 到
-32-bit type，`.v4` 64-bit 仍是尚待实现的 modern form。
-其余 source form、modern vector memory operation、其余 memory qualifier extension、
+32-bit type；PTX 8.8/SM 100 另支持精确 256-bit 的 `.v8` × 32-bit 与 `.v4` × 64-bit。
+其余 source form、其余 memory qualifier extension、
 静态 address alignment、`call` group、CFG、SSA 和目标 lowering 仍是后续 pass，不应改变此层的结构。
 
 生成的公共层还提供了一个与具体 opcode 无关的边界：
@@ -136,15 +136,16 @@ register、data symbol 与 address expression，避免这些 identifier 形状�
 `ResolvedSymbolRef` 的 variant，可选 offset 保留加减 operator 和解析后的 signed 64-bit
 value。32/64-bit integer 或 bit-size `mov d, symbol+offset` 使用未加方括号且限定为
 addressable data-symbol 或 formal-parameter base 的地址值；
-scalar 与 legacy `.v2/.v4` `ld`/`st` 要求方括号解引用，覆盖 register、immediate 与
+scalar 与 braced-vector `ld`/`st` 要求方括号解引用，覆盖 register、immediate 与
 bound-symbol base。每个 opcode 使用 `GenericScalar`、`ExplicitScalar`、`GenericVector`
 与 `ExplicitVector` variant；runtime type field 接受 `.b8/.b16/.b32/.b64`、
 `.u8/.u16/.u32/.u64`、`.s8/.s16/.s32/.s64` 与 `.f32/.f64`，当前 memory type 不包含
-`.b128`。vector variant 额外要求 runtime `.v2/.v4` field，register-vector operand
+`.b128`。vector variant 额外要求 runtime `.v2/.v4/.v8` field，register-vector operand
 descriptor 将期望元素数链接到该 field，而不是按 arity 复制 variant。memory vector 使用
 element type policy：每个 register element 都按 instruction type 检查，允许
-`EqualOrWider` register width，并拒绝 `_` sink。payload 最多 128 bit：`.v2` 到
-64-bit type，`.v4` 到 32-bit type，`.v4` 64-bit 仍待实现。默认 register-width policy 为 `SameWidth`，
+`EqualOrWider` register width。legacy payload 最多 128 bit；generated cross constraint
+另加入 PTX 8.8/SM 100 的精确 256-bit `.v8` × 32-bit 与 `.v4` × 64-bit form，地址已知时
+要求 global，并允许部分 sink。默认 register-width policy 为 `SameWidth`，
 保持 `mov/add/sub`、immediate 与 special-register 的既有行为；只有 `ld` destination 与
 `st` source register descriptor 选择 `EqualOrWider`，因此声明 register 位宽可大于等于
 instruction type。通过 size 检查后，任一侧为 bit type 即兼容，fundamental signed/unsigned
@@ -179,7 +180,10 @@ memory consistency 采用生成的 cross-modifier descriptor，而不是把每�
 checker 只允许 relaxed/acquire/release 携带 scope，拒绝 volatile/ordered/mmio 与
 cache 的组合；对已知 address space 执行 global/shared、PTX 9.1 的
 `volatile.local` 及 scalar `.mmio.relaxed.sys` 规则，而不猜测 unknown generic
-address。modern vector form 与静态地址 alignment 检查仍留作后续。
+address。生成的 `memory_vector` cross constraint 以 arity > 4、payload > 128 或 sink
+识别 modern candidate，要求 256 bit、地址已知时 global、以及 PTX 8.8/SM 100；只有这些
+modern load/store vector 可使用部分 sink，all-sink 与 legacy sink 仍拒绝。静态地址 alignment
+检查仍留作后续。
 
 `ResolvedAddress` 另行记录 enclosing function kind。generated address view 仅从已绑定的
 `InputParameter`/`ReturnParameter` 推导可选 parameter direction，不根据 spelling 猜测。
@@ -337,7 +341,7 @@ instruction 约束仍不属于当前 ABI。
 `resolved_ir.gen.hpp`。
 
 function-local call-argument `.param` memory、带限定的 `::entry`/`::func` form、call
-adjacency/predication constraint、modern memory vector form、`.b128`、wider `.b128` register
-所需的 declaration-type availability 与静态地址 alignment 检查仍不在本切片范围内。
+adjacency/predication constraint、scalar `.b128`、wider `.b128` register 所需的
+declaration-type availability 与静态地址 alignment 检查仍不在本切片范围内。
 legacy scalar/vector `ld/st` cache operator、legacy `.v2/.v4` braced memory vector 与
 memory consistency qualifier 已纳入本切片。

--- a/docs/zh-han/syntax_coverage.md
+++ b/docs/zh-han/syntax_coverage.md
@@ -21,14 +21,14 @@
 | 其他 directive | 尚未支持（直接拒绝） | debug、section、pragma、module variable 与结构化 kernel-tuning directive；未建模 function-header token 不会静默进入 AST |
 | 结构化控制语法 | 尚未支持 | nested scope 与由 directive 驱动的 control-flow metadata |
 | 恢复与编辑 | 尚未支持 | missing token、recovery node、多错误解析与 token edit |
-| Resolved opcode | 部分支持 | 仅支持 YAML database 中存在的 opcode；当前为 `add`、`sub`、`bar`、`bra`、部分 scalar/vector `mov`，以及 `.b8/.b16/.b32/.b64`、`.u8/.u16/.u32/.u64`、`.s8/.s16/.s32/.s64`、`.f32/.f64` 的 generic/basic-explicit scalar 与 legacy `.v2/.v4` braced-vector `ld`/`st`；`ld/st` 支持 omission/显式 `.weak`、`.volatile`、带 scope 的 relaxed/acquire/release，以及 PTX 8.2 scalar `.mmio.relaxed.sys`，并由生成的 cross-modifier checker 约束；modern vector 与静态 alignment 检查仍待后续；legacy vector payload 最多 128 bit（`.v2` 到 64-bit type，`.v4` 到 32-bit type；`.v4` 64-bit 尚待实现）；generic load 接受已知 `.const/.global/.local/.shared` space（`.const` 要求 PTX 3.1），generic store 接受 `.global/.local/.shared`，explicit form 要求精确匹配 runtime modifier；绑定的 `.param` load 要求 input parameter，store 要求 return parameter，并按 function context 检查 PTX/SM；load destination/store source register 以及 vector element 可在 bit/integer/float kind rule 下使用更宽声明，其余 typed operand 仍要求 same-width，未知 address identity 不推断 |
+| Resolved opcode | 部分支持 | 仅支持 YAML database 中存在的 opcode；当前为 `add`、`sub`、`bar`、`bra`、部分 scalar/vector `mov`，以及 `.b8/.b16/.b32/.b64`、`.u8/.u16/.u32/.u64`、`.s8/.s16/.s32/.s64`、`.f32/.f64` 的 generic/basic-explicit scalar 与 braced-vector `ld`/`st`；PTX 8.8/SM 100 modern vector 只接受 `.v8` × 32-bit 或 `.v4` × 64-bit 的 256-bit payload，地址已知时要求 global，并可部分使用 `_` sink；legacy vector 仍最多 128 bit 且拒绝 sink。`ld/st` 支持 omission/显式 `.weak`、`.volatile`、带 scope 的 relaxed/acquire/release，以及 PTX 8.2 scalar `.mmio.relaxed.sys`，并由生成的 cross-modifier checker 约束；静态 alignment 检查仍待后续；generic load 接受已知 `.const/.global/.local/.shared` space（`.const` 要求 PTX 3.1），generic store 接受 `.global/.local/.shared`，explicit form 要求精确匹配 runtime modifier；绑定的 `.param` load 要求 input parameter，store 要求 return parameter，并按 function context 检查 PTX/SM；load destination/store source register 以及 vector element 可在 bit/integer/float kind rule 下使用更宽声明，其余 typed operand 仍要求 same-width，未知 address identity 不推断 |
 
 Lexer 能切分矩阵以外的源码，Syntax AST 也可能以文本形式保留未知 opcode；这两种情况
 都不表示该结构能够 lower 到 Resolved IR。
 
 ## 近期实现顺序
 
-1. 扩展 `ld/st` 的 modern vector form、静态 alignment 检查与其余跨 modifier
+1. 扩展 `ld/st` 的静态 alignment 检查与其余跨 modifier
    规则；`.b128` 不属于当前 scalar family；
    function-local call-argument `.param`、`::entry`/`::func` 以及 call
    adjacency/predication 留到后续 call-context 工作；

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -247,7 +247,8 @@ modifier-value availability。explicit `.f64` 附加 SM 13 availability；generi
 `type: {expr: modifier(type)}`，由 runtime modifier 及其位置驱动公共
 fundamental-type 检查。register operand 还可以选择显式 width policy：
 legacy memory-vector payload 最多 128 bit：`.v2` 到 64-bit type，`.v4` 到
-32-bit type；`.v4` 64-bit 尚待实现。
+32-bit type；生成的 `memory_vector` constraint 另只允许 PTX 8.8/SM 100 的
+256-bit `.v8` × 32-bit 与 `.v4` × 64-bit，且地址已知时必须 global。
 
 ```yaml
 - name: dst
@@ -266,14 +267,15 @@ runtime Resolved IR field。当前 scalar `ld` destination、scalar `st` source�
 instruction size；通过 size 检查后，任一侧 bit type 与 signed/unsigned integer pair 兼容，
 float 要求 exact type/size，integer/float 不兼容。immediate 与 special-register check 仍为
 same-width。wider actual register 当前只覆盖到 64-bit；在 declaration type 的 target availability
-得到检查前，`.b128` 仍明确拒绝。`.b128` instruction type 与 modern vector form 仍不属于当前范围。
+得到检查前，`.b128` 仍明确拒绝。scalar `.b128` instruction type 仍不属于当前范围。
 
 `reg_vector` operand 必须用 `vector.arity` 声明合法元素数。静态形式使用整数或列表：
 
 ```yaml
 vector: {arity: [2, 4], type_policy: aggregate, allow_sink: true}
 ```
-该能力还受 operand access 的 write 约束。
+memory vector 的 generated cross rule 只允许精确 256-bit modern payload 使用部分 sink；
+legacy vector 与 all-sink form 仍拒绝。
 
 legacy memory vector 则把 arity 链接到 required runtime vector modifier：
 
@@ -289,8 +291,8 @@ legacy memory vector 则把 arity 链接到 required runtime vector modifier：
 
 `type_policy: aggregate` 按整条 instruction 的 bit width 检查 vector payload，用于
 `mov` pack/unpack；`type_policy: element` 逐元素按 instruction type 检查，用于 legacy
-memory vector。该 memory vector payload 最多 128 bit：`.v2` 到 64-bit type，`.v4` 到
-32-bit type；`.v4` 64-bit 尚待实现。`VectorArity` 是 required modifier domain，不支持
+memory vector。该 memory vector 保留最多 128-bit 的 legacy form（`.v2` 到 64-bit type，
+`.v4` 到 32-bit type），并加入上述 PTX 8.8 的 256-bit form。`VectorArity` 是 required modifier domain，不支持
 optional/default 形式。
 
 应使用语义 role（如 `dst`、`src1`、`barrier`、`thread_count`）而不是为了复用字段

--- a/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
+++ b/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
@@ -109,6 +109,7 @@ domains:
     values:
       v2: VectorArity::V2
       v4: VectorArity::V4
+      v8: VectorArity::V8
 
   memory_state_spaces:
     cpp_type: MemoryStateSpace

--- a/instructions/ptx_spec/data_movement.yaml
+++ b/instructions/ptx_spec/data_movement.yaml
@@ -141,6 +141,7 @@ operand_patterns:
         arity:
           expr: modifier(vector)
         type_policy: element
+        allow_sink: true
     - name: address
       kind: addr
       role: addr
@@ -166,6 +167,7 @@ operand_patterns:
         arity:
           expr: modifier(vector)
         type_policy: element
+        allow_sink: true
     - name: address
       kind: addr
       role: addr
@@ -210,6 +212,7 @@ operand_patterns:
         arity:
           expr: modifier(vector)
         type_policy: element
+        allow_sink: true
 
   st_explicit_vector:
     - name: address
@@ -235,6 +238,7 @@ operand_patterns:
         arity:
           expr: modifier(vector)
         type_policy: element
+        allow_sink: true
 
   st_explicit_scalar:
     - name: address
@@ -397,11 +401,10 @@ instructions:
   - opcode: ld
     section: "9.7.9.8"
     doc: >
-      Scalar and legacy v2/v4 8/16/32/64-bit integer, bit-size, and 32/64-bit
-      floating-point load through a generic address or the basic explicit
-      const, global, local, parameter, and shared spaces. Other qualifiers and
-      newer vector extensions remain separate coverage.
-    syntax: "ld{.const|.global|.local|.param|.shared}{.v2|.v4}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} dst, [address]"
+      Scalar and legacy v2/v4 forms, plus PTX 8.8 256-bit v8 32-bit and v4
+      64-bit vector loads through a generic address or explicit global space.
+      Alignment and other qualifiers remain separate coverage.
+    syntax: "ld{.const|.global|.local|.param|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} dst, [address]"
 
     variants:
       - name: ld_generic_scalar
@@ -546,7 +549,10 @@ instructions:
             kind: vector
             domain: vector_arities
             presence: required
-            values: [v2, v4]
+            values:
+              - v2
+              - v4
+              - v8
           - name: type
             kind: type
             domain: scalar_types
@@ -562,11 +568,18 @@ instructions:
             scope_modifier: scope
             cache_modifier: cache
             address_operand: address
+          - kind: memory_vector
+            type_modifier: type
+            vector_operand: dst
+            address_operand: address
+            availability: {ptx: "8.8", sm: 100}
 
         examples:
           - ptx: "ld.v2.u32 {%r0, %r1}, [%rd0];"
             valid: true
           - ptx: "ld.v4.u16 {%h0, %h1, %h2, %h3}, [%rd0];"
+            valid: true
+          - ptx: "ld.v8.u32 {%r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [%rd0];"
             valid: true
 
       - name: ld_explicit_vector
@@ -593,7 +606,10 @@ instructions:
             kind: vector
             domain: vector_arities
             presence: required
-            values: [v2, v4]
+            values:
+              - v2
+              - v4
+              - v8
           - name: type
             kind: type
             domain: scalar_types
@@ -613,6 +629,12 @@ instructions:
             cache_modifier: cache
             address_operand: address
             state_space_modifier: state_space
+          - kind: memory_vector
+            type_modifier: type
+            vector_operand: dst
+            address_operand: address
+            state_space_modifier: state_space
+            availability: {ptx: "8.8", sm: 100}
 
         examples:
           - ptx: "ld.global.v2.u32 {%r0, %r1}, [global_value];"
@@ -623,11 +645,10 @@ instructions:
   - opcode: st
     section: "9.7.9.11"
     doc: >
-      Scalar and legacy v2/v4 8/16/32/64-bit integer, bit-size, and 32/64-bit
-      floating-point store through a generic address or the basic explicit
-      global, local, parameter, and shared spaces. Other qualifiers and newer
-      vector extensions remain separate coverage.
-    syntax: "st{.global|.local|.param|.shared}{.v2|.v4}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} [address], src"
+      Scalar and legacy v2/v4 forms, plus PTX 8.8 256-bit v8 32-bit and v4
+      64-bit vector stores through a generic address or explicit global space.
+      Alignment and other qualifiers remain separate coverage.
+    syntax: "st{.global|.local|.param|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} [address], src"
 
     variants:
       - name: st_generic_scalar
@@ -740,7 +761,10 @@ instructions:
             kind: vector
             domain: vector_arities
             presence: required
-            values: [v2, v4]
+            values:
+              - v2
+              - v4
+              - v8
           - name: type
             kind: type
             domain: scalar_types
@@ -756,11 +780,18 @@ instructions:
             scope_modifier: scope
             cache_modifier: cache
             address_operand: address
+          - kind: memory_vector
+            type_modifier: type
+            vector_operand: src
+            address_operand: address
+            availability: {ptx: "8.8", sm: 100}
 
         examples:
           - ptx: "st.v2.u32 [%rd0], {%r0, %r1};"
             valid: true
           - ptx: "st.v4.u16 [%rd0], {%h0, %h1, %h2, %h3};"
+            valid: true
+          - ptx: "st.v4.u64 [%rd0], {%rd0, %rd1, %rd2, %rd3};"
             valid: true
 
       - name: st_explicit_vector
@@ -787,7 +818,10 @@ instructions:
             kind: vector
             domain: vector_arities
             presence: required
-            values: [v2, v4]
+            values:
+              - v2
+              - v4
+              - v8
           - name: type
             kind: type
             domain: scalar_types
@@ -807,6 +841,12 @@ instructions:
             cache_modifier: cache
             address_operand: address
             state_space_modifier: state_space
+          - kind: memory_vector
+            type_modifier: type
+            vector_operand: src
+            address_operand: address
+            state_space_modifier: state_space
+            availability: {ptx: "8.8", sm: 100}
 
         examples:
           - ptx: "st.global.v2.u32 [global_value], {%r0, %r1};"

--- a/instructions/schemas/ptx-instr-v1.schema.yaml
+++ b/instructions/schemas/ptx-instr-v1.schema.yaml
@@ -1003,6 +1003,7 @@ $defs:
           - implies_modifier
           - custom
           - memory_consistency
+          - memory_vector
 
       operands:
         type: array
@@ -1042,6 +1043,15 @@ $defs:
 
       state_space_modifier:
         $ref: "#/$defs/schema_identifier"
+
+      type_modifier:
+        $ref: "#/$defs/schema_identifier"
+
+      vector_operand:
+        $ref: "#/$defs/schema_identifier"
+
+      availability:
+        $ref: "#/$defs/availability"
 
   example:
     description: "Positive or negative PTX example for an instruction or variant."

--- a/next_step.md
+++ b/next_step.md
@@ -264,8 +264,8 @@ auto result = ptx_frontend::resolved_ir::resolveModule(module);
 - Python schema/model/normalizer/generator 与 C++ resolver/checker 回归覆盖 static plain/
   availability entry、非法输入、descriptor、generic allow/reject/availability、runtime
   explicit field/location、store source type、方括号要求及损坏 descriptor field；
-- legacy `.v2/.v4` vector memory form 已在后续切片完成；memory consistency、modern vector
-  form 与 `.b128` 仍待后续。explicit `ld.const` 本身属于 PTX 1.0 basic explicit baseline。
+- legacy `.v2/.v4` vector memory form 已在后续切片完成；memory consistency 与 modern vector
+  form 已由后续切片完成，scalar `.b128` 仍待后续。explicit `ld.const` 本身属于 PTX 1.0 basic explicit baseline。
 
 ## 已完成：ld/st explicit `.param` direction 与 function availability
 
@@ -365,13 +365,25 @@ auto result = ptx_frontend::resolved_ir::resolveModule(module);
   descriptor、resolver 与 checker；descriptor 保存 `vector_arity_modifier_field_id`，实际
   braced operand arity 会与 runtime field 对齐检查；
 - vector type policy 改为数据驱动：`mov` 使用 aggregate policy，memory vector 使用 element
-  policy；memory vector element 复用 `EqualOrWider` register-width policy，不允许 `_` sink；
+  policy；memory vector element 复用 `EqualOrWider` register-width policy；
 - generic/explicit baseline、14-type family、cache operator、address allowlist、`.param`
   direction/function availability、explicit `.f64` SM13 与 generic PTX2/SM20 规则继续复用
   既有 scalar 数据；
-- 本切片只覆盖 legacy braced operands，memory vector payload 最多 128 bit（`.v2` 到
-  64-bit type、`.v4` 到 32-bit type）；`.v4` 64-bit 与 `.v8`、modern sink、`.b128`、
-  vector-variable shorthand、consistency qualifier 或 alignment 规则均仍未实现。
+- legacy braced operands 保持最多 128 bit（`.v2` 到 64-bit type、`.v4` 到 32-bit
+  type）与无 sink；其余现代 form 由下一项覆盖。
+
+## 已完成：ld/st PTX 8.8 256-bit modern vector
+
+- 仍复用四个 `GenericVector`/`ExplicitVector` variants；runtime `.v8` 贯通 schema、
+  normalizer、resolved model、value domain、resolver、checker descriptor 与生成 wrapper；
+- 生成的 typed `memory_vector` cross constraint 以 arity > 4、payload > 128 或 sink
+  为现代候选，要求精确 256 bit、PTX 8.8/SM 100，以及地址已知时为 global；对 explicit form
+  则在现代候选上要求 runtime state-space 为 `.global`，generic 的 register/immediate/standalone
+  unknown address 继续允许；
+- 只接受 `.v8` × `b32/u32/s32/f32` 与 `.v4` × `b64/u64/s64/f64` 的 256-bit payload；
+  load destination 与 store source 可部分使用 `_`，但 all-sink 仍拒绝，legacy sink 仍拒绝；
+- 未加入 scalar `.b128`、alignment、cache-hint/eviction/prefetch/unified、param/shared
+  subqualifier 或 call-context；alignment 继续延期。
 
 ## 已完成：小模块的 source-bearing interface library
 
@@ -416,8 +428,8 @@ auto result = ptx_frontend::resolved_ir::resolveModule(module);
 1. 为 `ld/st` 增加 modern vector form、alignment 与其余跨 modifier 规则；已完成
    PTX ≤9.2 的 omission/`.weak`/`.volatile`/scoped
    `.relaxed/.acquire/.release` 及 PTX 8.2 scalar `.mmio.relaxed.sys` consistency
-   qualifier。legacy `.v2/.v4` 明确不接受 mmio；static address-alignment checking 与
-   modern vector extension 仍保留为后续工作；
+   qualifier。legacy `.v2/.v4` 明确不接受 mmio；PTX 8.8 256-bit modern vector 已完成，
+   static address-alignment checking 仍保留为后续工作；
    function-local call-argument `.param` 及相关 call-context 规则留到 `call` 阶段；
 2. 为 `call` group/variadic operand 增加非 `Flat` descriptor layout algorithm，再将 `call`
    接入统一 dispatch/checker；

--- a/python/code_gen/gen_resolved_checker_descriptor.py
+++ b/python/code_gen/gen_resolved_checker_descriptor.py
@@ -123,6 +123,27 @@ def _emit_variant_descriptor(variant: ResolvedVariant) -> str:
                   .address_field_id = "{consistency.address_field_id}",
                   .state_space_field_id = "{consistency.state_space_field_id or ""}",
               }},'''
+    vector = variant.memory_vector
+    memory_vector = ""
+    if vector is not None:
+        vector_availability = dict(vector.availability)
+        vector_minimum_ptx = _parse_ptx_version(
+            vector_availability.get("ptx", "0.0")
+        )
+        vector_minimum_sm = int(vector_availability.get("sm", 0))
+        vector_family = str(vector_availability.get("family", ""))
+        memory_vector = f'''
+              .memory_vector = {{
+                  .type_field_id = "{vector.type_field_id}",
+                  .vector_field_id = "{vector.vector_field_id}",
+                  .address_field_id = "{vector.address_field_id}",
+                  .state_space_field_id = "{vector.state_space_field_id or ""}",
+                  .availability = {{
+                      .minimum_ptx_version = {{{vector_minimum_ptx[0]}, {vector_minimum_ptx[1]}}},
+                      .minimum_sm_version = {vector_minimum_sm},
+                      .required_family = "{vector_family}",
+                  }},
+              }},'''
     return f"""          checker::VariantDescriptor{{
               .variant_name = "{variant.cpp_name}",
               .availability = {{
@@ -137,6 +158,7 @@ def _emit_variant_descriptor(variant: ResolvedVariant) -> str:
                   {variant.cpp_name}_operand_type_compatibilities,
               .rule_id = "{rule_id}",
 {memory_consistency}
+{memory_vector}
           }}"""
 
 

--- a/python/code_gen/gen_resolved_ir.py
+++ b/python/code_gen/gen_resolved_ir.py
@@ -474,6 +474,15 @@ def _emit_check_operand_dispatch(
                                  consistency_check.error().end());
             }}
 """
+    memory_vector_check = ""
+    if variant.memory_vector is not None:
+        memory_vector_check = f"""            const auto memory_vector_check = check_memory_vector(
+                {checker_variant_expr}.memory_vector, fields, operands, context);
+            if (!memory_vector_check) {{
+              diagnostics.insert(diagnostics.end(), memory_vector_check.error().begin(),
+                                 memory_vector_check.error().end());
+            }}
+"""
     if len(variant.operand_layouts) == 1:
         operand_views = ",\n".join(
             _emit_check_operand_view(field, "selected")
@@ -503,7 +512,7 @@ def _emit_check_operand_dispatch(
               diagnostics.insert(diagnostics.end(), operand_check.error().begin(),
                                  operand_check.error().end());
             }}
-{consistency_check}          }}"""
+{consistency_check}{memory_vector_check}          }}"""
 
     layout_lambdas = "\n\n".join(
         _emit_check_multi_layout_lambda(
@@ -560,7 +569,7 @@ def _emit_check_multi_layout_lambda(
                 {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
                     .operand_type_compatibilities,
                 context);"""
-    if variant.memory_consistency is not None:
+    if variant.memory_consistency is not None or variant.memory_vector is not None:
         consistency_return = f"""
             const auto operand_check = check_operands(
                 {instruction.cpp_name}::get_resolved_descriptor().variants[{variant_index}]
@@ -570,12 +579,16 @@ def _emit_check_multi_layout_lambda(
                 {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
                     .operand_type_compatibilities,
                 context);
-            if (!operand_check)
-              return operand_check;
-            return check_memory_consistency(
-                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
-                    .memory_consistency,
-                fields, operands, context);"""
+            CheckDiagnostics diagnostics;
+            if (!operand_check) {{
+              diagnostics.insert(diagnostics.end(), operand_check.error().begin(),
+                                 operand_check.error().end());
+            }}
+{_emit_multi_layout_memory_vector_check(
+    instruction, variant, variant_index
+)}            if (diagnostics.empty())
+              return CheckResult{{}};
+            return std::unexpected(std::move(diagnostics));"""
     return f"""          const auto {lambda_name} =
               [&](const {instruction.cpp_name}::{variant.cpp_name}::{layout.cpp_name}Operands& payload)
                   -> CheckResult {{
@@ -593,6 +606,37 @@ def _emit_check_multi_layout_lambda(
           static_assert(detail::VariantCheckFunction<
               decltype({lambda_name}),
               {instruction.cpp_name}::{variant.cpp_name}::{layout.cpp_name}Operands>);"""
+
+
+def _emit_multi_layout_memory_vector_check(
+    instruction: ResolvedInstruction,
+    variant: ResolvedVariant,
+    variant_index: int,
+) -> str:
+    """Emit the cross-rule calls shared by every payload-layout lambda."""
+
+    checks = ""
+    if variant.memory_consistency is not None:
+        checks += f"""            const auto consistency_check = check_memory_consistency(
+                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                    .memory_consistency,
+                fields, operands, context);
+            if (!consistency_check) {{
+              diagnostics.insert(diagnostics.end(), consistency_check.error().begin(),
+                                 consistency_check.error().end());
+            }}
+"""
+    if variant.memory_vector is not None:
+        checks += f"""            const auto memory_vector_check = check_memory_vector(
+                {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                    .memory_vector,
+                fields, operands, context);
+            if (!memory_vector_check) {{
+              diagnostics.insert(diagnostics.end(), memory_vector_check.error().begin(),
+                                 memory_vector_check.error().end());
+            }}
+"""
+    return checks
 
 
 def _check_layout_lambda_name(

--- a/python/code_gen/model.py
+++ b/python/code_gen/model.py
@@ -70,6 +70,17 @@ class MemoryConsistencyConstraint:
     state_space_modifier: str | None = None
 
 
+@dataclass(frozen=True)
+class MemoryVectorConstraint:
+    """Typed PTX 8.8 256-bit ld/st vector cross-rule."""
+
+    type_modifier: str
+    vector_operand: str
+    address_operand: str
+    availability: dict[str, Any] = field(default_factory=dict)
+    state_space_modifier: str | None = None
+
+
 class RuntimeLookupKind(str, Enum):
     """Runtime C++ lookup forms emitted for backend value domains."""
 
@@ -180,6 +191,7 @@ class VariantSpec:
     rule: str | None = None
     operand_type_compatibilities: tuple[OperandTypeCompatibilitySpec, ...] = ()
     memory_consistency: MemoryConsistencyConstraint | None = None
+    memory_vector: MemoryVectorConstraint | None = None
 
 
 @dataclass(frozen=True)

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -9,6 +9,7 @@ from code_gen.load_yaml import expand_value_refs
 from code_gen.model import (
     InstructionSpec,
     MemoryConsistencyConstraint,
+    MemoryVectorConstraint,
     ModifierSpec,
     ModifierValueSpec,
     OperandLayoutSpec,
@@ -69,8 +70,8 @@ def normalize_operand(raw: dict[str, Any]) -> OperandSpec:
             vector_arities = tuple(raw_arities)
         else:
             raise TypeError("vector.arity must be an integer, list, or expression")
-        if vector_arities and any(arity > 4 for arity in vector_arities):
-            raise ValueError("resolved vector operands support at most four elements")
+        if vector_arities and any(arity > 8 for arity in vector_arities):
+            raise ValueError("resolved vector operands support at most eight elements")
         try:
             vector_type_policy = OperandVectorTypePolicy(
                 vector.get("type_policy", "aggregate")
@@ -718,6 +719,85 @@ def _normalize_memory_consistency_constraint(
     )
 
 
+def _normalize_memory_vector_constraint(
+    raw_variant: dict[str, Any], modifiers: tuple[ModifierSpec, ...],
+    layouts: tuple[OperandLayoutSpec, ...]
+) -> MemoryVectorConstraint | None:
+    """Lower the typed PTX 8.8 256-bit ld/st vector rule, if present."""
+
+    matches = [
+        item for item in raw_variant.get("constraints", ())
+        if item.get("kind") == "memory_vector"
+    ]
+    if not matches:
+        return None
+    if len(matches) != 1:
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: at most one memory_vector "
+            "constraint is supported"
+        )
+    raw = matches[0]
+    required = {"type_modifier", "vector_operand", "address_operand", "availability"}
+    missing = required - raw.keys()
+    if missing:
+        raise ValueError(
+            f"variant {raw_variant['name']!r}: memory_vector constraint "
+            f"is missing {sorted(missing)}"
+        )
+    modifiers_by_name = {modifier.name: modifier for modifier in modifiers}
+    for key, expected_kind in (("type_modifier", "type"),):
+        value = raw[key]
+        if value not in modifiers_by_name:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector {key} "
+                f"references inactive modifier {value!r}"
+            )
+        if modifiers_by_name[value].kind != expected_kind:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector {key} "
+                f"must name a {expected_kind!r} modifier"
+            )
+    operand_by_name = {
+        operand.name: operand for layout in layouts for operand in layout.operands
+    }
+    for key, expected_kind in (("vector_operand", "reg_vector"), ("address_operand", "addr")):
+        value = raw[key]
+        operand = operand_by_name.get(value)
+        if operand is None:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector {key} "
+                f"references unknown operand {value!r}"
+            )
+        if operand.kind != expected_kind:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector {key} "
+                f"must name a {expected_kind!r} operand"
+            )
+    state_space_modifier = raw.get("state_space_modifier")
+    if state_space_modifier is not None:
+        modifier = modifiers_by_name.get(state_space_modifier)
+        if modifier is None:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector state_space_modifier "
+                f"references inactive modifier {state_space_modifier!r}"
+            )
+        if modifier.kind != "state_space":
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: memory_vector state_space_modifier "
+                "must name a 'state_space' modifier"
+            )
+    availability = raw["availability"]
+    if not isinstance(availability, dict):
+        raise TypeError("memory_vector availability must be an object")
+    return MemoryVectorConstraint(
+        type_modifier=raw["type_modifier"],
+        vector_operand=raw["vector_operand"],
+        address_operand=raw["address_operand"],
+        availability=dict(availability),
+        state_space_modifier=state_space_modifier,
+    )
+
+
 def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, ...]:
     """Normalize all instruction definitions in one PTX ISA YAML file."""
 
@@ -769,6 +849,9 @@ def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, .
                         )
                     ),
                     memory_consistency=_normalize_memory_consistency_constraint(
+                        raw_variant, modifiers, operand_layouts
+                    ),
+                    memory_vector=_normalize_memory_vector_constraint(
                         raw_variant, modifiers, operand_layouts
                     ),
                 )

--- a/python/ir/resolved_ir.py
+++ b/python/ir/resolved_ir.py
@@ -21,6 +21,7 @@ from code_gen.cpp_backend import (
 from code_gen.model import (
     InstructionSpec,
     MemoryConsistencyConstraint,
+    MemoryVectorConstraint,
     ModifierSpec,
     ModifierValueSpec,
     OperandParameterConstraint,
@@ -168,6 +169,17 @@ class ResolvedMemoryConsistencyConstraint:
 
 
 @dataclass(frozen=True)
+class ResolvedMemoryVectorConstraint:
+    """Generated field identities for the PTX 8.8 vector cross-rule."""
+
+    type_field_id: str
+    vector_field_id: str
+    address_field_id: str
+    availability: tuple[tuple[str, Any], ...]
+    state_space_field_id: str | None = None
+
+
+@dataclass(frozen=True)
 class ResolvedField:
     """One provenance-carrying field in a resolved variant struct."""
 
@@ -250,6 +262,7 @@ class ResolvedVariant:
     modifier_value_availabilities: tuple["ResolvedModifierValueAvailability", ...]
     operand_type_compatibilities: tuple["ResolvedOperandTypeCompatibility", ...]
     memory_consistency: ResolvedMemoryConsistencyConstraint | None
+    memory_vector: ResolvedMemoryVectorConstraint | None
     availability: tuple[tuple[str, Any], ...]
     rule: str | None
 
@@ -449,6 +462,10 @@ def _build_variant(opcode: str, variant: VariantSpec) -> ResolvedVariant:
             variant.memory_consistency,
             {field.source_name: field.name for field in modifier_fields},
         ),
+        memory_vector=_build_memory_vector_constraint(
+            variant.memory_vector,
+            {field.source_name: field.name for field in modifier_fields},
+        ),
         availability=tuple(variant.availability.items()),
         rule=variant.rule,
     )
@@ -470,6 +487,24 @@ def _build_memory_consistency_constraint(
         ),
         cache_field_id=modifier_field_ids[constraint.cache_modifier],
         address_field_id=constraint.address_operand,
+        state_space_field_id=(
+            modifier_field_ids[constraint.state_space_modifier]
+            if constraint.state_space_modifier is not None else None
+        ),
+    )
+
+
+def _build_memory_vector_constraint(
+    constraint: MemoryVectorConstraint | None,
+    modifier_field_ids: dict[str, str],
+) -> ResolvedMemoryVectorConstraint | None:
+    if constraint is None:
+        return None
+    return ResolvedMemoryVectorConstraint(
+        type_field_id=modifier_field_ids[constraint.type_modifier],
+        vector_field_id=constraint.vector_operand,
+        address_field_id=constraint.address_operand,
+        availability=tuple(constraint.availability.items()),
         state_space_field_id=(
             modifier_field_ids[constraint.state_space_modifier]
             if constraint.state_space_modifier is not None else None

--- a/python/tests/code_gen/test_backend_model.py
+++ b/python/tests/code_gen/test_backend_model.py
@@ -119,6 +119,10 @@ class BackendModelTests(unittest.TestCase):
             "MemoryScope::None",
         )
         self.assertEqual(
+            unit.domains[CppDomain.VECTOR_ARITIES.value].values["v8"],
+            "VectorArity::V8",
+        )
+        self.assertEqual(
             unit.domains[CppDomain.RESOLVED_VALUE_CPP_TYPES.value].values[
                 "MemoryConsistency"
             ],

--- a/python/tests/code_gen/test_resolved_value_domains.py
+++ b/python/tests/code_gen/test_resolved_value_domains.py
@@ -40,6 +40,7 @@ class ResolvedValueDomainGenerationTests(unittest.TestCase):
         self.assertIn("std::array<PtxSuffixEntry<RoundingMode>, 4>", source)
         self.assertIn("kRoundingModes", source)
         self.assertIn('{"rn", RoundingMode::Rn}', source)
+        self.assertIn('{"v8", VectorArity::V8}', source)
         self.assertNotIn("resolved_value_kinds =", source)
 
 

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -69,6 +69,56 @@ class ResolvedIrBuildTest(unittest.TestCase):
         cls.instruction = from_instruction_spec(add)
         cls.sub_instruction = from_instruction_spec(sub)
 
+    def test_normalizes_memory_vector_cross_constraint(self) -> None:
+        variant = {
+            "name": "sample_vector",
+            "availability": {"ptx": "1.0"},
+            "modifiers": [
+                {
+                    "name": "type",
+                    "kind": "type",
+                    "presence": "required",
+                    "domain": "scalar_types",
+                    "values": ["u32"],
+                }
+            ],
+            "operands": [
+                {
+                    "name": "dst",
+                    "kind": "reg_vector",
+                    "role": "dst",
+                    "access": "write",
+                    "type": {"expr": "modifier(type)"},
+                    "vector": {"kind": "vector", "arity": [8]},
+                },
+                {"name": "address", "kind": "addr", "role": "addr", "access": "read"},
+            ],
+            "constraints": [
+                {
+                    "kind": "memory_vector",
+                    "type_modifier": "type",
+                    "vector_operand": "dst",
+                    "address_operand": "address",
+                    "availability": {"ptx": "8.8", "sm": 100},
+                }
+            ],
+        }
+        spec = {
+            "category": "test",
+            "codegen_category": "test",
+            "instructions": [{"opcode": "sample", "variants": [variant]}],
+        }
+        normalized = normalize_instruction_spec(spec)[0].variants[0]
+        assert normalized.memory_vector is not None
+        self.assertEqual(normalized.memory_vector.vector_operand, "dst")
+        self.assertEqual(normalized.memory_vector.availability["sm"], 100)
+
+        invalid = dict(variant)
+        invalid["constraints"] = [dict(variant["constraints"][0], availability="8.8")]
+        spec["instructions"][0]["variants"] = [invalid]
+        with self.assertRaisesRegex(TypeError, "availability must be an object"):
+            normalize_instruction_spec(spec)
+
     def test_add_variant_names(self) -> None:
         self.assertEqual(self.instruction.opcode, "add")
         self.assertEqual(self.instruction.cpp_name, "Add")
@@ -824,7 +874,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(vector_variant.memory_consistency.mmio_field_id, "")
         self.assertEqual(
             [value.value for value in next(modifier for modifier in ld.variants[2].modifiers if modifier.name == "vector").values],
-            ["v2", "v4"],
+            ["v2", "v4", "v8"],
         )
         vector_binding = vector_variant.operand_layouts[0].bindings[0]
         self.assertEqual(vector_binding.allowed_vector_arities, ())
@@ -833,7 +883,13 @@ class ResolvedIrBuildTest(unittest.TestCase):
             vector_binding.vector_type_policy,
             ResolvedVectorTypePolicy.ELEMENT,
         )
-        self.assertFalse(vector_binding.allow_vector_sink)
+        self.assertTrue(vector_binding.allow_vector_sink)
+        self.assertEqual(vector_variant.memory_vector.type_field_id, "type")
+        self.assertEqual(vector_variant.memory_vector.vector_field_id, "dst")
+        self.assertEqual(
+            dict(vector_variant.memory_vector.availability),
+            {"ptx": "8.8", "sm": 100},
+        )
         self.assertEqual(
             explicit_vector_variant.operand_layouts[0]
             .bindings[0]
@@ -964,7 +1020,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(store_vector.memory_consistency.mmio_field_id, "")
         self.assertEqual(
             [value.value for value in next(modifier for modifier in st.variants[2].modifiers if modifier.name == "vector").values],
-            ["v2", "v4"],
+            ["v2", "v4", "v8"],
         )
         store_vector_binding = store_vector.operand_layouts[0].bindings[1]
         self.assertEqual(store_vector_binding.allowed_vector_arities, ())
@@ -976,6 +1032,8 @@ class ResolvedIrBuildTest(unittest.TestCase):
             store_vector_binding.vector_type_policy,
             ResolvedVectorTypePolicy.ELEMENT,
         )
+        self.assertTrue(store_vector_binding.allow_vector_sink)
+        self.assertEqual(store_vector.memory_vector.vector_field_id, "src")
         store_vector_parameter = (
             store.variants[3].operand_layouts[0].bindings[0].parameter_constraint
         )
@@ -1207,6 +1265,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn(".parameter_direction = parameter_direction", source)
         self.assertIn("CheckResult check<Ld>(", source)
         self.assertIn("check_memory_consistency(", source)
+        self.assertIn("check_memory_vector(", source)
 
     def test_generate_category_resolved_ir_source(self) -> None:
         database = load_codegen_database(
@@ -1352,6 +1411,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("checker::OperandLayoutDescriptor", source)
         self.assertIn("checker::OperandTypeCompatibilityDescriptor", source)
         self.assertIn(".memory_consistency = {", source)
+        self.assertIn(".memory_vector = {", source)
+        self.assertIn('.vector_field_id = "dst",', source)
+        self.assertIn('.vector_field_id = "src",', source)
         self.assertIn(".semantics_field_id = \"semantics\",", source)
         self.assertIn(
             ".special_register_kind = base::SpecialRegisterKind::Tid,",

--- a/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
@@ -36,6 +36,7 @@ enum class VectorArity : uint8_t {
   Invalid,
   V2,
   V4,
+  V8,
 };
 
 constexpr uint8_t vector_arity_count(VectorArity arity) noexcept {
@@ -44,6 +45,8 @@ constexpr uint8_t vector_arity_count(VectorArity arity) noexcept {
       return 2;
     case VectorArity::V4:
       return 4;
+    case VectorArity::V8:
+      return 8;
     case VectorArity::Invalid:
       return 0;
   }
@@ -174,9 +177,8 @@ enum class VectorTypePolicy : uint8_t {
   Element,
 };
 
-/** Current ResolvedRegisterVector/checker payload ceiling; modern memory-vector
- * support must raise or model it. */
-inline constexpr size_t kMaxRegisterVectorPayloadBits = 128;
+/** Maximum resolved register-vector payload width supported by this frontend. */
+inline constexpr size_t kMaxRegisterVectorPayloadBits = 256;
 
 /** Semantic constraints for one operand position in a resolved layout. */
 struct OperandDescriptor {
@@ -236,7 +238,7 @@ struct OperandView {
   EnclosingFunctionKind enclosing_function_kind = EnclosingFunctionKind::Unknown;
   /** None unless the base binds an input or return parameter declaration. */
   ParameterDirection parameter_direction = ParameterDirection::None;
-  std::array<ScalarType, 4> vector_element_types{};
+  std::array<ScalarType, 8> vector_element_types{};
   uint8_t vector_arity = 0;
   uint8_t vector_sink_count = 0;
   std::optional<AvailabilityDescriptor> value_availability;
@@ -332,6 +334,14 @@ struct VariantDescriptor {
     std::string_view address_field_id;
     std::string_view state_space_field_id;
   } memory_consistency;
+  /** Empty field IDs mean this variant has no modern memory-vector rule. */
+  struct MemoryVectorDescriptor {
+    std::string_view type_field_id;
+    std::string_view vector_field_id;
+    std::string_view address_field_id;
+    std::string_view state_space_field_id;
+    AvailabilityDescriptor availability;
+  } memory_vector;
 };
 
 /** Checker metadata for all variants of one resolved instruction. */
@@ -453,6 +463,12 @@ CheckResult check_modifier_value_availability(
 /** Check generated ld/st memory-order and address-space cross constraints. */
 CheckResult check_memory_consistency(
     const VariantDescriptor::MemoryConsistencyDescriptor& descriptor,
+    std::span<const FieldView> fields, std::span<const OperandView> operands,
+    const Context& context);
+
+/** Check generated PTX 8.8 256-bit ld/st vector cross constraints. */
+CheckResult check_memory_vector(
+    const VariantDescriptor::MemoryVectorDescriptor& descriptor,
     std::span<const FieldView> fields, std::span<const OperandView> operands,
     const Context& context);
 

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -1053,7 +1053,7 @@ std::expected<WithLocs<RegOrImm>, ResolveDiagnostic> resolve_reg_or_imm(
 
 std::expected<WithLocs<ResolvedRegisterVector>, ResolveDiagnostic>
 resolve_reg_vector(const syntax_ast::AstOperand& operand,
-                   ScalarType instruction_type, checker::OperandAccess access,
+                   ScalarType instruction_type,
                    std::span<const uint8_t> allowed_arities,
                    std::optional<uint8_t> required_arity,
                    checker::VectorTypePolicy vector_type_policy,
@@ -1103,7 +1103,9 @@ resolve_reg_vector(const syntax_ast::AstOperand& operand,
       std::ranges::find(allowed_arities, arity) == allowed_arities.end()) {
     return std::unexpected(ResolveDiagnostic{
         .range = vector->range,
-        .message = "A vector mov requires two or four elements.",
+        .message = vector_type_policy == checker::VectorTypePolicy::Aggregate
+                       ? "A vector mov requires two or four elements."
+                       : "A vector operand requires two, four, or eight elements.",
     });
   }
   size_t element_bytes = scalar_size_of(instruction_type);
@@ -1134,10 +1136,17 @@ resolve_reg_vector(const syntax_ast::AstOperand& operand,
     }
     locations.push_back(identifier->syntax.range);
     if (identifier->syntax.text == "_") {
-      if (access != checker::OperandAccess::Write || !allow_sink) {
+      if (!allow_sink) {
         return std::unexpected(ResolveDiagnostic{
             .range = identifier->syntax.range,
             .message = "The '_' sink is allowed only in a destination vector.",
+        });
+      }
+      if (vector_type_policy == checker::VectorTypePolicy::Element &&
+          vector_payload_bits != 256) {
+        return std::unexpected(ResolveDiagnostic{
+            .range = identifier->syntax.range,
+            .message = "The '_' sink is allowed only in a 256-bit memory vector.",
         });
       }
       ++sink_count;
@@ -1171,7 +1180,7 @@ resolve_reg_vector(const syntax_ast::AstOperand& operand,
   if (sink_count == arity) {
     return std::unexpected(ResolveDiagnostic{
         .range = vector->range,
-        .message = "A destination vector must contain at least one register.",
+        .message = "A vector must contain at least one register.",
     });
   }
   WithLocs<ResolvedRegisterVector> resolved{std::move(result)};
@@ -1654,7 +1663,7 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
       if (!arity)
         return std::unexpected(arity.error());
       auto value =
-          resolve_reg_vector(operand, *type, binding.access,
+          resolve_reg_vector(operand, *type,
                              binding.allowed_vector_arities,
                              *arity,
                              binding.vector_type_policy,

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -492,7 +492,7 @@ CheckResult check_operands(
         });
         continue;
       }
-      if (operand->vector_arity == 0 || operand->vector_arity > 4 ||
+      if (operand->vector_arity == 0 || operand->vector_arity > 8 ||
           (required_vector_arity &&
            operand->vector_arity != *required_vector_arity) ||
           (!required_vector_arity &&
@@ -528,8 +528,6 @@ CheckResult check_operands(
         continue;
       }
       if ((!descriptor.allow_vector_sink && operand->vector_sink_count != 0) ||
-          (descriptor.access != OperandAccess::Write &&
-           operand->vector_sink_count != 0) ||
           operand->vector_sink_count >= operand->vector_arity) {
         diagnostics.push_back(CheckDiagnostic{
             .kind = CheckDiagnosticKind::InvalidVectorOperand,
@@ -873,6 +871,102 @@ CheckResult check_memory_consistency(
       violation(*mmio_field,
                 "mmio requires a global address space when the address space is known.");
     }
+  }
+
+  if (diagnostics.empty())
+    return {};
+  return std::unexpected(std::move(diagnostics));
+}
+
+CheckResult check_memory_vector(
+    const VariantDescriptor::MemoryVectorDescriptor& descriptor,
+    std::span<const FieldView> fields, std::span<const OperandView> operands,
+    const Context& context) {
+  if (descriptor.vector_field_id.empty())
+    return {};
+
+  const FieldView* type = find_field(fields, descriptor.type_field_id);
+  const OperandView* vector = find_operand(operands, descriptor.vector_field_id);
+  const OperandView* address = find_operand(operands, descriptor.address_field_id);
+  if (type == nullptr || vector == nullptr || address == nullptr ||
+      !type->scalar_type || vector->actual_shape != OperandShape::Vector) {
+    return std::unexpected(CheckDiagnostics{CheckDiagnostic{
+        .kind = CheckDiagnosticKind::RuleViolation,
+        .range = context.instruction_range,
+        .message = "Generated memory-vector descriptor has missing fields.",
+    }});
+  }
+
+  const size_t payload_bits =
+      static_cast<size_t>(vector->vector_arity) * scalar_size_of(*type->scalar_type) * 8u;
+  const bool modern_candidate = vector->vector_arity > 4 ||
+                                payload_bits > 128 ||
+                                vector->vector_sink_count != 0;
+  if (!modern_candidate)
+    return {};
+
+  CheckDiagnostics diagnostics;
+  const SourceRange& vector_range = diagnostic_range(vector->locations, context);
+  if (payload_bits != 256) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::RuleViolation,
+        .range = vector_range,
+        .message = "Modern memory vectors require an exact 256-bit payload.",
+    });
+  }
+
+  std::optional<MemoryStateSpace> state_space = address->address_state_space;
+  const FieldView* state_space_field = nullptr;
+  if (!descriptor.state_space_field_id.empty()) {
+    state_space_field = find_field(fields, descriptor.state_space_field_id);
+    if (state_space_field == nullptr || !state_space_field->memory_state_space) {
+      diagnostics.push_back(CheckDiagnostic{
+          .kind = CheckDiagnosticKind::RuleViolation,
+          .range = context.instruction_range,
+          .message = "Generated memory-vector descriptor has an invalid state-space field.",
+      });
+    } else {
+      state_space = *state_space_field->memory_state_space;
+    }
+  }
+  if (state_space && *state_space != MemoryStateSpace::Global) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::RuleViolation,
+        .range = state_space_field != nullptr
+                     ? diagnostic_range(state_space_field->locations, context)
+                     : diagnostic_range(address->locations, context),
+        .message = "Modern memory vectors require a global address space when known.",
+    });
+  }
+
+  const auto& availability = descriptor.availability;
+  if (context.target.ptx_version < availability.minimum_ptx_version) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::UnsupportedPtxVersion,
+        .range = vector_range,
+        .message = fmt::format(
+            "Modern memory vectors require PTX ISA >= {}, but target PTX ISA is {}.",
+            format_version(availability.minimum_ptx_version),
+            format_version(context.target.ptx_version)),
+    });
+  }
+  if (context.target.sm_version < availability.minimum_sm_version) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::UnsupportedSmVersion,
+        .range = vector_range,
+        .message = fmt::format(
+            "Modern memory vectors require SM >= {}, but target SM is {}.",
+            availability.minimum_sm_version, context.target.sm_version),
+    });
+  }
+  if (!availability.required_family.empty() &&
+      !has_family(context.target.families, availability.required_family)) {
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::UnsupportedTargetFamily,
+        .range = vector_range,
+        .message = fmt::format("Modern memory vectors require target family '{}'.",
+                               availability.required_family),
+    });
   }
 
   if (diagnostics.empty())

--- a/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
@@ -316,7 +316,7 @@ TEST(ResolvedIrChecker, ChecksDynamicVectorArityAndElementPolicy) {
 }
 
 TEST(ResolvedIrChecker, RejectsOverwideVectorOperandPayload) {
-  const std::array<uint8_t, 2> allowed_vector_arities = {2, 4};
+  const std::array<uint8_t, 3> allowed_vector_arities = {2, 4, 8};
   const OperandDescriptor descriptors[] = {{
       .target_field_id = "dst",
       .type_expression =
@@ -335,8 +335,9 @@ TEST(ResolvedIrChecker, RejectsOverwideVectorOperandPayload) {
       .field_id = "dst",
       .actual_shape = OperandShape::Vector,
       .vector_element_types = {ScalarType::U64, ScalarType::U64, ScalarType::U64,
-                              ScalarType::U64},
-      .vector_arity = 4,
+                               ScalarType::U64, ScalarType::U64, ScalarType::U64,
+                               ScalarType::U64, ScalarType::U64},
+      .vector_arity = 8,
       .locations = std::span<const SourceRange>{&kInstructionRange, 1},
   };
   const Context context{.target = {}, .instruction_range = kInstructionRange};
@@ -350,8 +351,8 @@ TEST(ResolvedIrChecker, RejectsOverwideVectorOperandPayload) {
   EXPECT_EQ(rejected.error().front().kind,
             CheckDiagnosticKind::OperandTypeMismatch);
   EXPECT_EQ(rejected.error().front().message,
-            "Vector operand 'dst' payload width (256 bits) exceeds the "
-            "supported 128 bit limit.");
+            "Vector operand 'dst' payload width (512 bits) exceeds the "
+            "supported 256 bit limit.");
   EXPECT_EQ(rejected.error().front().range, kInstructionRange);
 }
 
@@ -966,6 +967,47 @@ TEST(ResolvedIrChecker, ChecksGeneratedMemoryConsistencyCrossRules) {
   EXPECT_TRUE(check_memory_consistency(vector_descriptor, vector_fields,
                                        global_address, context)
                   .has_value());
+}
+
+TEST(ResolvedIrChecker, ChecksGeneratedModernMemoryVectorCrossRules) {
+  constexpr VariantDescriptor::MemoryVectorDescriptor descriptor{
+      .type_field_id = "type",
+      .vector_field_id = "vector",
+      .address_field_id = "address",
+      .availability = {.minimum_ptx_version = {8, 8}, .minimum_sm_version = 100},
+  };
+  const FieldView fields[] = {{.field_id = "type", .scalar_type = ScalarType::U32}};
+  OperandView operands[] = {
+      {.field_id = "vector",
+       .actual_shape = OperandShape::Vector,
+       .vector_arity = 8,
+       .vector_sink_count = 1},
+      {.field_id = "address", .actual_shape = OperandShape::Address},
+  };
+  const Context supported{
+      .target = {.ptx_version = {8, 8}, .sm_version = 100},
+      .instruction_range = kInstructionRange,
+  };
+  EXPECT_TRUE(check_memory_vector(descriptor, fields, operands, supported)
+                  .has_value());
+
+  auto old_ptx = supported;
+  old_ptx.target.ptx_version = {8, 7};
+  const auto ptx_rejected = check_memory_vector(descriptor, fields, operands, old_ptx);
+  ASSERT_FALSE(ptx_rejected.has_value());
+  EXPECT_EQ(ptx_rejected.error().front().kind,
+            CheckDiagnosticKind::UnsupportedPtxVersion);
+  auto old_sm = supported;
+  old_sm.target.sm_version = 90;
+  const auto sm_rejected = check_memory_vector(descriptor, fields, operands, old_sm);
+  ASSERT_FALSE(sm_rejected.has_value());
+  EXPECT_EQ(sm_rejected.error().front().kind,
+            CheckDiagnosticKind::UnsupportedSmVersion);
+
+  operands[1].address_state_space = MemoryStateSpace::Shared;
+  const auto non_global = check_memory_vector(descriptor, fields, operands, supported);
+  ASSERT_FALSE(non_global.has_value());
+  EXPECT_EQ(non_global.error().front().kind, CheckDiagnosticKind::RuleViolation);
 }
 
 }  // namespace

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -869,9 +869,11 @@ TEST(ResolvedModule, RejectsInvalidLegacyLoadStoreRegisterVectors) {
     return resolveModule(parseModule(source));
   };
 
-  const auto v8 = resolve_source("ld.v8.u32 {%r0, %r1}, [%rd0];");
-  ASSERT_FALSE(v8.has_value());
-  EXPECT_EQ(v8.error().front().message, "Unknown modifier '.v8'.");
+  const auto v8_arity_mismatch =
+      resolve_source("ld.v8.u32 {%r0, %r1}, [%rd0];");
+  ASSERT_FALSE(v8_arity_mismatch.has_value());
+  EXPECT_EQ(v8_arity_mismatch.error().front().message,
+            "This vector operand requires 8 elements.");
 
   const auto scalar_load = resolve_source("ld.v2.u32 %r0, [%rd0];");
   ASSERT_FALSE(scalar_load.has_value());
@@ -891,24 +893,10 @@ TEST(ResolvedModule, RejectsInvalidLegacyLoadStoreRegisterVectors) {
   EXPECT_EQ(arity_mismatch.error().front().message,
             "This vector operand requires 4 elements.");
 
-  const auto overwide_load =
-      resolve_source("ld.v4.u64 {%r0, %r1, %r2, %r3}, [%rd0];");
-  ASSERT_FALSE(overwide_load.has_value());
-  EXPECT_EQ(overwide_load.error().front().message,
-            "This vector operand's payload width (256 bits) exceeds the "
-            "supported 128 bit limit.");
-
   const auto sink = resolve_source("st.v2.u32 [%rd0], {%r0, _};");
   ASSERT_FALSE(sink.has_value());
   EXPECT_EQ(sink.error().front().message,
-            "The '_' sink is allowed only in a destination vector.");
-
-  const auto overwide_store =
-      resolve_source("st.v4.u64 [%rd0], {%r0, %r1, %r2, %r3};");
-  ASSERT_FALSE(overwide_store.has_value());
-  EXPECT_EQ(overwide_store.error().front().message,
-            "This vector operand's payload width (256 bits) exceeds the "
-            "supported 128 bit limit.");
+            "The '_' sink is allowed only in a 256-bit memory vector.");
 
   EXPECT_TRUE(resolve_source("ld.v2.u16 {%r0, %r1}, [%rd0];").has_value());
 
@@ -923,6 +911,89 @@ TEST(ResolvedModule, RejectsInvalidLegacyLoadStoreRegisterVectors) {
   EXPECT_EQ(kind_mismatch.error().front().message,
             "Vector element '%f0' has type 'F32' incompatible with this "
             "instruction.");
+}
+
+TEST(ResolvedModule, ChecksModernLoadStoreRegisterVectors) {
+  const auto ast = parseModule(R"ptx(
+.global .u64 global64;
+.shared .u32 shared32;
+.entry kernel() {
+  .reg .u64 %rd0;
+  .reg .u32 %r<8>;
+  .reg .u64 %d<4>;
+  ld.v8.u32 {_, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [%rd0];
+  st.global.v4.u64 [global64], {_, %d1, %d2, %d3};
+  ld.v4.u64 {%d0, %d1, %d2, %d3}, [%rd0];
+  ld.shared.v8.u32 {%r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [shared32];
+  ld.v8.u32 {%r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [shared32];
+  ld.v8.u16 {%r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [%rd0];
+  st.v8.u32 [%rd0], {_, %r1, %r2, %r3, %r4, %r5, %r6, %r7};
+}
+)ptx");
+  const auto resolved = resolveModule(ast);
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& body = resolved->functions.front().body;
+  ASSERT_EQ(body.size(), 7u);
+
+  const checker::Context supported{
+      .target = {.ptx_version = {8, 8}, .sm_version = 100},
+      .instruction_range = ast.range,
+  };
+  EXPECT_TRUE(checker::check(std::get<Ld>(body[0]), supported).has_value());
+  EXPECT_TRUE(checker::check(std::get<St>(body[1]), supported).has_value());
+  EXPECT_TRUE(checker::check(std::get<Ld>(body[2]), supported).has_value());
+  EXPECT_TRUE(checker::check(std::get<St>(body[6]), supported).has_value());
+
+  const auto explicit_non_global = checker::check(std::get<Ld>(body[3]), supported);
+  ASSERT_FALSE(explicit_non_global.has_value());
+  EXPECT_EQ(explicit_non_global.error().front().kind,
+            checker::CheckDiagnosticKind::RuleViolation);
+  const auto generic_bound_non_global =
+      checker::check(std::get<Ld>(body[4]), supported);
+  ASSERT_FALSE(generic_bound_non_global.has_value());
+  EXPECT_EQ(generic_bound_non_global.error().front().kind,
+            checker::CheckDiagnosticKind::RuleViolation);
+  const auto wrong_width = checker::check(std::get<Ld>(body[5]), supported);
+  ASSERT_FALSE(wrong_width.has_value());
+  EXPECT_EQ(wrong_width.error().front().kind,
+            checker::CheckDiagnosticKind::RuleViolation);
+
+  auto old_ptx = supported;
+  old_ptx.target.ptx_version = {8, 7};
+  const auto ptx_rejected = checker::check(std::get<Ld>(body[2]), old_ptx);
+  ASSERT_FALSE(ptx_rejected.has_value());
+  EXPECT_EQ(ptx_rejected.error().front().kind,
+            checker::CheckDiagnosticKind::UnsupportedPtxVersion);
+  auto old_sm = supported;
+  old_sm.target.sm_version = 90;
+  const auto sm_rejected = checker::check(std::get<Ld>(body[2]), old_sm);
+  ASSERT_FALSE(sm_rejected.has_value());
+  EXPECT_EQ(sm_rejected.error().front().kind,
+            checker::CheckDiagnosticKind::UnsupportedSmVersion);
+
+  const auto overwide = parseModule(R"ptx(
+.entry kernel() {
+  .reg .u64 %rd0;
+  .reg .u64 %d<8>;
+  ld.v8.u64 {%d0, %d1, %d2, %d3, %d4, %d5, %d6, %d7}, [%rd0];
+}
+)ptx");
+  const auto overwide_resolved = resolveModule(overwide);
+  ASSERT_FALSE(overwide_resolved.has_value());
+  EXPECT_EQ(overwide_resolved.error().front().message,
+            "This vector operand's payload width (512 bits) exceeds the "
+            "supported 256 bit limit.");
+
+  const auto all_sinks = parseModule(R"ptx(
+.entry kernel() {
+  .reg .u64 %rd0;
+  ld.v8.u32 {_, _, _, _, _, _, _, _}, [%rd0];
+}
+)ptx");
+  const auto all_sinks_resolved = resolveModule(all_sinks);
+  ASSERT_FALSE(all_sinks_resolved.has_value());
+  EXPECT_EQ(all_sinks_resolved.error().front().message,
+            "A vector must contain at least one register.");
 }
 
 TEST(ResolvedModule, KeepsNonMemoryRegisterWidthChecksStrict) {
@@ -1475,7 +1546,7 @@ TEST(ResolvedModule, RejectsInvalidMovRegisterVectorForms) {
   const auto all_sinks = resolve_source("mov.b32 {_, _}, %r0;");
   ASSERT_FALSE(all_sinks.has_value());
   EXPECT_EQ(all_sinks.error().front().message,
-            "A destination vector must contain at least one register.");
+            "A vector must contain at least one register.");
 
   const auto scalar_b128 = resolve_source("mov.b128 %q0, %q0;");
   ASSERT_FALSE(scalar_b128.has_value());

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -200,11 +200,12 @@ TEST(SelectVariantLoadStore, SelectsLegalCacheOperatorsAndRejectsWrongOnes) {
             invalid_store.modifiers.front().syntax.range);
   EXPECT_EQ(invalid_store_selected.error().message, "Unknown modifier '.ca'.");
 
-  const auto invalid_vector = parse_instruction(
+  const auto modern_vector = parse_instruction(
       "ld.v8.u32 {%r0, %r1, %r2, %r3, %r4, %r5, %r6, %r7}, [%rd0];");
-  const auto invalid_vector_selected = selectVariant<Ld>(invalid_vector);
-  ASSERT_FALSE(invalid_vector_selected.has_value());
-  EXPECT_EQ(invalid_vector_selected.error().message, "Unknown modifier '.v8'.");
+  const auto modern_vector_selected = selectVariant<Ld>(modern_vector);
+  ASSERT_TRUE(modern_vector_selected.has_value())
+      << modern_vector_selected.error().message;
+  EXPECT_EQ(*modern_vector_selected, Ld::VariantType::GenericVector);
 
   const auto vector_mmio = parse_instruction(
       "ld.mmio.relaxed.sys.v2.u32 {%r0, %r1}, [%rd0];");


### PR DESCRIPTION
## Summary

- extend the existing `ld/st` vector variants with PTX 8.8 256-bit forms
- accept only `.v8` × 32-bit and `.v4` × 64-bit payloads
- require PTX 8.8 / SM 100 and global space when the address space is known
- support partial `_` sinks for modern load destinations and store sources
- preserve the legacy 128-bit vector and unknown-generic-address behavior
- add a generated, typed `memory_vector` cross constraint instead of duplicating variants
- update coverage/design documentation; static alignment remains the next independent slice

## Validation

- [Linux CI run #9](https://github.com/endingly/ptx_frontend/actions/runs/32876854853): Debug and Release passed the complete CMake workflow
- `git diff --check`
- YAML parse: 8/8
- Python syntax/normalizer smoke checks
- C++23 checker syntax compilation
- focused V8/payload/sink/target/state-space checker smoke tests