### PR TITLE
feat: add call literal typing helper

### DIFF
--- a/.agents/project_roadmap.md
+++ b/.agents/project_roadmap.md
@@ -1291,7 +1291,7 @@ call (return), function, (arguments);
 | M6-I02 | ✅ | 独立 | 实现 direct-call Resolved IR | 三个 `Call` layout、direct `.func` target、argument identity/range 和明确 indirect rejection |
 | M6-I03 | ✅ | 独立 | 修正 direct-call 基线文档 | 本轮已同步 README、coverage 和设计文档；priority 只由本文维护 |
 | M6-I04 | ✅ | 独立 | 建立 canonical `FunctionSignature` | prototype/definition 可转换为统一 return/input parameter contract |
-| M6-I05 | ⬜ | 独立 | 建立 call literal typing helper | immediate 按一个 formal parameter 定型；溢出和 kind mismatch 可诊断 |
+| M6-I05 | ✅ | 独立 | 建立 call literal typing helper | immediate 按一个 formal parameter 定型；溢出和 kind mismatch 可诊断 |
 | M6-I06 | ⬜ | 独立 | 建立 call argument compatibility helper | `.reg/.param`、type、alignment、array、pointer 和 state-space 可逐项比较 |
 | M6-I07 | ⬜ | 独立 | 建模 function-local call-argument `.param` | 与 formal parameter 分离，scope、lifetime、direction 和 address rule 明确 |
 | M6-I08 | ⬜ | 独立 | 建模 call-context syntax/semantics | `::entry/::func`、adjacency、predication 和 `.uni` 的 call-specific rule 明确 |

--- a/submod/resolved_ir/CMakeLists.txt
+++ b/submod/resolved_ir/CMakeLists.txt
@@ -20,8 +20,7 @@ find_package(fmt CONFIG REQUIRED)
 target_link_libraries(
     resolved_ir
     PUBLIC ptx_frontend::base ptx_frontend::binding ptx_frontend::syntax
-           ptx_frontend::common fmt::fmt
-    PRIVATE ptx_frontend::semantic
+           ptx_frontend::common ptx_frontend::semantic fmt::fmt
 )
 add_dependencies(resolved_ir resolved_ir_codegen)
 

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -19,6 +19,10 @@
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir_checker.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_ast.hpp>
 
