### PR TITLE
feat: add canonical function signatures

### DIFF
--- a/.agents/project_roadmap.md
+++ b/.agents/project_roadmap.md
@@ -1290,7 +1290,7 @@ call (return), function, (arguments);
 | M6-I01 | ✅ | 独立 | 建立 call 专用 CST/AST 和 binding shape | return/input group、callee 和 optional target-set syntax 不与 vector 共用 |
 | M6-I02 | ✅ | 独立 | 实现 direct-call Resolved IR | 三个 `Call` layout、direct `.func` target、argument identity/range 和明确 indirect rejection |
 | M6-I03 | ✅ | 独立 | 修正 direct-call 基线文档 | 本轮已同步 README、coverage 和设计文档；priority 只由本文维护 |
-| M6-I04 | ⬜ | 独立 | 建立 canonical `FunctionSignature` | prototype/definition 可转换为统一 return/input parameter contract |
+| M6-I04 | ✅ | 独立 | 建立 canonical `FunctionSignature` | prototype/definition 可转换为统一 return/input parameter contract |
 | M6-I05 | ⬜ | 独立 | 建立 call literal typing helper | immediate 按一个 formal parameter 定型；溢出和 kind mismatch 可诊断 |
 | M6-I06 | ⬜ | 独立 | 建立 call argument compatibility helper | `.reg/.param`、type、alignment、array、pointer 和 state-space 可逐项比较 |
 | M6-I07 | ⬜ | 独立 | 建模 function-local call-argument `.param` | 与 formal parameter 分离，scope、lifetime、direction 和 address rule 明确 |

