### PR TITLE
Check direct call ABI compatibility

### DIFF
--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -1,11 +1,325 @@
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
 
+#include <ptx_frontend/semantic/ptx_call_argument_compatibility.hpp>
 #include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
 
+#include <algorithm>
+#include <charconv>
+#include <limits>
+#include <ranges>
+#include <unordered_map>
 #include <utility>
+
+#include <fmt/format.h>
 
 namespace ptx_frontend::resolved_ir {
 namespace {
+
+using call_argument_compatibility::CallArgumentCompatibility;
+using call_argument_compatibility::CallArgumentProperties;
+using call_argument_compatibility::CallArgumentStateSpace;
+using call_argument_compatibility::PointedStateSpace;
+
+using CallArgumentPropertyIndex =
+    std::unordered_map<uint32_t, CallArgumentProperties>;
+using FunctionSignatureIndex =
+    std::unordered_map<uint32_t, declaration_semantics::FunctionSignature>;
+
+std::optional<CallArgumentStateSpace> call_state_space(
+    syntax_ast::AstStateSpace state_space) {
+  switch (state_space) {
+    case syntax_ast::AstStateSpace::Register:
+      return CallArgumentStateSpace::Register;
+    case syntax_ast::AstStateSpace::Parameter:
+      return CallArgumentStateSpace::Parameter;
+    case syntax_ast::AstStateSpace::Local:
+      return CallArgumentStateSpace::Local;
+    case syntax_ast::AstStateSpace::Shared:
+      return CallArgumentStateSpace::Shared;
+    case syntax_ast::AstStateSpace::Global:
+      return CallArgumentStateSpace::Global;
+    case syntax_ast::AstStateSpace::Constant:
+      return CallArgumentStateSpace::Constant;
+  }
+  return std::nullopt;
+}
+
+std::optional<PointedStateSpace> pointed_state_space(
+    const std::optional<std::string>& spelling) {
+  if (!spelling)
+    return std::nullopt;
+  if (*spelling == ".local")
+    return PointedStateSpace::Local;
+  if (*spelling == ".shared")
+    return PointedStateSpace::Shared;
+  if (*spelling == ".global")
+    return PointedStateSpace::Global;
+  if (*spelling == ".const")
+    return PointedStateSpace::Constant;
+  return std::nullopt;
+}
+
+std::optional<uint64_t> unsigned_value(std::string_view spelling) {
+  if (!spelling.empty() && (spelling.back() == 'u' || spelling.back() == 'U'))
+    spelling.remove_suffix(1);
+  uint64_t value = 0;
+  const auto [end, error] = std::from_chars(
+      spelling.data(), spelling.data() + spelling.size(), value);
+  if (spelling.empty() || error != std::errc{} ||
+      end != spelling.data() + spelling.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+std::optional<uint64_t> contract_array_size(
+    const declaration_semantics::FunctionParameterContract& contract) {
+  if (!contract.array_extent || contract.array_extent->empty() ||
+      contract.array_extent->front() != '#') {
+    return std::nullopt;
+  }
+  return unsigned_value(std::string_view{*contract.array_extent}.substr(1));
+}
+
+CallArgumentProperties call_argument_properties(
+    const declaration_semantics::FunctionParameterContract& contract) {
+  CallArgumentProperties properties{
+      .state_space = *call_state_space(contract.state_space),
+      .type_spelling = contract.type,
+      .array_alignment = contract.alignment
+                             ? unsigned_value(*contract.alignment).value_or(1)
+                             : 1,
+      .is_array = contract.is_array,
+      .array_size = contract_array_size(contract),
+  };
+  if (contract.is_pointer) {
+    const uint64_t pointer_alignment =
+        contract.pointer_alignment
+            ? unsigned_value(*contract.pointer_alignment).value_or(4)
+            : 4;
+    properties.pointer = {
+        .pointed_state_space = pointed_state_space(contract.pointer_space),
+        .pointed_alignment = pointer_alignment,
+    };
+  }
+  return properties;
+}
+
+std::optional<uint64_t> array_size(
+    const syntax_ast::AstVariableDeclarator& declarator) {
+  if (declarator.array_dimensions.empty())
+    return std::nullopt;
+  uint64_t size = 1;
+  for (const auto& dimension : declarator.array_dimensions) {
+    if (!dimension.size)
+      return std::nullopt;
+    const auto extent =
+        declaration_semantics::constantArrayExtent(*dimension.size);
+    if (!extent || (*extent != 0 &&
+                    size > std::numeric_limits<uint64_t>::max() / *extent)) {
+      return std::nullopt;
+    }
+    size *= *extent;
+  }
+  return size;
+}
+
+CallArgumentProperties call_argument_properties(
+    const syntax_ast::AstVariableDeclaration& declaration,
+    const syntax_ast::AstVariableDeclarator& declarator,
+    const binding::Symbol& symbol) {
+  return {
+      .state_space = *call_state_space(declaration.state_space),
+      .type_spelling = declaration.vector_type ? declaration.vector_type->text +
+                                                     " " + declaration.type.text
+                                               : declaration.type.text,
+      .array_alignment = symbol.address_alignment.value_or(1),
+      .is_array = !declarator.array_dimensions.empty(),
+      .array_size = array_size(declarator),
+  };
+}
+
+std::optional<binding::SymbolId> declared_symbol(
+    const binding::SymbolTable& symbols, binding::ScopeId scope,
+    const syntax_ast::AstVariableDeclarator& declarator) {
+  const bool parameterized = declarator.parameterized_count.has_value();
+  const auto found = std::ranges::find_if(symbols.symbols(),
+                                          [&](const binding::Symbol& symbol) {
+    return symbol.scope == scope &&
+           symbol.name == declarator.name.syntax.text &&
+           symbol.parameterized_count.has_value() == parameterized;
+  });
+  if (found == symbols.symbols().end())
+    return std::nullopt;
+  return found->id;
+}
+
+void index_function_call_arguments(const syntax_ast::AstFunction& function,
+                                   const binding::SymbolTable& symbols,
+                                   binding::ScopeId scope,
+                                   CallArgumentPropertyIndex& properties) {
+  const auto signature = declaration_semantics::functionSignature(function);
+  const auto index_parameters = [&](const auto& parameters,
+                                    const auto& contracts) {
+    for (size_t index = 0; index < parameters.size(); ++index) {
+      const auto lookup =
+          symbols.lookup(scope, parameters[index].name.syntax.text);
+      if (lookup) {
+        properties.emplace(lookup->symbol.value,
+                           call_argument_properties(contracts[index]));
+      }
+    }
+  };
+  index_parameters(function.return_parameters, signature.return_parameters);
+  index_parameters(function.parameters, signature.parameters);
+  for (const auto& item : function.body) {
+    const auto* declaration =
+        std::get_if<syntax_ast::AstVariableDeclaration>(&item);
+    if (declaration == nullptr)
+      continue;
+    for (const auto& declarator : declaration->declarators) {
+      const auto symbol_id = declared_symbol(symbols, scope, declarator);
+      if (symbol_id) {
+        properties.emplace(
+            symbol_id->value,
+            call_argument_properties(*declaration, declarator,
+                                     symbols.symbol(*symbol_id)));
+      }
+    }
+  }
+}
+
+std::string_view compatibility_message(
+    CallArgumentCompatibility compatibility) {
+  switch (compatibility) {
+    case CallArgumentCompatibility::Compatible:
+      return "compatible";
+    case CallArgumentCompatibility::FormalStateSpaceMismatch:
+      return "callee formal has an invalid call state space";
+    case CallArgumentCompatibility::ActualStateSpaceMismatch:
+      return "call argument state-space mismatch";
+    case CallArgumentCompatibility::TypeMismatch:
+      return "type or vector shape mismatch";
+    case CallArgumentCompatibility::ArrayMismatch:
+      return "array shape mismatch";
+    case CallArgumentCompatibility::ArraySizeMismatch:
+      return "array size mismatch";
+    case CallArgumentCompatibility::AlignmentMismatch:
+      return "array alignment mismatch";
+    case CallArgumentCompatibility::PointerMismatch:
+      return "pointer qualification mismatch";
+    case CallArgumentCompatibility::PointedStateSpaceMismatch:
+      return "pointed state-space mismatch";
+    case CallArgumentCompatibility::PointedAlignmentMismatch:
+      return "pointed alignment mismatch";
+  }
+  return "incompatible";
+}
+
+void check_direct_call_abi(const syntax_ast::AstInstruction& call,
+                           const binding::SymbolTable& symbols,
+                           binding::ScopeId scope,
+                           const FunctionSignatureIndex& signatures,
+                           const CallArgumentPropertyIndex& properties,
+                           ModuleResolveDiagnostics& diagnostics) {
+  if (call.opcode.syntax.text != "call")
+    return;
+
+  const syntax_ast::AstCallTarget* target = nullptr;
+  const syntax_ast::AstCallParameterList* returns = nullptr;
+  const syntax_ast::AstCallParameterList* inputs = nullptr;
+  for (const auto& operand : call.operands) {
+    if (const auto* value = std::get_if<syntax_ast::AstCallTarget>(&operand))
+      target = value;
+    else if (const auto* value =
+                 std::get_if<syntax_ast::AstCallParameterList>(&operand)) {
+      if (value->kind == syntax_ast::AstCallParameterListKind::Return)
+        returns = value;
+      else
+        inputs = value;
+    }
+  }
+  if (target == nullptr)
+    return;  // indirect calls remain outside M6-C01.
+
+  const auto target_lookup = symbols.lookup(scope, target->name.syntax.text);
+  if (!target_lookup || symbols.symbol(target_lookup->symbol).kind !=
+                            binding::SymbolKind::Function)
+    return;
+  const auto signature = signatures.find(target_lookup->symbol.value);
+  if (signature == signatures.end())
+    return;
+
+  const auto check_group = [&](std::string_view kind, const auto* actuals,
+                               const auto& formals) {
+    const size_t actual_count =
+        actuals == nullptr ? 0 : actuals->parameters.size();
+    if (actual_count != formals.size()) {
+      diagnostics.push_back(ResolveDiagnostic{
+          .range = actuals == nullptr ? target->range : actuals->range,
+          .message = fmt::format("Direct call to '{}' has {} {} argument{} but "
+                                 "callee requires {}.",
+                                 target->name.syntax.text, actual_count, kind,
+                                 actual_count == 1 ? "" : "s", formals.size()),
+      });
+    }
+    if (actuals == nullptr)
+      return;
+    const size_t count = std::min(actuals->parameters.size(), formals.size());
+    for (size_t index = 0; index < count; ++index) {
+      const auto& actual = actuals->parameters[index];
+      const SourceRange range = std::visit(
+          [](const auto& value) { return value.syntax.range; }, actual);
+      const auto formal_properties = call_argument_properties(formals[index]);
+      CallArgumentProperties actual_properties;
+      if (const auto* immediate =
+              std::get_if<syntax_ast::AstImmediate>(&actual)) {
+        const auto literal = resolve_call_literal(
+            ResolvedCallLiteral{.spelling = immediate->syntax.text,
+                                .kind = immediate->kind},
+            range, formals[index]);
+        if (!literal) {
+          diagnostics.push_back(std::move(literal.error()));
+          continue;
+        }
+        actual_properties = {
+            .state_space = CallArgumentStateSpace::Register,
+            .type_spelling = formals[index].type,
+        };
+      } else {
+        const auto& identifier =
+            std::get<syntax_ast::AstIdentifierRef>(actual);
+        const auto actual_lookup =
+            symbols.lookup(scope, identifier.syntax.text);
+        if (!actual_lookup) {
+          throw ResolveException(fmt::format(
+              "Bound call argument '{}' has no symbol.", identifier.syntax.text));
+        }
+        const auto properties_it = properties.find(actual_lookup->symbol.value);
+        if (properties_it == properties.end()) {
+          throw ResolveException(fmt::format(
+              "Bound call argument '{}' has no ABI properties.",
+              identifier.syntax.text));
+        }
+        actual_properties = properties_it->second;
+      }
+      const auto compatibility =
+          call_argument_compatibility::checkCallArgumentCompatibility(
+              formal_properties, actual_properties);
+      if (compatibility != CallArgumentCompatibility::Compatible) {
+        diagnostics.push_back(ResolveDiagnostic{
+            .range = range,
+            .message = fmt::format(
+                "Direct call {} argument {} for '{}' has {}.", kind, index + 1,
+                target->name.syntax.text, compatibility_message(compatibility)),
+        });
+      }
+    }
+  };
+
+  check_group("return", returns, signature->second.return_parameters);
+  check_group("input", inputs, signature->second.parameters);
+}
 
 struct CallParameterIdentity {
   binding::SymbolId symbol;
@@ -246,6 +560,26 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
   if (!diagnostics.empty())
     return std::unexpected(std::move(diagnostics));
 
+  FunctionSignatureIndex signatures;
+  CallArgumentPropertyIndex call_argument_properties;
+  for (const syntax_ast::AstModuleItem& item : ast.items) {
+    const auto* function = std::get_if<syntax_ast::AstFunction>(&item);
+    if (function == nullptr)
+      continue;
+    const auto lookup = binding_result.table.lookup(
+        binding_result.table.moduleScope(), function->name.syntax.text);
+    if (!lookup)
+      continue;
+    signatures.try_emplace(lookup->symbol.value,
+                           declaration_semantics::functionSignature(*function));
+    const binding::Symbol& symbol = binding_result.table.symbol(lookup->symbol);
+    if (symbol.owned_scope) {
+      index_function_call_arguments(*function, binding_result.table,
+                                    *symbol.owned_scope,
+                                    call_argument_properties);
+    }
+  }
+
   std::vector<ResolvedFunction> functions;
   for (const syntax_ast::AstModuleItem& item : ast.items) {
     const auto* function = std::get_if<syntax_ast::AstFunction>(&item);
@@ -287,6 +621,9 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
         diagnostics.push_back(std::move(resolved.error()));
         continue;
       }
+      check_direct_call_abi(*instruction, binding_result.table,
+                            *symbol.owned_scope, signatures,
+                            call_argument_properties, diagnostics);
       resolved_function.body.push_back(std::move(*resolved));
     }
     check_call_staging(*function, binding_result.table, *symbol.owned_scope,

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -2282,14 +2282,17 @@ TEST(ResolvedModule, StandaloneBranchTargetRemainsUnbound) {
 
 TEST(ResolvedModule, ResolvesDirectCallGroupsAndPreservesBindings) {
   const auto ast = parseModule(R"ptx(
-.func callee(.param .u32 input);
+.func callee();
+.func callee_empty();
+.func (.param .u32 result) callee_full(
+    .param .u32 input0, .param .u32 input1, .param .s32 literal);
 .entry caller() {
   .reg .pred %p;
   .reg .u32 %out, %arg;
   .param .u32 parameter;
   call callee;
-  call callee, ();
-  @%p call.uni (%out), callee, (%arg, parameter, -4);
+  call callee_empty, ();
+  @%p call.uni (%out), callee_full, (%arg, parameter, -4);
 }
 )ptx");
 
@@ -2346,9 +2349,104 @@ TEST(ResolvedModule, ResolvesDirectCallGroupsAndPreservesBindings) {
             checker::CheckDiagnosticKind::InvalidOperandLayoutTag);
 }
 
+TEST(ResolvedModule, ChecksDirectCallAbiForMixedParametersAndLiterals) {
+  const auto resolved = resolveModule(parseModule(R"ptx(
+.func (.param .u32 result) callee(
+    .reg .u32 register_input, .param .u32 parameter_input,
+    .param .s16 literal_input, .reg .u32 parameterized_register_input);
+.entry caller() {
+  .reg .u32 register_argument;
+  .reg .u32 %r<1>;
+  .param .u32 parameter_argument, return_argument;
+  call (return_argument), callee,
+      (register_argument, parameter_argument, -4, %r0);
+}
+)ptx"));
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+}
+
+TEST(ResolvedModule, ReportsDirectCallAbiArityMismatches) {
+  const auto resolved = resolveModule(parseModule(R"ptx(
+.func (.param .u32 return0, .param .u32 return1) callee(
+    .param .u32 input0, .param .u32 input1);
+.entry caller() {
+  .param .u32 return0, input0;
+  call (return0), callee, (input0);
+}
+)ptx"));
+
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), 2u);
+  EXPECT_EQ(resolved.error()[0].message,
+            "Direct call to 'callee' has 1 return argument but callee requires "
+            "2.");
+  EXPECT_EQ(resolved.error()[1].message,
+            "Direct call to 'callee' has 1 input argument but callee requires "
+            "2.");
+}
+
+TEST(ResolvedModule, ReportsDirectCallAbiPropertyAndLiteralMismatches) {
+  const auto resolved = resolveModule(parseModule(R"ptx(
+.func scalar(.param .u32 input);
+.func bytes(.param .align 16 .b8 input[8]);
+.func pointer(.param .u64 .ptr .global .align 16 input);
+.func literal(.param .u16 input);
+.entry caller(.param .u64 .ptr .shared .align 32 wrong_space,
+              .param .u64 .ptr .global .align 8 weak_alignment) {
+  .reg .v2 .u32 vector_argument;
+  .reg .b8 register_byte;
+  .param .align 16 .b8 wrong_size[4];
+  .param .align 8 .b8 weak_array_alignment[8];
+  call scalar, (vector_argument);
+  call bytes, (register_byte);
+  call bytes, (wrong_size);
+  call bytes, (weak_array_alignment);
+  call pointer, (wrong_space);
+  call pointer, (weak_alignment);
+  call literal, (1.5);
+  call literal, (65536);
+  call bytes, (1);
+  call pointer, (1);
+}
+)ptx"));
+
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), 10u);
+  EXPECT_EQ(resolved.error()[0].message,
+            "Direct call input argument 1 for 'scalar' has type or vector "
+            "shape mismatch.");
+  EXPECT_EQ(resolved.error()[1].message,
+            "Direct call input argument 1 for 'bytes' has call argument "
+            "state-space mismatch.");
+  EXPECT_EQ(
+      resolved.error()[2].message,
+      "Direct call input argument 1 for 'bytes' has array size mismatch.");
+  EXPECT_EQ(resolved.error()[3].message,
+            "Direct call input argument 1 for 'bytes' has array alignment "
+            "mismatch.");
+  EXPECT_EQ(resolved.error()[4].message,
+            "Direct call input argument 1 for 'pointer' has pointed "
+            "state-space mismatch.");
+  EXPECT_EQ(resolved.error()[5].message,
+            "Direct call input argument 1 for 'pointer' has pointed alignment "
+            "mismatch.");
+  EXPECT_EQ(resolved.error()[6].message,
+            "Decimal floating literal '1.5' is incompatible with scalar type "
+            "'U16'.");
+  EXPECT_EQ(resolved.error()[7].message,
+            "Integer literal '65536' is out of range for scalar type 'U16'.");
+  EXPECT_EQ(resolved.error()[8].message,
+            "Direct call input argument 1 for 'bytes' has call argument "
+            "state-space mismatch.");
+  EXPECT_EQ(resolved.error()[9].message,
+            "Direct call input argument 1 for 'pointer' has pointer "
+            "qualification mismatch.");
+}
+
 TEST(ResolvedModule, EnforcesPtx93CallParameterContexts) {
   const auto ast = parseModule(R"ptx(
-.func callee(.param .u32 input);
+.func (.param .u32 result) callee(.param .u32 input0, .param .u32 input1);
 .entry caller(.param .u32 entry_input) {
   .reg .pred %p;
   .reg .u32 %r0;
@@ -2396,7 +2494,7 @@ TEST(ResolvedModule, EnforcesPtx93CallParameterContexts) {
 TEST(ResolvedModule, RejectsInvalidPtx93CallParameterContexts) {
   const auto resolve_source = [](std::string_view body) {
     return resolveModule(parseModule(fmt::format(R"ptx(
-.func callee(.param .u32 input);
+.func (.param .u32 result) callee(.param .u32 input);
 .entry caller(.param .u32 entry_input) {{
   .reg .pred %p;
   .reg .u32 %r0;
@@ -2424,33 +2522,33 @@ TEST(ResolvedModule, RejectsInvalidPtx93CallParameterContexts) {
             ".param::entry may access only a kernel entry input parameter.");
 
   const auto predicated_store = resolve_source(
-      "@%p st.param.u32 [input], %r0;\n  call callee, (input);");
+      "@%p st.param.u32 [input], %r0;\n  call (output), callee, (input);");
   ASSERT_FALSE(predicated_store.has_value());
   EXPECT_EQ(predicated_store.error().front().message,
             "A function-local .param argument store cannot be predicated.");
 
   const auto non_adjacent_store = resolve_source(
-      "st.param.u32 [input], %r0;\n  mov.u32 %r0, %r0;\n  call callee, (input);");
+      "st.param.u32 [input], %r0;\n  mov.u32 %r0, %r0;\n  call (output), callee, (input);");
   ASSERT_FALSE(non_adjacent_store.has_value());
   EXPECT_EQ(non_adjacent_store.error().front().message,
             "A function-local .param argument store must be in the contiguous "
             "block immediately before a call that uses it.");
 
   const auto wrong_call_argument = resolve_source(
-      "st.param.u32 [input], %r0;\n  call callee, (other);");
+      "st.param.u32 [input], %r0;\n  call (output), callee, (other);");
   ASSERT_FALSE(wrong_call_argument.has_value());
   EXPECT_EQ(wrong_call_argument.error().front().message,
             "A function-local .param argument store must be in the contiguous "
             "block immediately before a call that uses it.");
 
   const auto predicated_return_load = resolve_source(
-      "call (output), callee, ();\n  @%p ld.param.u32 %r0, [output];");
+      "call (output), callee, (input);\n  @%p ld.param.u32 %r0, [output];");
   ASSERT_FALSE(predicated_return_load.has_value());
   EXPECT_EQ(predicated_return_load.error().front().message,
             "A function-local .param return load cannot be predicated.");
 
   const auto non_adjacent_return_load = resolve_source(
-      "call (output), callee, ();\n  mov.u32 %r0, %r0;\n  ld.param.u32 %r0, [output];");
+      "call (output), callee, (input);\n  mov.u32 %r0, %r0;\n  ld.param.u32 %r0, [output];");
   ASSERT_FALSE(non_adjacent_return_load.has_value());
   EXPECT_EQ(non_adjacent_return_load.error().front().message,
             "A function-local .param return load must be in the contiguous "

--- a/submod/semantic/include/ptx_declaration_semantics.hpp
+++ b/submod/semantic/include/ptx_declaration_semantics.hpp
@@ -40,6 +40,10 @@ struct FunctionSignature {
 [[nodiscard]] FunctionSignature functionSignature(
     const syntax_ast::AstFunction& function);
 
+/** Return a nonnegative constant array extent when the expression has one. */
+[[nodiscard]] std::optional<uint64_t> constantArrayExtent(
+    const syntax_ast::AstConstantExpression& expression);
+
 enum class DeclarationDiagnosticKind : uint8_t {
   InvalidArrayDimension,
   UnsizedArrayDimension,

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -871,6 +871,11 @@ FunctionSignature functionSignature(const syntax_ast::AstFunction& function) {
   return signature;
 }
 
+std::optional<uint64_t> constantArrayExtent(
+    const syntax_ast::AstConstantExpression& expression) {
+  return nonnegativeIntegerValue(classifyExpression(expression));
+}
+
 std::vector<DeclarationDiagnostic> checkDeclarations(
     const syntax_ast::AstModule& module, const binding::SymbolTable& symbols) {
   return Checker{symbols}.run(module);


### PR DESCRIPTION
## Summary
- Validate direct call ABI compatibility using the canonical I04 functionSignature, I05 resolve_call_literal, and I06 checkCallArgumentCompatibility paths.
- Cover arity/order, identifiers/literals, arrays/alignment, pointers, and parameterized register properties while keeping standalone and indirect calls unchanged.

## Validation
- Full build passed.
- CTest: 213/213 passed.
- Python unittest: 21/21 targeted and 63/63 full passed.
- M6-C01/call-context focused CTest: 6/6 passed.