+namespace ptx_frontend::declaration_semantics {
+struct FunctionParameterContract;
+}
+
 namespace ptx_frontend::resolved_ir {
 using base::ScalarType;
 using base::RoundingMode;
@@ -448,6 +452,12 @@ std::expected<T, ResolveDiagnostic> resolve(
 /** Resolve one lexer-classified immediate literal for a selected scalar type. */
 std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_literal(
     const syntax_ast::AstImmediate& immediate, ScalarType type);
+
+/** Type a retained call literal by one formal parameter contract. */
+std::expected<WithLocs<ResolvedImmediate>, ResolveDiagnostic>
+resolve_call_literal(const ResolvedCallLiteral& literal, SourceRange range,
+                     const declaration_semantics::FunctionParameterContract&
+                         formal);
 
 std::expected<ResolvedInstructionFields, ResolveDiagnostic> resolve_fields(
     const syntax_ast::AstInstruction& ast,

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <limits>
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
 #include <string_view>
 #include <vector>
 #include "resolved_value_domains.gen.hpp"
@@ -1989,6 +1990,29 @@ ResolvedFieldValue resolve_default_modifier_value(
 std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_literal(
     const syntax_ast::AstImmediate& immediate, ScalarType type) {
   return resolve_immediate_value(immediate, type);
+}
+
+std::expected<WithLocs<ResolvedImmediate>, ResolveDiagnostic>
+resolve_call_literal(
+    const ResolvedCallLiteral& literal, SourceRange range,
+    const declaration_semantics::FunctionParameterContract& formal) {
+  const auto type = scalar_type_from_ptx_name(formal.type);
+  if (!type) {
+    return std::unexpected(ResolveDiagnostic{
+        .range = range,
+        .message = fmt::format(
+            "Call literal '{}' has unsupported formal scalar type '{}'.",
+            literal.spelling, formal.type),
+    });
+  }
+  const syntax_ast::AstImmediate immediate{
+      .syntax = {.text = literal.spelling, .range = range},
+      .kind = literal.kind,
+  };
+  auto resolved = resolve_immediate_literal(immediate, *type);
+  if (!resolved)
+    return std::unexpected(resolved.error());
+  return WithLocs<ResolvedImmediate>{std::move(*resolved), range};
 }
 
 std::expected<ActualModifierTable, ResolveDiagnostic> collect_actual_modifiers(

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
 
 namespace ptx_frontend::resolved_ir {
@@ -752,6 +753,53 @@ TEST(ResolveImmediateLiteral, SupportsFloatingLexicalForms) {
   EXPECT_EQ(incompatible.error().message,
             "Decimal floating literal '1.5' is incompatible with scalar type "
             "'U32'.");
+}
+
+TEST(ResolveCallLiteral, TypesAgainstTheFormalAndPreservesSourceRange) {
+  const declaration_semantics::FunctionParameterContract u16{.type = ".u16"};
+  const auto typed_immediate = parse_immediate("42");
+  const auto typed = resolve_call_literal(
+      ResolvedCallLiteral{.spelling = typed_immediate.syntax.text,
+                          .kind = typed_immediate.kind},
+      typed_immediate.syntax.range, u16);
+  ASSERT_TRUE(typed.has_value()) << typed.error().message;
+  EXPECT_EQ(typed->value,
+            (ResolvedImmediate{.bits = 42, .type = ScalarType::U16}));
+  EXPECT_EQ(typed->locs, std::vector{typed_immediate.syntax.range});
+
+  const auto overflow_immediate = parse_immediate("65536");
+  const auto overflow = resolve_call_literal(
+      ResolvedCallLiteral{.spelling = overflow_immediate.syntax.text,
+                          .kind = overflow_immediate.kind},
+      overflow_immediate.syntax.range, u16);
+  ASSERT_FALSE(overflow.has_value());
+  EXPECT_EQ(overflow.error().range, overflow_immediate.syntax.range);
+  EXPECT_EQ(overflow.error().message,
+            "Integer literal '65536' is out of range for scalar type 'U16'.");
+
+  const declaration_semantics::FunctionParameterContract u32{.type = ".u32"};
+  const auto float_immediate = parse_immediate("1.5");
+  const auto mismatch = resolve_call_literal(
+      ResolvedCallLiteral{.spelling = float_immediate.syntax.text,
+                          .kind = float_immediate.kind},
+      float_immediate.syntax.range, u32);
+  ASSERT_FALSE(mismatch.has_value());
+  EXPECT_EQ(mismatch.error().range, float_immediate.syntax.range);
+  EXPECT_EQ(mismatch.error().message,
+            "Decimal floating literal '1.5' is incompatible with scalar type "
+            "'U32'.");
+
+  const declaration_semantics::FunctionParameterContract unsupported_type{
+      .type = ".v2"};
+  const auto unsupported_immediate = parse_immediate("1");
+  const auto unsupported = resolve_call_literal(
+      ResolvedCallLiteral{.spelling = unsupported_immediate.syntax.text,
+                          .kind = unsupported_immediate.kind},
+      unsupported_immediate.syntax.range, unsupported_type);
+  ASSERT_FALSE(unsupported.has_value());
+  EXPECT_EQ(unsupported.error().range, unsupported_immediate.syntax.range);
+  EXPECT_EQ(unsupported.error().message,
+            "Call literal '1' has unsupported formal scalar type '.v2'.");
 }
 
 TEST(ResolveAdd, PreservesOptionalModifierPresence) {


### PR DESCRIPTION
## Summary
- Add a formal-driven helper for typing retained call literals against one function parameter contract.
- Reuse the existing immediate parser and resolver for literal kind, range, and scalar compatibility diagnostics.
- Cover successful typing, source-range preservation, overflow, kind mismatch, and unsupported formal boundaries with tests.

This is a stacked PR based on feat/m6-i04-function-signature. The implementation is intentionally scoped to M6-I05; it is not merged here, and CI is not awaited.