--- a/submod/semantic/include/ptx_declaration_semantics.hpp
+++ b/submod/semantic/include/ptx_declaration_semantics.hpp
@@ -11,6 +11,35 @@
 
 namespace ptx_frontend::declaration_semantics {
 
+/** ABI-relevant, source-location-independent function parameter data. */
+struct FunctionParameterContract {
+  syntax_ast::AstStateSpace state_space{};
+  std::optional<std::string> alignment;
+  std::string type;
+  bool is_pointer{};
+  std::optional<std::string> pointer_space;
+  std::optional<std::string> pointer_alignment;
+  bool is_array{};
+  /** A normalized constant extent, or a structural key for an invalid one. */
+  std::optional<std::string> array_extent;
+
+  bool operator==(const FunctionParameterContract&) const = default;
+};
+
+/** Canonical ABI-relevant data shared by function declarations and bodies. */
+struct FunctionSignature {
+  bool is_entry{};
+  bool is_noreturn{};
+  std::vector<FunctionParameterContract> return_parameters;
+  std::vector<FunctionParameterContract> parameters;
+
+  bool operator==(const FunctionSignature&) const = default;
+};
+
+/** Build the canonical signature used by declaration checking and call ABI work. */
+[[nodiscard]] FunctionSignature functionSignature(
+    const syntax_ast::AstFunction& function);
+
 enum class DeclarationDiagnosticKind : uint8_t {
   InvalidArrayDimension,
   UnsizedArrayDimension,

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <variant>
 
 #include <fmt/format.h>
 
@@ -459,24 +460,24 @@ std::string optionalSyntaxKey(
   return syntax ? syntax->text : "-";
 }
 
-std::string parameterKey(const syntax_ast::AstFunctionParameter& parameter) {
-  return fmt::format(
-      "{}:{}:{}:{}:{}:{}:{}:{}", static_cast<int>(parameter.state_space),
-      optionalSyntaxKey(parameter.alignment), parameter.type.text,
-      parameter.is_pointer, optionalSyntaxKey(parameter.pointer_space),
-      optionalSyntaxKey(parameter.pointer_alignment), parameter.is_array,
-      parameter.array_size ? dimensionKey(*parameter.array_size) : "-");
-}
-
-std::string functionSignature(const syntax_ast::AstFunction& function) {
-  std::string signature =
-      fmt::format("function:{}:{}", function.is_entry, function.is_noreturn);
-  for (const auto& parameter : function.return_parameters)
-    signature += "|r:" + parameterKey(parameter);
-  signature += "|inputs";
-  for (const auto& parameter : function.parameters)
-    signature += "|p:" + parameterKey(parameter);
-  return signature;
+FunctionParameterContract parameterContract(
+    const syntax_ast::AstFunctionParameter& parameter) {
+  const auto syntax_text =
+      [](const auto& syntax) -> std::optional<std::string> {
+    return syntax ? std::optional<std::string>{syntax->text} : std::nullopt;
+  };
+  return {
+      .state_space = parameter.state_space,
+      .alignment = syntax_text(parameter.alignment),
+      .type = parameter.type.text,
+      .is_pointer = parameter.is_pointer,
+      .pointer_space = syntax_text(parameter.pointer_space),
+      .pointer_alignment = syntax_text(parameter.pointer_alignment),
+      .is_array = parameter.is_array,
+      .array_extent = parameter.array_size
+                          ? std::optional{dimensionKey(*parameter.array_size)}
+                          : std::nullopt,
+  };
 }
 
 std::string variableSignature(
@@ -554,7 +555,7 @@ class Checker {
 
  private:
   struct SeenDeclaration {
-    std::string signature;
+    std::variant<std::string, FunctionSignature> signature;
     binding::SymbolLinkage linkage{};
     SourceRange range;
     std::optional<SourceRange> definition_range;
@@ -575,10 +576,10 @@ class Checker {
     });
   }
 
-  void rememberDeclaration(std::string key, std::string_view name,
-                           std::string signature,
-                           binding::SymbolLinkage linkage, bool is_definition,
-                           SourceRange range) {
+  void rememberDeclaration(
+      std::string key, std::string_view name,
+      std::variant<std::string, FunctionSignature> signature,
+      binding::SymbolLinkage linkage, bool is_definition, SourceRange range) {
     auto iterator = declarations_.find(key);
     if (iterator == declarations_.end()) {
       declarations_.emplace(
@@ -849,6 +850,21 @@ class Checker {
 };
 
 }  // namespace
+
+FunctionSignature functionSignature(const syntax_ast::AstFunction& function) {
+  FunctionSignature signature{
+      .is_entry = function.is_entry,
+      .is_noreturn = function.is_noreturn,
+  };
+  const auto append_contracts = [](const auto& parameters, auto& contracts) {
+    contracts.reserve(parameters.size());
+    for (const auto& parameter : parameters)
+      contracts.push_back(parameterContract(parameter));
+  };
+  append_contracts(function.return_parameters, signature.return_parameters);
+  append_contracts(function.parameters, signature.parameters);
+  return signature;
+}
 
 std::vector<DeclarationDiagnostic> checkDeclarations(
     const syntax_ast::AstModule& module, const binding::SymbolTable& symbols) {

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -131,6 +131,44 @@ TEST(PtxDeclarationSemantics,
             helper->symbol);
 }
 
+TEST(PtxDeclarationSemantics, BuildsReusableCanonicalFunctionSignatures) {
+  PtxSyntaxParser parser(R"ptx(
+.func (.param .align 16 .u32 result) helper(
+    .param .u64 .ptr .global .align 16 pointer,
+    .param .u32 values[2 * 2]);
+.func (.param .align 16 .u32 output) helper(
+    .param .u64 .ptr .global .align 16 address,
+    .param .u32 data[4]) { ret; }
+.entry kernel() .noreturn { }
+)ptx");
+  const auto module = parser.parseModule();
+  ASSERT_TRUE(module.has_value()) << module.error().message;
+  const auto& prototype = std::get<syntax_ast::AstFunction>(module->items[0]);
+  const auto& definition = std::get<syntax_ast::AstFunction>(module->items[1]);
+
+  const FunctionSignature prototype_signature = functionSignature(prototype);
+  EXPECT_EQ(prototype_signature, functionSignature(definition));
+  ASSERT_EQ(prototype_signature.return_parameters.size(), 1u);
+  const auto& result = prototype_signature.return_parameters[0];
+  EXPECT_EQ(result.state_space, syntax_ast::AstStateSpace::Parameter);
+  EXPECT_EQ(result.alignment, "16");
+  EXPECT_EQ(result.type, ".u32");
+  const auto& pointer = prototype_signature.parameters[0];
+  EXPECT_TRUE(pointer.is_pointer);
+  EXPECT_EQ(pointer.pointer_space, ".global");
+  EXPECT_EQ(pointer.pointer_alignment, "16");
+  ASSERT_EQ(prototype_signature.parameters.size(), 2u);
+  const auto& values = prototype_signature.parameters[1];
+  EXPECT_TRUE(values.is_array);
+  EXPECT_EQ(values.array_extent, "#4");
+  const FunctionSignature kernel_signature =
+      functionSignature(std::get<syntax_ast::AstFunction>(module->items[2]));
+  EXPECT_TRUE(kernel_signature.is_entry);
+  EXPECT_TRUE(kernel_signature.is_noreturn);
+  EXPECT_TRUE(
+      checkDeclarations(*module, binding::bindSymbols(*module).table).empty());
+}
+
 TEST(PtxDeclarationSemantics, RejectsIncompatibleRedeclarationsAndDefinitions) {
   const CheckedModule result = check(R"ptx(
 .extern .global .u32 value[4];


### PR DESCRIPTION
## Summary
- Add source-location-independent FunctionParameterContract and canonical FunctionSignature data for function ABI-relevant declarations.
- Reuse canonical signatures when checking prototype/definition redeclarations.
- Add coverage for equivalent prototype/definition signatures, pointer and array normalization, and entry/noreturn flags.

## Validation
- Full build completed successfully.
- CTest: 196/196 passed.

## Follow-up scope
- This PR establishes the declaration-side canonical contract only.
- Call literal typing and formal/actual argument compatibility remain M6-I05 and M6-I06.