### PR TITLE
ci: seed caches from main

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -121,9 +121,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-${{ steps.cache-epoch.outputs.month }}
+          key: ccache-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-${{ steps.cache-epoch.outputs.month }}
           restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-
+            ccache-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-
 
       - name: Run CMake workflow preset
         shell: bash

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -5,6 +5,11 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
+    paths:
+      - .github/workflows/linux-ci.yml
+      - vcpkg.json
+  schedule:
+    - cron: "0 0 1 * *"
 
 permissions:
   contents: read

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -3,6 +3,8 @@ name: Linux CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 permissions:
   contents: read
@@ -21,7 +23,7 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 60
     concurrency:
-      group: linux-ci-${{ github.event.pull_request.number }}-${{ matrix.preset }}
+      group: linux-ci-${{ github.ref }}-${{ matrix.preset }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -114,7 +116,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-${{ steps.cache-epoch.outputs.month }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(GNUInstallDirs)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 option(PTX_USE_CCACHE "Use ccache to speed up compilation" ON)
 option(BUILD_TESTING "enable test program building" OFF)


### PR DESCRIPTION
## Summary

- seed default-branch APT, vcpkg, and ccache entries only when the workflow or vcpkg manifest changes
- refresh the monthly APT/ccache generation once at the start of each month
- keep ordinary source merges from rerunning the full Debug/Release workflow on `main`
- make the concurrency key valid for pull request, push, and scheduled events
- roll ccache keys monthly instead of creating one cache entry per commit SHA

## Root cause

GitHub Actions scopes caches by key, version, and branch/ref. Caches saved by `pull_request` runs live under `refs/pull/<number>/merge`, so later commits in the same PR can restore them but a new PR cannot. Because this workflow never ran on `main`, there was no default-branch cache for a new PR to inherit.

## Trigger behavior

- every PR: Debug/Release validation
- push to `main`: only when `.github/workflows/linux-ci.yml` or `vcpkg.json` changed
- schedule: once per month for the month-based APT/ccache keys

## Validation

[Linux CI #14](https://github.com/endingly/ptx_frontend/actions/runs/32928786347) passed Debug and Release. Both jobs restored APT by prefix and hit the exact vcpkg and monthly ccache keys.

After merge, the workflow-file change triggers one `main` run that seeds default-branch caches. Ordinary source merges will not trigger another run.