### PR TITLE
feat: model function-local call argument parameters

### DIFF
--- a/.agents/project_roadmap.md
+++ b/.agents/project_roadmap.md
@@ -1293,7 +1293,7 @@ call (return), function, (arguments);
 | M6-I04 | ✅ | 独立 | 建立 canonical `FunctionSignature` | prototype/definition 可转换为统一 return/input parameter contract |
 | M6-I05 | ✅ | 独立 | 建立 call literal typing helper | immediate 按一个 formal parameter 定型；溢出和 kind mismatch 可诊断 |
 | M6-I06 | ⬜ | 独立 | 建立 call argument compatibility helper | `.reg/.param`、type、alignment、array、pointer 和 state-space 可逐项比较 |
-| M6-I07 | ⬜ | 独立 | 建模 function-local call-argument `.param` | 与 formal parameter 分离，scope、lifetime、direction 和 address rule 明确 |
+| M6-I07 | ✅ | 独立 | 建模 function-local call-argument `.param` | 与 formal parameter 分离，scope、lifetime、direction 和 address rule 明确 |
 | M6-I08 | ⬜ | 独立 | 建模 call-context syntax/semantics | `::entry/::func`、adjacency、predication 和 `.uni` 的 call-specific rule 明确 |
 | M6-C01 | ⬜ | 耦合 | 实现 direct-call ABI checker | callee signature 与 return/input actual 按数量、顺序、类型和 shape 完整比较 |
 | M6-C02 | ⬜ | 耦合 | 完成 direct-call 端到端回归 | prototype、definition、extern、recursive、wrong arity/type/space 和 immediate 全覆盖 |

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -158,8 +158,10 @@ a `.param` address, while taking a device-function formal parameter address
 with `mov` materializes it on the stack and produces a `.local` address. A
 device-function formal-parameter `mov` address carries a PTX 2.0 / SM 20
 baseline; a return-parameter address raises the PTX minimum to 6.0. A
-function-local `.param` call-argument
-variable remains non-addressable through `mov`. Standalone resolution cannot
+function-local `.param` call-argument variable is a distinct bound symbol:
+direct `ld.param`/`st.param` addresses retain `.param`, satisfy either parameter
+direction, and require PTX 2.0 / SM 20; it remains non-addressable through `mov`.
+Standalone resolution cannot
 perform lexical binding, so it leaves identity and state-space fields empty as
 it does for branch targets. `ResolvedMovSource` classifies registers,
 immediates, special registers, data symbols, and address expressions after
@@ -238,7 +240,8 @@ when the address is known.
 
 `ResolvedAddress` separately records the enclosing function kind. Generated
 address views derive an optional parameter direction only from a bound
-`InputParameter` or `ReturnParameter`; they do not infer it from spelling.
+`InputParameter`, `ReturnParameter`, or a function-local call argument; they do
+not infer it from spelling.
 For explicit `.param`, the generated operand constraint requires input
 parameters for `ld` and return parameters for `st`. A known wrong direction
 reports `ParameterDirectionMismatch` without stacking target diagnostics. A

--- a/docs/us-en/symbol_binding_design.md
+++ b/docs/us-en/symbol_binding_design.md
@@ -128,8 +128,9 @@ addresses and kernel formal-parameter `mov` addresses remain in `.param`;
 device-function formal-parameter `mov` addresses are in `.local`, and the
 checker applies a PTX 2.0 / SM 20 baseline to all such addresses and raises
 the PTX minimum to 6.0 for a return-parameter address.
-Function-local `.param` variables remain non-addressable, while
-standalone resolution keeps spelling only. A bare function name binds to a
+Function-local `.param` call-argument variables are bound separately from
+formal parameters; direct `ld.param`/`st.param` addresses are valid, while
+`mov` remains non-addressable. Standalone resolution keeps spelling only. A bare function name binds to a
 `ResolvedFunctionRef` with the same stable `SymbolId` and its `.func`/`.entry`
 classification. The checker requires PTX 3.1 / SM 35 for a kernel-function
 address; a device-function address uses the base PTX 1.0 availability of

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -126,8 +126,8 @@ address 与 kernel formal parameter 的 `mov` 取址仍得到 `.param` address�
 formal parameter 经 `mov` 取址会将参数物化到 stack，因此得到 `.local` address。
 device-function formal parameter 的 `mov` 地址值携带 PTX 2.0 / SM 20 baseline；return
 parameter 再把最低 PTX 提升至 6.0，供 checker 按 target 检查。function-local `.param`
