### PR TITLE
Enforce PTX 9.3 call context semantics

### DIFF
--- a/.agents/project_roadmap.md
+++ b/.agents/project_roadmap.md
@@ -1294,7 +1294,7 @@ call (return), function, (arguments);
 | M6-I05 | ✅ | 独立 | 建立 call literal typing helper | immediate 按一个 formal parameter 定型；溢出和 kind mismatch 可诊断 |
 | M6-I06 | ⬜ | 独立 | 建立 call argument compatibility helper | `.reg/.param`、type、alignment、array、pointer 和 state-space 可逐项比较 |
 | M6-I07 | ✅ | 独立 | 建模 function-local call-argument `.param` | 与 formal parameter 分离，scope、lifetime、direction 和 address rule 明确 |
-| M6-I08 | ⬜ | 独立 | 建模 call-context syntax/semantics | `::entry/::func`、adjacency、predication 和 `.uni` 的 call-specific rule 明确 |
+| M6-I08 | ✅ | 独立 | 建模 call-context syntax/semantics | PTX 9.3 `::entry/::func`、function-local `.param` staging adjacency/predication 与 predicated `call.uni` 规则已明确 |
 | M6-C01 | ⬜ | 耦合 | 实现 direct-call ABI checker | callee signature 与 return/input actual 按数量、顺序、类型和 shape 完整比较 |
 | M6-C02 | ⬜ | 耦合 | 完成 direct-call 端到端回归 | prototype、definition、extern、recursive、wrong arity/type/space 和 immediate 全覆盖 |
 | M6-C03 | ⬜ | 耦合 | 同步 direct-call 文档和 package regression | 双语设计、coverage、README、installed consumer 全部通过 |

--- a/docs/us-en/control_flow_syntax_design.md
+++ b/docs/us-en/control_flow_syntax_design.md
@@ -65,3 +65,21 @@ or a `CallTargetSet` fourth operand is rejected clearly: indirect calls need
 the still-unmodeled `.calltargets`/`.callprototype` metadata. Direct function
 signature/ABI comparison is deferred too; the existing declaration pass has
 no reusable call-contract representation.
+
+## PTX 9.3 call parameter context
+
+`ld` accepts `.param`, `.param::entry`, and `.param::func`; `st` accepts
+`.param` and `.param::func`. `::entry` addresses only an entry's formal input.
+`::func` addresses a device-function parameter or a function-local call
+parameter. The unqualified spelling defaults to entry parameters in an entry,
+to function parameters in a device function, and to function-local call
+parameters in either context.
+
+Only function-local `.param` variables are call staging. Their `st.param` input
+stores must be unpredicated and form the contiguous block immediately before a
+call that passes the same variable; their `ld.param` return loads must be
+unpredicated and form the contiguous block immediately after a call returning
+the same variable. Labels, declarations, and other instructions break a block.
+`call` itself may be predicated. `.uni` is retained as the programmer's
+uniformity assertion, so the frontend does not attempt unprovable static
+uniformity analysis or reject a predicated direct `call.uni`.

--- a/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
+++ b/instructions/ptx_cpp_backend_spec/ptx_frontend.yaml
@@ -121,6 +121,8 @@ domains:
       global: MemoryStateSpace::Global
       local: MemoryStateSpace::Local
       param: MemoryStateSpace::Parameter
+      param::entry: MemoryStateSpace::Parameter
+      param::func: MemoryStateSpace::Parameter
       shared: MemoryStateSpace::Shared
 
   parameter_directions:

--- a/instructions/ptx_spec/data_movement.yaml
+++ b/instructions/ptx_spec/data_movement.yaml
@@ -2,7 +2,7 @@
 # yaml-language-server: $schema=../schemas/ptx-instr-v1.schema.yaml
 
 schema: ptx-instr/v1
-ptx_isa: "9.2"
+ptx_isa: "9.3"
 category: data_movement_and_conversion
 codegen_category: data_movement
 section: "9.7.9"
@@ -404,7 +404,7 @@ instructions:
       Scalar and legacy v2/v4 forms, plus PTX 8.8 256-bit v8 32-bit and v4
       64-bit vector loads through a generic address or explicit global space.
       Alignment and other qualifiers remain separate coverage.
