### PR TITLE
feat: add call argument compatibility helper

### DIFF
--- a/submod/semantic/include/ptx_call_argument_compatibility.hpp
+++ b/submod/semantic/include/ptx_call_argument_compatibility.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace ptx_frontend::call_argument_compatibility {
+
+/** State space of a value passed at a direct-call boundary. */
+enum class CallArgumentStateSpace : uint8_t {
+  Invalid,
+  Register,
+  Parameter,
+  Local,
+  Shared,
+  Global,
+  Constant,
+};
+
+/** A concrete state space addressed by a pointer. */
+enum class PointedStateSpace : uint8_t {
+  Local,
+  Shared,
+  Global,
+  Constant,
+};
+
+/** Canonical pointer contract supplied by the caller. */
+struct PointerProperties {
+  // An absent space is generic.
+  std::optional<PointedStateSpace> pointed_state_space;
+  uint64_t pointed_alignment = 4;
+
+  bool operator==(const PointerProperties&) const = default;
+};
+
+/**
+ * Canonical properties shared by a formal parameter and an actual argument.
+ *
+ * Scalar/vector formals and actuals may independently be Register or
+ * Parameter. `type_spelling` is the normalized scalar or vector ABI spelling
+ * (including its shape) and is compared exactly. `array_alignment` is the
+ * effective byte alignment used only for `.param .b8` arrays. An unsized array
+ * has `is_array == true` and no `array_size`.
+ */
+struct CallArgumentProperties {
+  CallArgumentStateSpace state_space = CallArgumentStateSpace::Invalid;
+  std::string type_spelling;
+  uint64_t array_alignment = 1;
+  bool is_array{};
+  std::optional<uint64_t> array_size;
+  std::optional<PointerProperties> pointer;
+
+  bool operator==(const CallArgumentProperties&) const = default;
+};
+
+/** The first incompatible property, or Compatible. */
+enum class CallArgumentCompatibility : uint8_t {
+  Compatible,
+  FormalStateSpaceMismatch,
+  ActualStateSpaceMismatch,
+  TypeMismatch,
+  ArrayMismatch,
+  ArraySizeMismatch,
+  AlignmentMismatch,
+  PointerMismatch,
+  PointedStateSpaceMismatch,
+  PointedAlignmentMismatch,
+};
+
+/**
+ * Check whether `actual` satisfies the (intentionally asymmetric) `formal`.
+ */
+[[nodiscard]] CallArgumentCompatibility checkCallArgumentCompatibility(
+    const CallArgumentProperties& formal, const CallArgumentProperties& actual);
+
+}  // namespace ptx_frontend::call_argument_compatibility

--- a/submod/semantic/src/ptx_call_argument_compatibility.cpp
+++ b/submod/semantic/src/ptx_call_argument_compatibility.cpp
@@ -1,0 +1,52 @@
+#include <ptx_frontend/semantic/ptx_call_argument_compatibility.hpp>
+
+namespace ptx_frontend::call_argument_compatibility {
+namespace {
+
+bool isCallStateSpace(CallArgumentStateSpace state_space) {
+  return state_space == CallArgumentStateSpace::Register ||
+         state_space == CallArgumentStateSpace::Parameter;
+}
+
+}  // namespace
+
+CallArgumentCompatibility checkCallArgumentCompatibility(
+    const CallArgumentProperties& formal, const CallArgumentProperties& actual) {
+  if (!isCallStateSpace(formal.state_space) ||
+      (formal.is_array &&
+       formal.state_space != CallArgumentStateSpace::Parameter)) {
+    return CallArgumentCompatibility::FormalStateSpaceMismatch;
+  }
+  if (!isCallStateSpace(actual.state_space) ||
+      (formal.is_array &&
+       actual.state_space != CallArgumentStateSpace::Parameter)) {
+    return CallArgumentCompatibility::ActualStateSpaceMismatch;
+  }
+  if (formal.type_spelling != actual.type_spelling)
+    return CallArgumentCompatibility::TypeMismatch;
+  if (formal.is_array != actual.is_array)
+    return CallArgumentCompatibility::ArrayMismatch;
+  if (formal.is_array) {
+    if (!actual.array_size)
+      return CallArgumentCompatibility::ArraySizeMismatch;
+    if (formal.array_size && formal.array_size != actual.array_size)
+      return CallArgumentCompatibility::ArraySizeMismatch;
+    if (formal.array_alignment != actual.array_alignment)
+      return CallArgumentCompatibility::AlignmentMismatch;
+  }
+  if (formal.pointer.has_value() != actual.pointer.has_value())
+    return CallArgumentCompatibility::PointerMismatch;
+  if (!formal.pointer)
+    return CallArgumentCompatibility::Compatible;
+
+  if (formal.pointer->pointed_state_space &&
+      formal.pointer->pointed_state_space !=
+          actual.pointer->pointed_state_space) {
+    return CallArgumentCompatibility::PointedStateSpaceMismatch;
+  }
+  if (actual.pointer->pointed_alignment < formal.pointer->pointed_alignment)
+    return CallArgumentCompatibility::PointedAlignmentMismatch;
+  return CallArgumentCompatibility::Compatible;
+}
+
+}  // namespace ptx_frontend::call_argument_compatibility