-call-argument variable 不能由
-`mov` 取址。standalone resolution 无法完成 lexical binding，因此和 branch target 一样保留
+call-argument variable 是独立的 bound symbol：direct `ld.param`/`st.param` 地址保留 `.param`、
+匹配任一 parameter direction，并要求 PTX 2.0 / SM 20；仍不能由 `mov` 取址。standalone resolution 无法完成 lexical binding，因此和 branch target 一样保留
 空 identity/state-space。`ResolvedMovSource` 在 binding 后区分 register、immediate、special
 register、data symbol 与 address expression，避免这些 identifier 形状在 variant/layout 选择
 阶段产生歧义。standalone resolution 无法区分未绑定名称是 data 还是 function，因此仍保留为
@@ -187,7 +187,7 @@ modern load/store vector 可使用部分 sink，all-sink 与 legacy sink 仍拒�
 `.v2/.v4` 与 modern 256-bit 的静态 natural alignment 会按 total access size 检查已知 address。
 
 `ResolvedAddress` 另行记录 enclosing function kind。generated address view 仅从已绑定的
-`InputParameter`/`ReturnParameter` 推导可选 parameter direction，不根据 spelling 猜测。
+`InputParameter`/`ReturnParameter`/function-local call argument 推导可选 parameter direction，不根据 spelling 猜测。
 对于 explicit `.param`，生成的 operand constraint 要求 `ld` 使用 input parameter、`st`
 使用 return parameter；已知方向错误只报告 `ParameterDirectionMismatch`，不叠加 target
 诊断。device-function `ld.param` 与所有 `st.param` 都应用 YAML 提供的 PTX 2.0 / SM 20

--- a/docs/zh-han/symbol_binding_design.md
+++ b/docs/zh-han/symbol_binding_design.md
@@ -107,8 +107,8 @@ parameterized member、declaration kind、声明 state space 与实际 address s
 parameter memory address 与 kernel formal parameter 的 `mov` 地址属于 `.param`，
 device-function formal parameter 的 `mov` 地址属于 `.local`，且 return parameter 取址由
 checker 在所有 device parameter 上要求 PTX 2.0 / SM 20 baseline，并将 return parameter 的
-最低 PTX 提升至 6.0。function-local `.param` variable 仍拒绝取址；
-standalone resolution 只保留 spelling。bare function name 绑定为 `ResolvedFunctionRef`，保存
+最低 PTX 提升至 6.0。function-local `.param` call-argument variable 与 formal parameter 分开绑定；
+direct `ld.param`/`st.param` 可取址，`mov` 仍拒绝取址。standalone resolution 只保留 spelling。bare function name 绑定为 `ResolvedFunctionRef`，保存
 同一稳定 `SymbolId` 与 `.func/.entry` 类别；kernel function 地址由 checker 要求 PTX 3.1 /
 SM 35，device-function 地址沿用 `mov` 的 PTX 1.0 baseline。
 后续语义阶段仍需完成：

--- a/python/code_gen/gen_resolved_ir.py
+++ b/python/code_gen/gen_resolved_ir.py
@@ -1064,6 +1064,9 @@ def _emit_check_operand_view(field: ResolvedField, object_name: str) -> str:
                   }} else if (*symbol->declaration_kind ==
                              binding::SymbolKind::ReturnParameter) {{
                     parameter_direction = ParameterDirection::Return;
+                  }} else if (*symbol->declaration_kind ==
+                             binding::SymbolKind::CallParameter) {{
+                    parameter_direction = ParameterDirection::CallArgument;
                   }}
                 }}
                 std::optional<uint64_t> address_alignment;

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -1300,6 +1300,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
             "parameter_direction = ParameterDirection::Return", source
         )
         self.assertIn(
+            "parameter_direction = ParameterDirection::CallArgument", source
+        )
+        self.assertIn(
             "ParameterDirection parameter_direction = ParameterDirection::None",
             source,
         )

--- a/submod/binding/include/ptx_symbol_table.hpp
+++ b/submod/binding/include/ptx_symbol_table.hpp
@@ -30,6 +30,7 @@ enum class SymbolKind : uint8_t {
   Variable,
   InputParameter,
   ReturnParameter,
+  CallParameter,
   Function,
   Label,
 };