-    syntax: "ld{.const|.global|.local|.param|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} dst, [address]"
+    syntax: "ld{.const|.global|.local|.param|.param::entry|.param::func|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} dst, [address]"
 
     variants:
       - name: ld_generic_scalar
@@ -494,7 +494,7 @@ instructions:
             kind: state_space
             domain: state_spaces
             presence: required
-            values: [const, global, local, param, shared]
+            values: [const, global, local, param, param::entry, param::func, shared]
           - name: cache
             kind: cache
             domain: cache_operators
@@ -601,7 +601,7 @@ instructions:
             kind: state_space
             domain: state_spaces
             presence: required
-            values: [const, global, local, param, shared]
+            values: [const, global, local, param, param::entry, param::func, shared]
           - name: cache
             kind: cache
             domain: cache_operators
@@ -662,7 +662,7 @@ instructions:
       Scalar and legacy v2/v4 forms, plus PTX 8.8 256-bit v8 32-bit and v4
       64-bit vector stores through a generic address or explicit global space.
       Alignment and other qualifiers remain separate coverage.
-    syntax: "st{.global|.local|.param|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} [address], src"
+    syntax: "st{.global|.local|.param|.param::func|.shared}{.v2|.v4|.v8}.{b8|b16|b32|b64|u8|u16|u32|u64|s8|s16|s32|s64|f32|f64} [address], src"
 
     variants:
       - name: st_generic_scalar
@@ -720,7 +720,7 @@ instructions:
             kind: state_space
             domain: state_spaces
             presence: required
-            values: [global, local, param, shared]
+            values: [global, local, param, param::func, shared]
           - name: cache
             kind: cache
             domain: cache_operators
@@ -827,7 +827,7 @@ instructions:
             kind: state_space
             domain: state_spaces
             presence: required
-            values: [global, local, param, shared]
+            values: [global, local, param, param::func, shared]
           - name: cache
             kind: cache
             domain: cache_operators

--- a/instructions/schemas/ptx-instr-v1.schema.yaml
+++ b/instructions/schemas/ptx-instr-v1.schema.yaml
@@ -304,6 +304,8 @@ $defs:
       - global
       - local
       - param
+      - param::entry
+      - param::func
       - shared
       - tex
       - surf

--- a/python/code_gen/gen_resolved_ir.py
+++ b/python/code_gen/gen_resolved_ir.py
@@ -1098,6 +1098,8 @@ def _emit_check_operand_view(field: ResolvedField, object_name: str) -> str:
                   .enclosing_function_kind =
                       {object_name}.{field.name}.value.enclosing_function_kind,
                   .parameter_direction = parameter_direction,