--- a/submod/semantic/test/test_ptx_call_argument_compatibility.cpp
+++ b/submod/semantic/test/test_ptx_call_argument_compatibility.cpp
@@ -1,0 +1,144 @@
+#include <gtest/gtest.h>
+
+#include <ptx_frontend/semantic/ptx_call_argument_compatibility.hpp>
+
+namespace ptx_frontend::call_argument_compatibility {
+namespace {
+
+using Compatibility = CallArgumentCompatibility;
+using StateSpace = CallArgumentStateSpace;
+
+CallArgumentProperties scalar(StateSpace state_space = StateSpace::Register) {
+  return {.state_space = state_space, .type_spelling = ".u32"};
+}
+
+TEST(CallArgumentCompatibility, AcceptsCompatibleScalarAndVectorValues) {
+  auto formal = scalar();
+  auto actual = scalar(StateSpace::Parameter);
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+
+  formal.type_spelling = ".v4 .u32";
+  actual.type_spelling = ".v4 .u32";
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+}
+
+TEST(CallArgumentCompatibility, ReportsUnsupportedCallStateSpaces) {
+  auto formal = scalar(StateSpace::Local);
+  const auto actual = scalar();
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::FormalStateSpaceMismatch);
+
+  EXPECT_EQ(checkCallArgumentCompatibility(CallArgumentProperties{}, actual),
+            Compatibility::FormalStateSpaceMismatch);
+
+  formal = scalar();
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, scalar(StateSpace::Global)),
+            Compatibility::ActualStateSpaceMismatch);
+}
+
+TEST(CallArgumentCompatibility, DefaultsPointerAlignmentToFourBytes) {
+  EXPECT_EQ(PointerProperties{}.pointed_alignment, 4u);
+}
+
+TEST(CallArgumentCompatibility, ReportsTypeAndArrayMismatches) {
+  const auto formal = scalar();
+  auto actual = scalar();
+  actual.type_spelling = ".u64";
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::TypeMismatch);
+
+  actual = scalar();
+  actual.is_array = true;
+  actual.array_size = 4;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::ArrayMismatch);
+}
+
+TEST(CallArgumentCompatibility, ChecksParameterByteArrays) {
+  CallArgumentProperties formal{
+      .state_space = StateSpace::Parameter,
+      .type_spelling = ".b8",
+      .array_alignment = 16,
+      .is_array = true,
+      .array_size = 8,
+  };
+  auto actual = formal;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+
+  actual.state_space = StateSpace::Register;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::ActualStateSpaceMismatch);
+
+  actual = formal;
+  actual.array_size = 4;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::ArraySizeMismatch);
+
+  actual = formal;
+  actual.array_alignment = 8;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::AlignmentMismatch);
+}
+
+TEST(CallArgumentCompatibility, AcceptsSizedActualForUnsizedArrayFormal) {
+  const CallArgumentProperties formal{
+      .state_space = StateSpace::Parameter,
+      .type_speling = ".b8",
+      .array_alignment = 8,
+      .is_array = true,
+  };
+  auto actual = formal;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::ArraySizeMismatch);
+
+  actual.array_size = 32;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+}
+
+TEST(CallArgumentCompatibility, ChecksPointerContractAsymmetrically) {
+  auto formal = scalar();
+  auto actual = formal;
+  formal.pointer = PointerProperties{
+      .pointed_state_space = PointedStateSpace::Global,
+      .pointed_alignment = 16,
+  };
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::PointerMismatch);
+
+  actual.pointer = PointerProperties{
+      .pointed_state_space = PointedStateSpace::Shared,
+      .pointed_alignment = 32,
+  };
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::PointedStateSpaceMismatch);
+
+  actual.pointer = PointerProperties{
+      .pointed_state_space = PointedStateSpace::Global,
+      .pointed_alignment = 8,
+  };
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::PointedAlignmentMismatch);
+
+  actual.pointer->pointed_alignment = 32;
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+}
+
+TEST(CallArgumentCompatibility, GenericFormalPointerAcceptsConcreteActualSpace) {
+  auto formal = scalar();
+  auto actual = formal;
+  formal.pointer = PointerProperties{.pointed_alignment = 8};
+  actual.pointer = PointerProperties{
+      .pointed_state_space = PointedStateSpace::Global,
+      .pointed_alignment = 8,
+  };
+  EXPECT_EQ(checkCallArgumentCompatibility(formal, actual),
+            Compatibility::Compatible);
+}
+
+}  // namespace
+}  // namespace ptx_frontend::call_argument_compatibility

--- a/submod/semantic/test/test_ptx_call_argument_compatibility.cpp
+++ b/submod/semantic/test/test_ptx_call_argument_compatibility.cpp
@@ -86,7 +86,7 @@ TEST(CallArgumentCompatibility, ChecksParameterByteArrays) {
 TEST(CallArgumentCompatibility, AcceptsSizedActualForUnsizedArrayFormal) {
   const CallArgumentProperties formal{
       .state_space = StateSpace::Parameter,
-      .type_speling = ".b8",
+      .type_spelling = ".b8",
       .array_alignment = 8,
       .is_array = true,
   };


### PR DESCRIPTION
## Summary

- add a normalized direct-call formal/actual compatibility contract
- compare call state-space eligibility, exact ABI type/shape, `.param .b8` array size/alignment, and pointer attributes
- support unsized formal byte arrays while requiring sized actual arrays
- preserve PTX's asymmetric generic/concrete pointer-space and pointed-alignment rules

## Scope

This is the independent M6-I06 slice only. It does not add `FunctionSignature`, literal typing, or wire the helper into the direct-call ABI checker; those remain M6-I04, M6-I05, and M6-C01.

## Validation

- C++23 strict source compilation (`-Wall -Wextra -Werror`)
- focused semantic smoke assertions
- `git diff --check`
- full Debug/Release CMake workflows delegated to PR CI because the local environment has no CMake executable