--- a/submod/binding/src/ptx_symbol_table.cpp
+++ b/submod/binding/src/ptx_symbol_table.cpp
@@ -337,8 +337,13 @@ struct SymbolTableBuilder {
       ScopeId scope, const syntax_ast::AstVariableDeclaration& declaration) {
     const SymbolLinkage declaration_linkage =
         linkage(declaration.qualifiers, declaration.range);
+    const SymbolKind kind =
+        scope != result.table.moduleScope() &&
+                declaration.state_space == syntax_ast::AstStateSpace::Parameter
+            ? SymbolKind::CallParameter
+            : SymbolKind::Variable;
     for (const auto& declarator : declaration.declarators) {
-      addSymbol(scope, SymbolKind::Variable, declarator.name.syntax.text,
+      addSymbol(scope, kind, declarator.name.syntax.text,
                 declarator.name.syntax.range, declaration_linkage,
                 declaration.state_space, declaration.type.text,
                 declarationAlignment(declaration.alignment,
@@ -425,7 +430,8 @@ struct SymbolTableBuilder {
   bool isRegisterOrParameter(const Symbol& symbol) const {
     const bool supported_kind = symbol.kind == SymbolKind::Variable ||
                                 symbol.kind == SymbolKind::InputParameter ||
-                                symbol.kind == SymbolKind::ReturnParameter;
+                                symbol.kind == SymbolKind::ReturnParameter ||
+                                symbol.kind == SymbolKind::CallParameter;
     return supported_kind && symbol.state_space &&
            (*symbol.state_space == syntax_ast::AstStateSpace::Register ||
             *symbol.state_space == syntax_ast::AstStateSpace::Parameter);

--- a/submod/binding/test/test_ptx_symbol_table.cpp
+++ b/submod/binding/test/test_ptx_symbol_table.cpp
@@ -251,6 +251,44 @@ again:
   }
 }
 
+TEST(PtxSymbolTable, ClassifiesLocalCallParametersInTheirFunctionScope) {
+  constexpr std::string_view source = R"ptx(
+.func callee();
+.func first() {
+  .param .u32 staging;
+  call callee, (staging);
+}
+.func second() { call callee; }
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto module = parser.parseModule();
+  ASSERT_TRUE(module.has_value()) << module.error().message;
+
+  const auto binding_result = binding::bindSymbols(*module);
+  ASSERT_TRUE(binding_result.diagnostics.empty());
+  const auto first = binding_result.table.lookup(
+      binding_result.table.moduleScope(), "first");
+  const auto second = binding_result.table.lookup(
+      binding_result.table.moduleScope(), "second");
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  const auto first_scope =
+      *binding_result.table.symbol(first->symbol).owned_scope;
+  const auto second_scope =
+      *binding_result.table.symbol(second->symbol).owned_scope;
+  const auto staging = binding_result.table.lookup(first_scope, "staging");
+  ASSERT_TRUE(staging.has_value());
+  EXPECT_EQ(binding_result.table.symbol(staging->symbol).kind,
+            binding::SymbolKind::CallParameter);
+  EXPECT_EQ(binding_result.table.symbol(staging->symbol).scope, first_scope);
+  EXPECT_FALSE(binding_result.table.lookup(second_scope, "staging").has_value());
+  const auto* argument = findReference(binding_result.table, "staging",
+                                       binding::ReferenceKind::CallArgument);
+  ASSERT_NE(argument, nullptr);
+  ASSERT_TRUE(argument->target.has_value());
+  EXPECT_EQ(argument->target->symbol, staging->symbol);
+}
+
 TEST(PtxSymbolTable, DiagnosesInvalidCallAndBranchTargetKinds) {
   constexpr std::string_view source = R"ptx(
 .global .u32 global_value;

--- a/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
@@ -60,11 +60,12 @@ enum class EnclosingFunctionKind : uint8_t {
   Device,
 };
 
-/** Formal-parameter direction independent of binding-layer enum types. */
+/** Parameter role independent of binding-layer enum types. */
 enum class ParameterDirection : uint8_t {
   None,
   Input,
   Return,
+  CallArgument,
 };
 
 namespace checker {
@@ -248,7 +249,7 @@ struct OperandView {
   std::optional<uint64_t> address_alignment;
   /** Function provenance is independent of whether the base binds a symbol. */
   EnclosingFunctionKind enclosing_function_kind = EnclosingFunctionKind::Unknown;
-  /** None unless the base binds an input or return parameter declaration. */
+  /** None unless the base binds a formal or call-argument parameter. */
   ParameterDirection parameter_direction = ParameterDirection::None;
   std::array<ScalarType, 8> vector_element_types{};
   uint8_t vector_arity = 0;

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -664,7 +664,8 @@ resolve_call_parameter(const syntax_ast::AstIdentifierRef& identifier,
   const bool parameter_or_variable =
       symbol.kind == binding::SymbolKind::Variable ||
       symbol.kind == binding::SymbolKind::InputParameter ||
-      symbol.kind == binding::SymbolKind::ReturnParameter;
+      symbol.kind == binding::SymbolKind::ReturnParameter ||
+      symbol.kind == binding::SymbolKind::CallParameter;
   const bool allowed_space = symbol.state_space &&
       (*symbol.state_space == syntax_ast::AstStateSpace::Register ||
        *symbol.state_space == syntax_ast::AstStateSpace::Parameter);
@@ -897,7 +898,10 @@ bool is_addressable_data_symbol(const binding::Symbol& symbol,
   }
   return parameter_policy != FormalParameterAddressPolicy::Reject &&
          (symbol.kind == binding::SymbolKind::InputParameter ||
-          symbol.kind == binding::SymbolKind::ReturnParameter) &&
+          symbol.kind == binding::SymbolKind::ReturnParameter ||
+          (parameter_policy ==
+               FormalParameterAddressPolicy::PreserveParameterSpace &&
+           symbol.kind == binding::SymbolKind::CallParameter)) &&
          symbol.state_space == syntax_ast::AstStateSpace::Parameter;
 }
 

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -179,6 +179,8 @@ std::string_view parameter_direction_name(ParameterDirection direction) noexcept
       return "input";
     case ParameterDirection::Return:
       return "return";
+    case ParameterDirection::CallArgument:
+      return "call argument";
   }
   return "unknown";
 }
@@ -198,6 +200,7 @@ void append_parameter_address_diagnostics(
   }
 
   if (operand.parameter_direction != ParameterDirection::None &&
+      operand.parameter_direction != ParameterDirection::CallArgument &&
       operand.parameter_direction != constraint.direction) {
     // Direction is the more specific error and suppresses contextual target
     // diagnostics for the same address.
@@ -215,7 +218,8 @@ void append_parameter_address_diagnostics(
   }
 
   if (constraint.direction == ParameterDirection::Return ||
-      operand.enclosing_function_kind == EnclosingFunctionKind::Device) {
+      operand.enclosing_function_kind == EnclosingFunctionKind::Device ||
+      operand.parameter_direction == ParameterDirection::CallArgument) {
     append_address_constraint_availability_diagnostics(
         constraint.function_availability, "Parameter address", operand,
         context, diagnostics);

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -1998,6 +1998,65 @@ TEST(ResolvedModule, RejectsLocallyScopedParamVariableAddress) {
             "Symbol 'call_argument' is not an addressable data symbol.");
 }
 
+TEST(ResolvedModule, ResolvesAndChecksLocalCallParameterAddresses) {
+  const auto ast = parseModule(R"ptx(
+.func (.param .u32 result) callee(.param .u32 input);
+.entry caller() {
+  .reg .u32 %r0, %r1;
+  .param .u32 input_staging, return_staging;
+  st.param.u32 [input_staging], %r0;
+  call (return_staging), callee, (input_staging);
+  ld.param.u32 %r1, [return_staging];
+}
+)ptx");
+  const auto resolved = resolveModule(ast);
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& body = resolved->functions[1].body;
+  ASSERT_EQ(body.size(), 3u);
+  const auto& store = std::get<St>(body[0]);
+  const auto& load = std::get<Ld>(body[2]);
+  const auto& address =
+      std::get<St::ExplicitScalar>(store.variant).address.value;
+  const auto& staging = std::get<ResolvedSymbolRef>(address.base);
+  EXPECT_EQ(staging.declaration_kind, binding::SymbolKind::CallParameter);
+  EXPECT_EQ(staging.declaration_state_space,
+            syntax_ast::AstStateSpace::Parameter);
+  EXPECT_EQ(staging.address_state_space, syntax_ast::AstStateSpace::Parameter);
+  const auto& call = std::get<Call>(body[1]);
+  const auto& call_operands =
+      std::get<Call::Direct::ReturnTargetInputOperands>(
+          std::get<Call::Direct>(call.variant).operands);
+  const auto caller_scope =
+      *resolved->symbols.symbol(resolved->functions[1].symbol_id).owned_scope;
+  const auto return_staging =
+      resolved->symbols.lookup(caller_scope, "return_staging");
+  ASSERT_TRUE(return_staging.has_value());
+  EXPECT_EQ(call_operands.return_value.value.symbol_id,
+            return_staging->symbol);
+
+  const checker::Context old_context{
+      .target = {.ptx_version = {1, 5}, .sm_version = 10},
+      .instruction_range = ast.range,
+  };
+  const checker::Context supported_context{
+      .target = {.ptx_version = {2, 0}, .sm_version = 20},
+      .instruction_range = ast.range,
+  };
+  const auto expect_availability = [&](const auto& instruction) {
+    const auto checked = checker::check(instruction, old_context);
+    ASSERT_FALSE(checked.has_value());
+    ASSERT_EQ(checked.error().size(), 2u);
+    EXPECT_EQ(checked.error()[0].kind,
+              checker::CheckDiagnosticKind::UnsupportedPtxVersion);
+    EXPECT_EQ(checked.error()[1].kind,
+              checker::CheckDiagnosticKind::UnsupportedSmVersion);
+    EXPECT_TRUE(checker::check(instruction, supported_context).has_value());
+  };
+  expect_availability(store);
+  expect_availability(load);
+}
+
 TEST(ResolvedModule, KeepsStandaloneAddressAndSymbolIdentityOpen) {
   PtxSyntaxParser mov_parser("mov.u64 %rd0, global_value;");
   const auto mov_ast = mov_parser.parseInstruction();

--- a/submod/semantic/include/ptx_declaration_semantics.hpp
+++ b/submod/semantic/include/ptx_declaration_semantics.hpp
@@ -51,6 +51,7 @@ enum class DeclarationDiagnosticKind : uint8_t {
   MultipleDefinitions,
   InvalidLinkage,
   InvalidAlignment,
+  ModuleScopeParameter,
 };
 
 struct DeclarationDiagnostic {

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -537,6 +537,11 @@ class Checker {
               std::get_if<syntax_ast::AstVariableDeclaration>(&item)) {
         checkAlignment(declaration->alignment);
         checkVariableDeclaration(*declaration);
+        if (declaration->state_space == syntax_ast::AstStateSpace::Parameter) {
+          diagnose(DeclarationDiagnosticKind::ModuleScopeParameter,
+                   declaration->range,
+                   "A .param variable declaration must be local to a function.");
+        }
       } else if (const auto* function =
                      std::get_if<syntax_ast::AstFunction>(&item)) {
         checkFunctionAlignments(*function);

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -214,5 +214,13 @@ TEST(PtxDeclarationSemantics, RequiresPositivePowerOfTwoAlignment) {
             4u);
 }
 
+TEST(PtxDeclarationSemantics, RejectsModuleScopeParameterVariables) {
+  const CheckedModule result = check(".param .u32 staging;");
+
+  EXPECT_EQ(diagnosticCount(result,
+                            DeclarationDiagnosticKind::ModuleScopeParameter),
+            1u);
+}
+
 }  // namespace
 }  // namespace ptx_frontend::declaration_semantics


### PR DESCRIPTION
## Summary

- Add `CallParameter` symbols for function-local `.param` call arguments, keeping them scoped to their owning function and separate from formal parameters.
- Carry call-argument direction through resolved operand views, preserve `.param` addresses for direct `ld.param`/`st.param`, and enforce the PTX 2.0 / SM 20 availability gate.
- Reject module-scope `.param` variables and document the scope, direction, lifetime, and address rules.

## Validation

- Python tests: 21/21
- Full build: passed
- CTest: 200/200

## Scope

This stacked PR covers M6-I07 only. M6-I06 call-argument compatibility checking and M6-I08 call-context syntax/semantics remain out of scope.