+                  .parameter_qualifier =
+                      {object_name}.{field.name}.value.parameter_qualifier,
                   .locations = {object_name}.{field.name}.locs,
                 }};
               }}()"""

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -708,7 +708,15 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(ld.variants[1].modifiers[0].presence, "required")
         self.assertEqual(
             [value.value for value in ld.variants[1].modifiers[0].values],
-            ["const", "global", "local", "param", "shared"],
+            [
+                "const",
+                "global",
+                "local",
+                "param",
+                "param::entry",
+                "param::func",
+                "shared",
+            ],
         )
         variant = instruction.variants[0]
         explicit_variant = instruction.variants[1]
@@ -957,7 +965,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         store = from_instruction_spec(st)
         self.assertEqual(
             [value.value for value in st.variants[1].modifiers[0].values],
-            ["global", "local", "param", "shared"],
+            ["global", "local", "param", "param::func", "shared"],
         )
         self.assertEqual(
             [variant.cpp_name for variant in store.variants],

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -338,6 +338,9 @@ struct ResolvedAddress {
   std::optional<ResolvedAddressOffset> offset;
   /** Instruction context captured by module resolution; standalone is unknown. */
   EnclosingFunctionKind enclosing_function_kind = EnclosingFunctionKind::Unknown;
+  /** PTX 9.3 .param subqualifier selected by this memory instruction. */
+  ParameterAddressQualifier parameter_qualifier =
+      ParameterAddressQualifier::Default;
   bool operator==(const ResolvedAddress&) const = default;
 };
 

--- a/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
@@ -68,6 +68,13 @@ enum class ParameterDirection : uint8_t {
   CallArgument,
 };
 
+/** PTX 9.3 subqualifier retained for a .param memory access. */
+enum class ParameterAddressQualifier : uint8_t {
+  Default,
+  Entry,
+  Function,
+};
+
 namespace checker {
 using base::ScalarType;
 using base::RoundingMode;
@@ -251,6 +258,8 @@ struct OperandView {
   EnclosingFunctionKind enclosing_function_kind = EnclosingFunctionKind::Unknown;
   /** None unless the base binds a formal or call-argument parameter. */
   ParameterDirection parameter_direction = ParameterDirection::None;
+  ParameterAddressQualifier parameter_qualifier =
+      ParameterAddressQualifier::Default;
   std::array<ScalarType, 8> vector_element_types{};
   uint8_t vector_arity = 0;
   uint8_t vector_sink_count = 0;
@@ -382,6 +391,7 @@ enum class CheckDiagnosticKind : uint8_t {
   AddressStateSpaceMismatch,
   AddressAlignmentMismatch,
   ParameterDirectionMismatch,
+  ParameterQualifierMismatch,
   InvalidVectorOperand,
   MemoryConsistencyViolation,
   RuleViolation,

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -379,6 +379,15 @@ resolve_memory_state_space(const syntax_ast::AstModifier& modifier) {
   return WithLocs<MemoryStateSpace>{*state_space, modifier.syntax.range};
 }
 
+ParameterAddressQualifier parameter_address_qualifier_from_modifier(
+    std::string_view spelling) noexcept {
+  if (spelling == ".param::entry")
+    return ParameterAddressQualifier::Entry;
+  if (spelling == ".param::func")
+    return ParameterAddressQualifier::Function;
+  return ParameterAddressQualifier::Default;
+}
+
 struct ParsedNumberedRegister {
   std::string_view prefix;
   uint32_t index;
@@ -2269,6 +2278,14 @@ std::expected<ResolvedInstructionFields, ResolveDiagnostic> resolve_fields(
                                        fields, context);
     if (!value)
       return std::unexpected(value.error());
+    if (auto* address = std::get_if<WithLocs<ResolvedAddress>>(&*value)) {
+      const auto state_space = actual_modifiers->find("state_space");
+      if (state_space != actual_modifiers->end()) {
+        address->value.parameter_qualifier =
+            parameter_address_qualifier_from_modifier(
+                state_space->second->syntax.text);
+      }
+    }
     const auto [_, inserted] =
         fields.operands.emplace(std::string(field.field_id), std::move(*value));
     if (!inserted) {

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -185,6 +185,50 @@ std::string_view parameter_direction_name(ParameterDirection direction) noexcept
   return "unknown";
 }
 
+std::string_view parameter_qualifier_name(
+    ParameterAddressQualifier qualifier) noexcept {
+  switch (qualifier) {
+    case ParameterAddressQualifier::Default:
+      return ".param";
+    case ParameterAddressQualifier::Entry:
+      return ".param::entry";
+    case ParameterAddressQualifier::Function:
+      return ".param::func";
+  }
+  return ".param";
+}
+
+void append_parameter_qualifier_diagnostics(
+    const OperandDescriptor& descriptor, const OperandView& operand,
+    std::optional<MemoryStateSpace> selected_state_space,
+    const Context& context, CheckDiagnostics& diagnostics) {
+  if (selected_state_space != MemoryStateSpace::Parameter ||
+      operand.parameter_qualifier == ParameterAddressQualifier::Default) {
+    return;
+  }
+
+  bool mismatch = false;
+  if (operand.parameter_qualifier == ParameterAddressQualifier::Entry) {
+    mismatch = operand.enclosing_function_kind == EnclosingFunctionKind::Device ||
+               operand.parameter_direction == ParameterDirection::Return ||
+               operand.parameter_direction == ParameterDirection::CallArgument;
+  } else {
+    mismatch = operand.enclosing_function_kind == EnclosingFunctionKind::Entry &&
+               operand.parameter_direction == ParameterDirection::Input;
+  }
+  if (!mismatch)
+    return;
+
+  diagnostics.push_back(CheckDiagnostic{
+      .kind = CheckDiagnosticKind::ParameterQualifierMismatch,
+      .range = diagnostic_range(operand.locations, context),
+      .message = fmt::format(
+          "Address operand '{}' uses {} for an incompatible parameter context.",
+          descriptor.target_field_id,
+          parameter_qualifier_name(operand.parameter_qualifier)),
+  });
+}
+
 void append_parameter_address_diagnostics(
     const OperandDescriptor& descriptor, const OperandView& operand,
     std::optional<MemoryStateSpace> selected_state_space,
@@ -372,6 +416,9 @@ CheckResult check_operands(
         }
       }
     }
+    append_parameter_qualifier_diagnostics(descriptor, *operand,
+                                           selected_state_space, context,
+                                           diagnostics);
     append_parameter_address_diagnostics(descriptor, *operand,
                                          selected_state_space, context,
                                          diagnostics);

--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -5,6 +5,224 @@
 #include <utility>
 
 namespace ptx_frontend::resolved_ir {
+namespace {
+
+struct CallParameterIdentity {
+  binding::SymbolId symbol;
+  std::optional<uint32_t> parameterized_index;
+  bool operator==(const CallParameterIdentity&) const = default;
+};
+
+std::optional<CallParameterIdentity> call_parameter_identity(
+    const syntax_ast::AstIdentifierRef& identifier,
+    const binding::SymbolTable& symbols, binding::ScopeId scope) {
+  const auto lookup = symbols.lookup(scope, identifier.syntax.text);
+  if (!lookup || symbols.symbol(lookup->symbol).kind !=
+                     binding::SymbolKind::CallParameter) {
+    return std::nullopt;
+  }
+  return CallParameterIdentity{
+      .symbol = lookup->symbol,
+      .parameterized_index = lookup->parameterized_index};
+}
+
+bool has_parameter_modifier(const syntax_ast::AstInstruction& instruction) {
+  for (const auto& modifier : instruction.modifiers) {
+    if (modifier.syntax.text == ".param" ||
+        modifier.syntax.text == ".param::entry" ||
+        modifier.syntax.text == ".param::func") {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<CallParameterIdentity> staging_parameter(
+    const syntax_ast::AstInstruction& instruction,
+    const binding::SymbolTable& symbols, binding::ScopeId scope) {
+  const bool is_load = instruction.opcode.syntax.text == "ld";
+  const bool is_store = instruction.opcode.syntax.text == "st";
+  if ((!is_load && !is_store) || !has_parameter_modifier(instruction))
+    return std::nullopt;
+
+  const size_t address_index = is_load ? 1 : 0;
+  if (instruction.operands.size() <= address_index)
+    return std::nullopt;
+  const auto* address =
+      std::get_if<syntax_ast::AstAddress>(&instruction.operands[address_index]);
+  if (address == nullptr || !address->bracketed)
+    return std::nullopt;
+  const auto* identifier =
+      std::get_if<syntax_ast::AstIdentifierRef>(&address->base);
+  if (identifier == nullptr)
+    return std::nullopt;
+  return call_parameter_identity(*identifier, symbols, scope);
+}
+
+bool is_staging_store(const syntax_ast::AstFunctionBodyItem& item,
+                      const binding::SymbolTable& symbols,
+                      binding::ScopeId scope) {
+  const auto* instruction = std::get_if<syntax_ast::AstInstruction>(&item);
+  return instruction != nullptr && instruction->opcode.syntax.text == "st" &&
+         staging_parameter(*instruction, symbols, scope).has_value();
+}
+
+bool is_staging_load(const syntax_ast::AstFunctionBodyItem& item,
+                     const binding::SymbolTable& symbols,
+                     binding::ScopeId scope) {
+  const auto* instruction = std::get_if<syntax_ast::AstInstruction>(&item);
+  return instruction != nullptr && instruction->opcode.syntax.text == "ld" &&
+         staging_parameter(*instruction, symbols, scope).has_value();
+}
+
+bool call_uses_parameter(const syntax_ast::AstInstruction& call,
+                         syntax_ast::AstCallParameterListKind group_kind,
+                         const CallParameterIdentity& parameter,
+                         const binding::SymbolTable& symbols,
+                         binding::ScopeId scope) {
+  if (call.opcode.syntax.text != "call")
+    return false;
+  for (const auto& operand : call.operands) {
+    const auto* group = std::get_if<syntax_ast::AstCallParameterList>(&operand);
+    if (group == nullptr || group->kind != group_kind)
+      continue;
+    for (const auto& value : group->parameters) {
+      const auto* identifier =
+          std::get_if<syntax_ast::AstIdentifierRef>(&value);
+      if (identifier &&
+          call_parameter_identity(*identifier, symbols, scope) == parameter) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void check_parameter_qualifier(const syntax_ast::AstFunction& function,
+                               const syntax_ast::AstInstruction& instruction,
+                               const binding::SymbolTable& symbols,
+                               binding::ScopeId scope,
+                               ModuleResolveDiagnostics& diagnostics) {
+  std::string_view qualifier;
+  for (const auto& modifier : instruction.modifiers) {
+    if (modifier.syntax.text == ".param::entry" ||
+        modifier.syntax.text == ".param::func") {
+      qualifier = modifier.syntax.text;
+      break;
+    }
+  }
+  if (qualifier.empty())
+    return;
+
+  const bool is_load = instruction.opcode.syntax.text == "ld";
+  const bool is_store = instruction.opcode.syntax.text == "st";
+  const size_t address_index = is_load ? 1 : 0;
+  if ((!is_load && !is_store) || instruction.operands.size() <= address_index)
+    return;
+  const auto* address =
+      std::get_if<syntax_ast::AstAddress>(&instruction.operands[address_index]);
+  if (address == nullptr || !address->bracketed)
+    return;
+  const auto* identifier =
+      std::get_if<syntax_ast::AstIdentifierRef>(&address->base);
+  if (identifier == nullptr)
+    return;
+  const auto lookup = symbols.lookup(scope, identifier->syntax.text);
+  if (!lookup)
+    return;
+  const binding::SymbolKind kind = symbols.symbol(lookup->symbol).kind;
+
+  const bool valid =
+      qualifier == ".param::entry"
+          ? function.is_entry && kind == binding::SymbolKind::InputParameter
+          : kind == binding::SymbolKind::CallParameter || !function.is_entry;
+  if (!valid) {
+    diagnostics.push_back(ResolveDiagnostic{
+        .range = instruction.range,
+        .message = qualifier == ".param::entry"
+                       ? ".param::entry may access only a kernel entry input "
+                         "parameter."
+                       : ".param::func may access only a device-function "
+                         "parameter or function-local call parameter.",
+    });
+  }
+}
+
+void check_call_staging(const syntax_ast::AstFunction& function,
+                        const binding::SymbolTable& symbols,
+                        binding::ScopeId scope,
+                        ModuleResolveDiagnostics& diagnostics) {
+  for (size_t index = 0; index < function.body.size(); ++index) {
+    const auto* instruction =
+        std::get_if<syntax_ast::AstInstruction>(&function.body[index]);
+    if (instruction == nullptr)
+      continue;
+
+    check_parameter_qualifier(function, *instruction, symbols, scope,
+                              diagnostics);
+    const auto parameter = staging_parameter(*instruction, symbols, scope);
+    if (!parameter)
+      continue;
+    const bool is_store = instruction->opcode.syntax.text == "st";
+    if (instruction->predicate) {
+      diagnostics.push_back(ResolveDiagnostic{
+          .range = instruction->predicate->range,
+          .message =
+              is_store
+                  ? "A function-local .param argument store cannot be "
+                    "predicated."
+                  : "A function-local .param return load cannot be predicated.",
+      });
+      continue;
+    }
+
+    if (is_store) {
+      size_t call_index = index + 1;
+      while (call_index < function.body.size() &&
+             is_staging_store(function.body[call_index], symbols, scope)) {
+        ++call_index;
+      }
+      const auto* call = call_index < function.body.size()
+                             ? std::get_if<syntax_ast::AstInstruction>(
+                                   &function.body[call_index])
+                             : nullptr;
+      if (call == nullptr ||
+          !call_uses_parameter(*call,
+                               syntax_ast::AstCallParameterListKind::Input,
+                               *parameter, symbols, scope)) {
+        diagnostics.push_back(ResolveDiagnostic{
+            .range = instruction->range,
+            .message =
+                "A function-local .param argument store must be in the "
+                "contiguous block immediately before a call that uses it.",
+        });
+      }
+      continue;
+    }
+
+    size_t call_index = index;
+    while (call_index > 0 &&
+           is_staging_load(function.body[call_index - 1], symbols, scope)) {
+      --call_index;
+    }
+    const auto* call = call_index > 0 ? std::get_if<syntax_ast::AstInstruction>(
+                                            &function.body[call_index - 1])
+                                      : nullptr;
+    if (call == nullptr ||
+        !call_uses_parameter(*call,
+                             syntax_ast::AstCallParameterListKind::Return,
+                             *parameter, symbols, scope)) {
+      diagnostics.push_back(ResolveDiagnostic{
+          .range = instruction->range,
+          .message =
+              "A function-local .param return load must be in the contiguous "
+              "block immediately after a call that returns it.",
+      });
+    }
+  }
+}
+
+}  // namespace
 
 std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
     const syntax_ast::AstModule& ast) {
@@ -71,6 +289,8 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
       }
       resolved_function.body.push_back(std::move(*resolved));
     }
+    check_call_staging(*function, binding_result.table, *symbol.owned_scope,
+                       diagnostics);
     functions.push_back(std::move(resolved_function));
   }
 

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -2346,6 +2346,126 @@ TEST(ResolvedModule, ResolvesDirectCallGroupsAndPreservesBindings) {
             checker::CheckDiagnosticKind::InvalidOperandLayoutTag);
 }
 
+TEST(ResolvedModule, EnforcesPtx93CallParameterContexts) {
+  const auto ast = parseModule(R"ptx(
+.func callee(.param .u32 input);
+.entry caller(.param .u32 entry_input) {
+  .reg .pred %p;
+  .reg .u32 %r0;
+  .param .u32 input0, input1, output;
+  ld.param::entry.u32 %r0, [entry_input];
+  ld.param.u32 %r0, [entry_input];
+  st.param::func.u32 [input0], %r0;
+  st.param.u32 [input1], %r0;
+  @%p call.uni (output), callee, (input0, input1);
+  ld.param::func.u32 %r0, [output];
+}
+.func device(.param .u32 input) {
+  .reg .u32 %r0;
+  ld.param::func.u32 %r0, [input];
+  ld.param.u32 %r0, [input];
+}
+)ptx");
+
+  const auto resolved = resolveModule(ast);
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& caller = resolved->functions[1].body;
+  ASSERT_EQ(caller.size(), 6u);
+  const auto& entry_load = std::get<Ld::ExplicitScalar>(
+      std::get<Ld>(caller[0]).variant);
+  EXPECT_EQ(entry_load.address.value.parameter_qualifier,
+            ParameterAddressQualifier::Entry);
+  const auto& staged_store = std::get<St::ExplicitScalar>(
+      std::get<St>(caller[2]).variant);
+  EXPECT_EQ(staged_store.address.value.parameter_qualifier,
+            ParameterAddressQualifier::Function);
+  const auto& default_load = std::get<Ld::ExplicitScalar>(
+      std::get<Ld>(caller[1]).variant);
+  EXPECT_EQ(default_load.address.value.parameter_qualifier,
+            ParameterAddressQualifier::Default);
+  const auto& call = std::get<Call>(caller[4]);
+  EXPECT_TRUE(call.execution_predicate.has_value());
+  EXPECT_TRUE(std::get<Call::Direct>(call.variant).uni.value);
+  const auto& return_load = std::get<Ld::ExplicitScalar>(
+      std::get<Ld>(caller[5]).variant);
+  EXPECT_EQ(return_load.address.value.parameter_qualifier,
+            ParameterAddressQualifier::Function);
+}
+
+TEST(ResolvedModule, RejectsInvalidPtx93CallParameterContexts) {
+  const auto resolve_source = [](std::string_view body) {
+    return resolveModule(parseModule(fmt::format(R"ptx(
+.func callee(.param .u32 input);
+.entry caller(.param .u32 entry_input) {{
+  .reg .pred %p;
+  .reg .u32 %r0;
+  .param .u32 input, other, output;
+  {}
+}}
+.func device(.param .u32 input) {{
+  .reg .u32 %r0;
+  ld.param::entry.u32 %r0, [input];
+}}
+)ptx",
+                                                body)));
+  };
+
+  const auto entry_as_function = resolve_source(
+      "ld.param::func.u32 %r0, [entry_input];");
+  ASSERT_FALSE(entry_as_function.has_value());
+  EXPECT_EQ(entry_as_function.error().front().message,
+            ".param::func may access only a device-function parameter or "
+            "function-local call parameter.");
+
+  const auto device_as_entry = resolve_source("mov.u32 %r0, %r0;");
+  ASSERT_FALSE(device_as_entry.has_value());
+  EXPECT_EQ(device_as_entry.error().front().message,
+            ".param::entry may access only a kernel entry input parameter.");
+
+  const auto predicated_store = resolve_source(
+      "@%p st.param.u32 [input], %r0;\n  call callee, (input);");
+  ASSERT_FALSE(predicated_store.has_value());
+  EXPECT_EQ(predicated_store.error().front().message,
+            "A function-local .param argument store cannot be predicated.");
+
+  const auto non_adjacent_store = resolve_source(
+      "st.param.u32 [input], %r0;\n  mov.u32 %r0, %r0;\n  call callee, (input);");
+  ASSERT_FALSE(non_adjacent_store.has_value());
+  EXPECT_EQ(non_adjacent_store.error().front().message,
+            "A function-local .param argument store must be in the contiguous "
+            "block immediately before a call that uses it.");
+
+  const auto wrong_call_argument = resolve_source(
+      "st.param.u32 [input], %r0;\n  call callee, (other);");
+  ASSERT_FALSE(wrong_call_argument.has_value());
+  EXPECT_EQ(wrong_call_argument.error().front().message,
+            "A function-local .param argument store must be in the contiguous "
+            "block immediately before a call that uses it.");
+
+  const auto predicated_return_load = resolve_source(
+      "call (output), callee, ();\n  @%p ld.param.u32 %r0, [output];");
+  ASSERT_FALSE(predicated_return_load.has_value());
+  EXPECT_EQ(predicated_return_load.error().front().message,
+            "A function-local .param return load cannot be predicated.");
+
+  const auto non_adjacent_return_load = resolve_source(
+      "call (output), callee, ();\n  mov.u32 %r0, %r0;\n  ld.param.u32 %r0, [output];");
+  ASSERT_FALSE(non_adjacent_return_load.has_value());
+  EXPECT_EQ(non_adjacent_return_load.error().front().message,
+            "A function-local .param return load must be in the contiguous "
+            "block immediately after a call that returns it.");
+
+  const auto entry_store = resolveModule(parseModule(R"ptx(
+.entry caller() {
+  .reg .u32 %r0;
+  .param .u32 output;
+  st.param::entry.u32 [output], %r0;
+}
+)ptx"));
+  EXPECT_FALSE(entry_store.has_value());
+}
+
 TEST(ResolvedModule, RejectsIndirectCallsUntilTargetMetadataExists) {
   const auto indirect = parseModule(R"ptx(
 .entry caller() {


### PR DESCRIPTION
## Summary
- Add PTX 9.3 .param::entry and .param::func qualifiers with context validation.
- Enforce call-parameter staging adjacency and reject predicated st/ld staging operations.
- Preserve and accept predicated call.uni forms.

## Validation
- Full build passed.
- CTest: 202/202 passed.
- Python unittest: 21/21 targeted and 63/63 full passed.
- M6-I08 focused CTest: 3/3 passed.