### PR TITLE
fix(python): qualify wheel package names

### DIFF
--- a/cmake/ptx_frontendCodegen.cmake
+++ b/cmake/ptx_frontendCodegen.cmake
@@ -5,14 +5,14 @@ function(ptx_frontend_check_codegen result_variable)
     find_package(Python3 COMPONENTS Interpreter QUIET)
     if(NOT Python3_Interpreter_FOUND)
         set(ptx_frontend_CODEGEN_NOT_FOUND_MESSAGE
-            "A Python3 interpreter is required to import code_gen"
+            "A Python3 interpreter is required to import ptx_frontend.code_gen"
             PARENT_SCOPE)
         set(${result_variable} FALSE PARENT_SCOPE)
         return()
     endif()
     execute_process(
         COMMAND "${Python3_EXECUTABLE}" -c
-            "from importlib.metadata import version; from pathlib import Path; import code_gen; expected = '${ptx_frontend_VERSION}'; actual = version('ptx_frontend');\nif actual != expected and not actual.startswith(tuple(expected + suffix for suffix in ('a', 'b', 'rc', '.dev', '.post', '+'))): raise RuntimeError(f'expected ptx_frontend {expected}, got {actual}')\nroot = Path(code_gen.__file__).resolve().parent.parent\nif not root.is_dir(): raise RuntimeError(f'invalid code_gen package root: {root}')\nprint(root)"
+            "from importlib.metadata import version; from pathlib import Path; from ptx_frontend import code_gen; expected = '${ptx_frontend_VERSION}'; actual = version('ptx_frontend');\nif actual != expected and not actual.startswith(tuple(expected + suffix for suffix in ('a', 'b', 'rc', '.dev', '.post', '+'))): raise RuntimeError(f'expected ptx_frontend {expected}, got {actual}')\nroot = Path(code_gen.__file__).resolve().parent.parent\nif not root.is_dir(): raise RuntimeError(f'invalid ptx_frontend package root: {root}')\nprint(root)"
         RESULT_VARIABLE _result
         OUTPUT_VARIABLE _root
         ERROR_VARIABLE _error
@@ -25,7 +25,7 @@ function(ptx_frontend_check_codegen result_variable)
         set(${result_variable} TRUE PARENT_SCOPE)
     else()
         set(ptx_frontend_CODEGEN_NOT_FOUND_MESSAGE
-            "Python3 ${Python3_EXECUTABLE} cannot import code_gen from ptx_frontend ${ptx_frontend_VERSION}: ${_error}"
+            "Python3 ${Python3_EXECUTABLE} cannot import ptx_frontend.code_gen from ptx_frontend ${ptx_frontend_VERSION}: ${_error}"
             PARENT_SCOPE)
         set(${result_variable} FALSE PARENT_SCOPE)
     endif()
@@ -94,7 +94,7 @@ function(ptx_frontend_generate)
 
     execute_process(
         COMMAND
-            "${ptx_frontend_CODEGEN_PYTHON_EXECUTABLE}" -m code_gen
+            "${ptx_frontend_CODEGEN_PYTHON_EXECUTABLE}" -m ptx_frontend.code_gen
             --spec-dir "${PTX_CODEGEN_SPEC_DIR}"
             --backend-spec "${PTX_CODEGEN_BACKEND_SPEC}"
             --output "${PTX_CODEGEN_OUTPUT_DIR}"
@@ -113,7 +113,7 @@ function(ptx_frontend_generate)
     add_custom_command(
         OUTPUT ${_generated_files}
         COMMAND
-            "${ptx_frontend_CODEGEN_PYTHON_EXECUTABLE}" -m code_gen
+            "${ptx_frontend_CODEGEN_PYTHON_EXECUTABLE}" -m ptx_frontend.code_gen
             --spec-dir "${PTX_CODEGEN_SPEC_DIR}"
             --backend-spec "${PTX_CODEGEN_BACKEND_SPEC}"
             --output "${PTX_CODEGEN_OUTPUT_DIR}"

--- a/docs/us-en/cmake_components.md
+++ b/docs/us-en/cmake_components.md
@@ -15,7 +15,7 @@ The package then defines:
 - `ptx_frontend_PTX_SPEC_DIR`, the installed directory containing the public PTX instruction YAML files;
 - `ptx_frontend_PTX_SPEC_SCHEMA`, the installed `ptx-instr-v1.schema.yaml` path.
 
-The canonical PTX specification lives in `python/code_gen/resources/ptx_spec` and is packaged as Python `code_gen` data. The CMake `ptx_spec` component installs independent raw data at `share/ptx_frontend/ptx_spec` and `share/ptx_frontend/ptx-instr-v1.schema.yaml`. `instructions/ptx_spec` remains only as a source-tree compatibility symlink.
+The canonical PTX specification lives in `python/code_gen/resources/ptx_spec` and is packaged as Python `ptx_frontend.code_gen` data. The CMake `ptx_spec` component installs independent raw data at `share/ptx_frontend/ptx_spec` and `share/ptx_frontend/ptx-instr-v1.schema.yaml`. `instructions/ptx_spec` remains only as a source-tree compatibility symlink.
 
 The repository-specific C++ backend policy remains at `instructions/ptx_cpp_backend_spec/ptx_frontend.yaml`; it is deliberately not a Python package resource and is not part of `ptx_spec`.
 
@@ -34,7 +34,7 @@ The `codegen` component installs only the CMake helper and provides `ptx_fronten
 cmake -S . -B build -DPython3_EXECUTABLE=/path/to/python
 ```
 
-The helper invokes `python -m code_gen`. Generation requires the consumer to select a backend specification explicitly:
+The helper invokes `python -m ptx_frontend.code_gen`. Generation requires the consumer to select a backend specification explicitly:
 
 ```cmake
 ptx_frontend_generate(

--- a/docs/us-en/python_generator_model.md
+++ b/docs/us-en/python_generator_model.md
@@ -16,11 +16,11 @@ YAML files
 
 ## Input database
 
-`code_gen.database` recursively discovers the canonical
+`ptx_frontend.code_gen.database` recursively discovers the canonical
 `python/code_gen/resources/ptx_spec/**/*.yaml` (available in source trees via
 the compatibility symlink `instructions/ptx_spec`),
 loads them in path order, enforces one schema version, and then merges
-definitions of the same opcode. The minimal stable model in `code_gen.model` is:
+definitions of the same opcode. The minimal stable model in `ptx_frontend.code_gen.model` is:
 
 ```python
 InstructionSpec(opcode, variants, syntax_forms, source_categories,
@@ -44,7 +44,7 @@ remaining independent of modifier source order.
 
 ## Normalization
 
-`code_gen.normalize` converts different legal YAML spellings into one model:
+`ptx_frontend.code_gen.normalize` converts different legal YAML spellings into one model:
 
 - expands `$name` references from both `type_sets` and `value_sets`, rejecting
   names defined in both namespaces;
@@ -61,7 +61,7 @@ the compatibility boundary, not the emitters.
 
 ## Syntax model
 
-`ir.syntax_ast` builds a source-syntax descriptor model from `InstructionSpec`:
+`ptx_frontend.ir.syntax_ast` builds a source-syntax descriptor model from `InstructionSpec`:
 
 ```python
 SyntaxInstructionDescriptor(opcode, variants)
@@ -79,7 +79,7 @@ AST shape must first extend this model and the C++ foundation ABI.
 
 ## Resolved model
 
-`ir.resolved_ir` maps the same `InstructionSpec` to a resolved C++ field model:
+`ptx_frontend.ir.resolved_ir` maps the same `InstructionSpec` to a resolved C++ field model:
 
 ```python
 ResolvedInstruction(opcode, cpp_name, variants)
@@ -162,7 +162,7 @@ backend specs and generator inputs therefore produce byte-identical content.
 
 `instructions/ptx_cpp_backend_spec/ptx_frontend.yaml` and
 `instructions/schemas/ptx-cpp-backend-v1.schema.yaml` are retained as a
-separate C++ backend configuration layer. `code_gen.cpp_backend` normalizes its
+separate C++ backend configuration layer. `ptx_frontend.code_gen.cpp_backend` normalizes its
 `domains` into `DomainBackend`; Syntax, Resolved, and checker emitters use only
 typed lookups for C++ spellings. Lookup APIs require a `CppDomain` enum member,
 such as `CppDomain.SCALAR_TYPES`, rather than a bare string. Current domains

--- a/docs/zh-han/cmake_components.md
+++ b/docs/zh-han/cmake_components.md
@@ -15,7 +15,7 @@ find_package(ptx_frontend CONFIG REQUIRED COMPONENTS ptx_spec)
 - `ptx_frontend_PTX_SPEC_DIR`：已安装的公共 PTX instruction YAML 目录；
 - `ptx_frontend_PTX_SPEC_SCHEMA`：已安装的 `ptx-instr-v1.schema.yaml` 路径。
 
-PTX specification 的 canonical source 位于 `python/code_gen/resources/ptx_spec`，并作为 Python `code_gen` 的 package data 一起发布。CMake 的 `ptx_spec` component 将独立 raw data 安装至 `share/ptx_frontend/ptx_spec` 和 `share/ptx_frontend/ptx-instr-v1.schema.yaml`。`instructions/ptx_spec` 仅保留为源码树兼容 symlink。
+PTX specification 的 canonical source 位于 `python/code_gen/resources/ptx_spec`，并作为 Python `ptx_frontend.code_gen` 的 package data 一起发布。CMake 的 `ptx_spec` component 将独立 raw data 安装至 `share/ptx_frontend/ptx_spec` 和 `share/ptx_frontend/ptx-instr-v1.schema.yaml`。`instructions/ptx_spec` 仅保留为源码树兼容 symlink。
 
 仓库自身的 C++ backend policy 仍位于 `instructions/ptx_cpp_backend_spec/ptx_frontend.yaml`；它不是 Python package resource，也不属于 `ptx_spec`，不会被导出。
 
@@ -34,7 +34,7 @@ find_package(ptx_frontend CONFIG REQUIRED COMPONENTS ptx_spec codegen)
 cmake -S . -B build -DPython3_EXECUTABLE=/path/to/python
 ```
 
-helper 通过 `python -m code_gen` 执行生成。consumer 必须显式指定自己的 backend specification：
+helper 通过 `python -m ptx_frontend.code_gen` 执行生成。consumer 必须显式指定自己的 backend specification：
 
 ```cmake
 ptx_frontend_generate(

--- a/docs/zh-han/python_generator_model.md
+++ b/docs/zh-han/python_generator_model.md
@@ -15,11 +15,11 @@ YAML files
 
 ## 输入数据库
 
-`code_gen.database` 递归发现 canonical 的
+`ptx_frontend.code_gen.database` 递归发现 canonical 的
 `python/code_gen/resources/ptx_spec/**/*.yaml`（源码树可通过兼容 symlink
 `instructions/ptx_spec` 访问），按路径排序加载，并
 保证所有文件使用相同 schema 版本；同 opcode 的定义随后合并。`InstructionSpec` 的最小稳定
-模型位于 `code_gen.model`：
+模型位于 `ptx_frontend.code_gen.model`：
 
 ```python
 InstructionSpec(opcode, variants, syntax_forms, source_categories,
@@ -40,7 +40,7 @@ C++ matcher 才能对每个候选 variant 做确定性的局部绑定，同时�
 
 ## Normalization
 
-`code_gen.normalize` 负责将 schema 合法但书写方式不同的 YAML 收敛为一个模型：
+`ptx_frontend.code_gen.normalize` 负责将 schema 合法但书写方式不同的 YAML 收敛为一个模型：
 
 - 统一展开 `type_sets` 与 `value_sets` 的 `$name` 引用，并拒绝两者同名；
 - 将 operand 的 `type: {expr: modifier(type)}` 解析为
@@ -56,7 +56,7 @@ C++ matcher 才能对每个候选 variant 做确定性的局部绑定，同时�
 
 ## Syntax 模型
 
-`ir.syntax_ast` 从 `InstructionSpec` 构建源语法 descriptor 模型：
+`ptx_frontend.ir.syntax_ast` 从 `InstructionSpec` 构建源语法 descriptor 模型：
 
 ```python
 SyntaxInstructionDescriptor(opcode, variants)
@@ -72,7 +72,7 @@ shape 与 slot 数量。当前 `OperandLayoutKind.FLAT` 和 `reg`、`imm`、`reg
 
 ## Resolved 模型
 
-`ir.resolved_ir` 把相同的 `InstructionSpec` 映射为 C++ resolved field 设计：
+`ptx_frontend.ir.resolved_ir` 把相同的 `InstructionSpec` 映射为 C++ resolved field 设计：
 
 ```python
 ResolvedInstruction(opcode, cpp_name, variants)
@@ -143,7 +143,7 @@ specialization 声明位于公共头的单一 `checker` namespace，每个 categ
 
 `instructions/ptx_cpp_backend_spec/ptx_frontend.yaml` 及其
 `instructions/schemas/ptx-cpp-backend-v1.schema.yaml` 作为独立的 C++ backend
-配置层。`code_gen.cpp_backend` 将 `domains` 规范化为 `DomainBackend`，Syntax、Resolved、
+配置层。`ptx_frontend.code_gen.cpp_backend` 将 `domains` 规范化为 `DomainBackend`，Syntax、Resolved、
 checker emitter 只通过 typed lookup 读取 C++ 拼写。查询接口的 domain 参数必须使用
 `CppDomain` 枚举成员，例如 `CppDomain.SCALAR_TYPES`，不接受裸字符串。当前 domain
 覆盖 scalar type、

--- a/python/code_gen/__main__.py
+++ b/python/code_gen/__main__.py
@@ -1,4 +1,4 @@
-from code_gen.cli import main
+from .cli import main
 
 
 main()

--- a/python/code_gen/cli.py
+++ b/python/code_gen/cli.py
@@ -5,20 +5,20 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from base.utils import format_file_inplace
-from code_gen.cpp_backend import configure_cpp_backend, get_cpp_backend
-from code_gen.database import CodegenDatabase, load_codegen_database
-from code_gen.gen_resolved_checker_descriptor import (
+from ptx_frontend.base.utils import format_file_inplace
+from .cpp_backend import configure_cpp_backend, get_cpp_backend
+from .database import CodegenDatabase, load_codegen_database
+from .gen_resolved_checker_descriptor import (
     generate_resolved_checker_descriptor_source,
 )
-from code_gen.gen_resolved_descriptor import generate_resolved_descriptor_source
-from code_gen.gen_resolved_ir import (
+from .gen_resolved_descriptor import generate_resolved_descriptor_source
+from .gen_resolved_ir import (
     generate_resolved_dispatch_source,
     generate_resolved_ir_header,
     generate_resolved_ir_source,
 )
-from code_gen.gen_resolved_value_domains import generate_resolved_value_domain_header
-from code_gen.gen_syntax_ast_arch import generate_syntax_descriptor_source
+from .gen_resolved_value_domains import generate_resolved_value_domain_header
+from .gen_syntax_ast_arch import generate_syntax_descriptor_source
 
 
 def parse_arguments() -> argparse.Namespace:

--- a/python/code_gen/cpp_backend.py
+++ b/python/code_gen/cpp_backend.py
@@ -9,8 +9,8 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
-from code_gen.model import (
+from .load_yaml import load_yaml
+from .model import (
     CodegenUnit,
     DomainBackend,
     EmitAlternativeBackend,

--- a/python/code_gen/database.py
+++ b/python/code_gen/database.py
@@ -8,10 +8,10 @@ from functools import cache
 from pathlib import Path
 from typing import Any, TypeVar
 
-from base.utils import file_stem_to_pascal_case
-from code_gen.load_yaml import load_yaml
-from code_gen.model import InstructionSpec, VariantSpec, modifier_spellings
-from code_gen.normalize import normalize_instruction_spec
+from ptx_frontend.base.utils import file_stem_to_pascal_case
+from .load_yaml import load_yaml
+from .model import InstructionSpec, VariantSpec, modifier_spellings
+from .normalize import normalize_instruction_spec
 from jsonschema import Draft202012Validator
 
 

--- a/python/code_gen/gen_resolved_checker_descriptor.py
+++ b/python/code_gen/gen_resolved_checker_descriptor.py
@@ -4,15 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from base.utils import generated_at_comment
-from code_gen.cpp_backend import CppDomain, cpp_default, cpp_value
-from code_gen.database import CodegenDatabase
-from code_gen.normalize import (
+from ptx_frontend.base.utils import generated_at_comment
+from .cpp_backend import CppDomain, cpp_default, cpp_value
+from .database import CodegenDatabase
+from .normalize import (
     parse_availability_target,
     validate_availability_family,
     validate_availability_sm_version,
 )
-from ir.resolved_ir import (
+from ptx_frontend.ir.resolved_ir import (
     ResolvedInstruction,
     ResolvedModifierValueAvailability,
     ResolvedOperandLayout,

--- a/python/code_gen/gen_resolved_descriptor.py
+++ b/python/code_gen/gen_resolved_descriptor.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from base.utils import generated_at_comment, to_file_stem
-from code_gen.cpp_backend import CppDomain, cpp_default, cpp_value
-from code_gen.gen_resolved_checker_descriptor import _emit_availability
-from code_gen.database import CodegenDatabase
-from ir.resolved_ir import (
+from ptx_frontend.base.utils import generated_at_comment, to_file_stem
+from .cpp_backend import CppDomain, cpp_default, cpp_value
+from .gen_resolved_checker_descriptor import _emit_availability
+from .database import CodegenDatabase
+from ptx_frontend.ir.resolved_ir import (
     ResolvedField,
     ResolvedInstruction,
     ResolvedModifierBinding,

--- a/python/code_gen/gen_resolved_ir.py
+++ b/python/code_gen/gen_resolved_ir.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from base.utils import generated_at_comment
-from code_gen.cpp_backend import CppDomain, cpp_default, cpp_value
-from code_gen.database import CodegenDatabase
-from ir.resolved_ir import (
+from ptx_frontend.base.utils import generated_at_comment
+from .cpp_backend import CppDomain, cpp_default, cpp_value
+from .database import CodegenDatabase
+from ptx_frontend.ir.resolved_ir import (
     ResolvedField,
     ResolvedFieldStorage,
     ResolvedInstruction,

--- a/python/code_gen/gen_resolved_value_domains.py
+++ b/python/code_gen/gen_resolved_value_domains.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from base.utils import file_stem_to_pascal_case, generated_at_comment
-from code_gen.model import CodegenUnit, DomainBackend, RuntimeLookupKind
+from ptx_frontend.base.utils import file_stem_to_pascal_case, generated_at_comment
+from .model import CodegenUnit, DomainBackend, RuntimeLookupKind
 
 
 def generate_resolved_value_domain_header(

--- a/python/code_gen/gen_syntax_ast_arch.py
+++ b/python/code_gen/gen_syntax_ast_arch.py
@@ -1,17 +1,17 @@
-"""Emit C++ syntax architecture descriptors from ``ir.syntax_ast``."""
+"""Emit C++ syntax architecture descriptors from ``ptx_frontend.ir.syntax_ast``."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
-from base.utils import (
+from ptx_frontend.base.utils import (
     file_stem_to_pascal_case,
     generated_at_comment,
     to_file_stem,
 )
-from code_gen.cpp_backend import CppDomain, cpp_value
-from code_gen.database import CodegenDatabase
-from ir.syntax_ast import (
+from .cpp_backend import CppDomain, cpp_value
+from .database import CodegenDatabase
+from ptx_frontend.ir.syntax_ast import (
     ModifierPresence,
     OperandLayoutKind,
     OperandPresence,

--- a/python/code_gen/m12_natural_corpus.py
+++ b/python/code_gen/m12_natural_corpus.py
@@ -6,7 +6,7 @@ from collections import Counter
 from pathlib import Path
 import re
 
-from code_gen.database import CodegenDatabase, _variant_modifier_language
+from .database import CodegenDatabase, _variant_modifier_language
 
 
 _ENTRY = re.compile(r"^\.visible\s+\.entry\s+([A-Za-z_][A-Za-z0-9_]*)\(")

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from code_gen.load_yaml import expand_value_refs
-from code_gen.model import (
+from .load_yaml import expand_value_refs
+from .model import (
     AddressAlignmentConstraint,
     ImmediateMultipleOfConstraint,
     ImmediateRangeConstraint,
@@ -31,7 +31,7 @@ from code_gen.model import (
     OperandVectorTypePolicy,
     VariantSpec,
 )
-from ir.syntax_ast import OPERAND_SYNTAX_SHAPES
+from ptx_frontend.ir.syntax_ast import OPERAND_SYNTAX_SHAPES
 
 
 UINT64_MAX = (1 << 64) - 1

--- a/python/ir/resolved_ir.py
+++ b/python/ir/resolved_ir.py
@@ -11,14 +11,14 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from base.utils import file_stem_to_pascal_case
-from code_gen.cpp_backend import (
+from ptx_frontend.base.utils import file_stem_to_pascal_case
+from ptx_frontend.code_gen.cpp_backend import (
     CppDomain,
     cpp_domain,
     cpp_optional_value,
     cpp_value,
 )
-from code_gen.model import (
+from ptx_frontend.code_gen.model import (
     AddressAlignmentConstraint,
     ImmediateMultipleOfConstraint,
     ImmediateRangeConstraint,

--- a/python/ir/syntax_ast.py
+++ b/python/ir/syntax_ast.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, IntFlag
-from code_gen.model import (
+from ptx_frontend.code_gen.model import (
     InstructionSpec,
     ModifierSpec,
     OperandLayoutKind as ModelOperandLayoutKind,

--- a/python/scripts/gen_all.py
+++ b/python/scripts/gen_all.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compatibility wrapper for the public ``code_gen`` CLI."""
+"""Compatibility wrapper for the public ``ptx_frontend.code_gen`` CLI."""
 
 from pathlib import Path
 import sys
@@ -8,7 +8,7 @@ PYTHON_ROOT = Path(__file__).resolve().parents[1]
 if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
-from code_gen.cli import main
+from ptx_frontend.code_gen.cli import main
 
 
 if __name__ == "__main__":

--- a/python/scripts/regenerate_m12_corpus.py
+++ b/python/scripts/regenerate_m12_corpus.py
@@ -22,8 +22,8 @@ if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
 
-from code_gen.database import load_codegen_database
-from code_gen.m12_natural_corpus import (
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.m12_natural_corpus import (
     build_natural_manifest,
     canonical_bytes,
     fixture_targets,

--- a/python/scripts/verify_ptx_isa_baseline.py
+++ b/python/scripts/verify_ptx_isa_baseline.py
@@ -17,7 +17,7 @@ if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 class BaselineVerificationError(ValueError):

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -5,25 +5,26 @@ description = ptx frontend helper packages
 author = endingly
 
 [options]
-packages = find:
+packages =
+    ptx_frontend.base
+    ptx_frontend.code_gen
+    ptx_frontend.code_gen.resources
+    ptx_frontend.ir
+package_dir =
+    ptx_frontend.base = base
+    ptx_frontend.code_gen = code_gen
+    ptx_frontend.code_gen.resources = code_gen/resources
+    ptx_frontend.ir = ir
 include_package_data = True
 install_requires =
     PyYAML>=6.0,<7
     jsonschema>=4.26,<5
 
 [options.package_data]
-code_gen =
-    resources/*.yaml
-    resources/ptx_spec/*.yaml
+ptx_frontend.code_gen.resources =
+    *.yaml
+    ptx_spec/*.yaml
 
 [options.entry_points]
 console_scripts =
-    ptx-frontend-codegen = code_gen.cli:main
-
-[options.packages.find]
-where = .
-exclude =
-    test
-    test.*
-    tests
-    tests.*
+    ptx-frontend-codegen = ptx_frontend.code_gen.cli:main

--- a/python/tests/code_gen/test_backend_model.py
+++ b/python/tests/code_gen/test_backend_model.py
@@ -6,14 +6,14 @@ from unittest.mock import patch
 
 import yaml
 
-from code_gen import cpp_backend
-from code_gen.cpp_backend import (
+from ptx_frontend.code_gen import cpp_backend
+from ptx_frontend.code_gen.cpp_backend import (
     CppDomain,
     configure_cpp_backend,
     cpp_value,
     load_cpp_backend,
 )
-from code_gen.model import (
+from ptx_frontend.code_gen.model import (
     CodegenUnit,
     DomainBackend,
     EmitAlternativeBackend,
@@ -23,7 +23,7 @@ from code_gen.model import (
     OperandBackend,
     RuntimeLookupKind,
 )
-from ir.resolved_ir import ResolvedField, ResolvedFieldOrigin, ResolvedFieldStorage
+from ptx_frontend.ir.resolved_ir import ResolvedField, ResolvedFieldOrigin, ResolvedFieldStorage
 
 
 REPOSITORY_CPP_BACKEND_SPEC = (

--- a/python/tests/code_gen/test_common_kernel_gaps_manifest.py
+++ b/python/tests/code_gen/test_common_kernel_gaps_manifest.py
@@ -5,8 +5,8 @@ import unittest
 import yaml
 from jsonschema import Draft202012Validator
 
-from code_gen.database import load_codegen_database
-from code_gen.m12_natural_corpus import classify_instruction_spelling
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.m12_natural_corpus import classify_instruction_spelling
 
 
 ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_corpus_provenance.py
+++ b/python/tests/code_gen/test_corpus_provenance.py
@@ -7,7 +7,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.m12_natural_corpus import (
+from ptx_frontend.code_gen.m12_natural_corpus import (
     canonical_bytes,
     fixture_targets,
     target_directive_architectures,

--- a/python/tests/code_gen/test_database.py
+++ b/python/tests/code_gen/test_database.py
@@ -6,10 +6,10 @@ import unittest
 import yaml
 from jsonschema import Draft202012Validator
 
-from code_gen.database import load_codegen_database
-from code_gen.load_yaml import load_yaml
-from code_gen.gen_resolved_checker_descriptor import _emit_availability
-from code_gen.normalize import normalize_availability, normalize_operand
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.gen_resolved_checker_descriptor import _emit_availability
+from ptx_frontend.code_gen.normalize import normalize_availability, normalize_operand
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ld_st_extension_gaps_manifest.py
+++ b/python/tests/code_gen/test_ld_st_extension_gaps_manifest.py
@@ -3,7 +3,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_m12_natural_manifest.py
+++ b/python/tests/code_gen/test_m12_natural_manifest.py
@@ -4,8 +4,8 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.database import load_codegen_database
-from code_gen.m12_natural_corpus import build_natural_manifest
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.m12_natural_corpus import build_natural_manifest
 
 
 ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_opcode_coverage_manifest.py
+++ b/python/tests/code_gen/test_opcode_coverage_manifest.py
@@ -4,8 +4,8 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.database import load_codegen_database
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ptx_directive_registry.py
+++ b/python/tests/code_gen/test_ptx_directive_registry.py
@@ -6,7 +6,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ptx_instruction_registry.py
+++ b/python/tests/code_gen/test_ptx_instruction_registry.py
@@ -5,7 +5,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ptx_inventory_accounting.py
+++ b/python/tests/code_gen/test_ptx_inventory_accounting.py
@@ -6,7 +6,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ptx_isa_baseline.py
+++ b/python/tests/code_gen/test_ptx_isa_baseline.py
@@ -4,7 +4,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 from scripts.verify_ptx_isa_baseline import (
     BaselineVerificationError,
     fetch_raw_response_body,

--- a/python/tests/code_gen/test_ptx_spec_taxonomy.py
+++ b/python/tests/code_gen/test_ptx_spec_taxonomy.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import unittest
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_ptx_special_register_registry.py
+++ b/python/tests/code_gen/test_ptx_special_register_registry.py
@@ -6,7 +6,7 @@ import unittest
 
 from jsonschema import Draft202012Validator
 
-from code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.load_yaml import load_yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]

--- a/python/tests/code_gen/test_resolved_value_domains.py
+++ b/python/tests/code_gen/test_resolved_value_domains.py
@@ -4,8 +4,8 @@ import unittest
 
 import yaml
 
-from code_gen.cpp_backend import load_cpp_backend
-from code_gen.gen_resolved_value_domains import (
+from ptx_frontend.code_gen.cpp_backend import load_cpp_backend
+from ptx_frontend.code_gen.gen_resolved_value_domains import (
     generate_resolved_value_domain_header,
 )
 

--- a/python/tests/code_gen/wheel_smoke.py
+++ b/python/tests/code_gen/wheel_smoke.py
@@ -22,15 +22,19 @@ def main(wheel: Path) -> None:
     with zipfile.ZipFile(wheel) as archive:
         names = archive.namelist()
     for name in (
-        "code_gen/cli.py",
-        "code_gen/__main__.py",
-        "code_gen/resources/ptx_spec/arithmetic.yaml",
+        "ptx_frontend/base/utils.py",
+        "ptx_frontend/code_gen/cli.py",
+        "ptx_frontend/code_gen/__main__.py",
+        "ptx_frontend/code_gen/resources/ptx_spec/arithmetic.yaml",
+        "ptx_frontend/ir/resolved_ir.py",
         f"ptx_frontend-{EXPECTED_VERSION}.dist-info/METADATA",
     ):
         if name not in names:
             raise AssertionError(f"wheel is missing {name}")
     if any("ptx_cpp_backend_spec" in name for name in names):
         raise AssertionError("wheel contains a private backend specification")
+    if any(name.startswith(("base/", "code_gen/", "ir/")) for name in names):
+        raise AssertionError("wheel contains an unqualified top-level package")
 
     with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
@@ -45,14 +49,14 @@ def main(wheel: Path) -> None:
             check=True, cwd=root, env=wheel_environment,
         )
         installed_spec_dir = subprocess.check_output(
-            [executable, "-c", f"from importlib.metadata import version; from importlib.resources import files; assert version('ptx_frontend') == {EXPECTED_VERSION!r}; print(files('code_gen.resources').joinpath('ptx_spec'))"],
+            [executable, "-c", f"from importlib.metadata import version; from importlib.resources import files; assert version('ptx_frontend') == {EXPECTED_VERSION!r}; print(files('ptx_frontend.code_gen.resources').joinpath('ptx_spec'))"],
             text=True, cwd=root, env=wheel_environment,
         ).strip()
-        subprocess.run([executable, "-m", "code_gen", "--help"], check=True, cwd=root, env=wheel_environment)
+        subprocess.run([executable, "-m", "ptx_frontend.code_gen", "--help"], check=True, cwd=root, env=wheel_environment)
         subprocess.run([bin_dir / "ptx-frontend-codegen", "--help"], check=True, cwd=root, env=wheel_environment)
         generated = root / "generated"
         command = [
-            executable, "-m", "code_gen", "--spec-dir", installed_spec_dir,
+            executable, "-m", "ptx_frontend.code_gen", "--spec-dir", installed_spec_dir,
             "--backend-spec", str(BACKEND_SPEC), "--output", str(generated),
         ]
         listed_outputs = subprocess.check_output(

--- a/python/tests/ir/test_modern_operand_primitives.py
+++ b/python/tests/ir/test_modern_operand_primitives.py
@@ -16,21 +16,21 @@ if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
 
-from code_gen.database import load_codegen_database
-from code_gen.cpp_backend import configure_cpp_backend
-from code_gen.gen_resolved_descriptor import generate_resolved_descriptor_source
-from code_gen.gen_resolved_checker_descriptor import (
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.cpp_backend import configure_cpp_backend
+from ptx_frontend.code_gen.gen_resolved_descriptor import generate_resolved_descriptor_source
+from ptx_frontend.code_gen.gen_resolved_checker_descriptor import (
     generate_resolved_checker_descriptor_source,
 )
-from code_gen.gen_resolved_ir import (
+from ptx_frontend.code_gen.gen_resolved_ir import (
     generate_resolved_ir_header,
     generate_resolved_ir_source,
 )
-from code_gen.gen_syntax_ast_arch import generate_syntax_descriptor_source
-from code_gen.load_yaml import load_yaml
-from code_gen.normalize import normalize_instruction_spec, normalize_operand
-from ir.resolved_ir import ResolvedOperandShape, from_instruction_spec
-from ir.syntax_ast import (
+from ptx_frontend.code_gen.gen_syntax_ast_arch import generate_syntax_descriptor_source
+from ptx_frontend.code_gen.load_yaml import load_yaml
+from ptx_frontend.code_gen.normalize import normalize_instruction_spec, normalize_operand
+from ptx_frontend.ir.resolved_ir import ResolvedOperandShape, from_instruction_spec
+from ptx_frontend.ir.syntax_ast import (
     OPERAND_SYNTAX_SHAPES,
     OperandSyntaxShape,
     from_InstructionSpec,

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -14,24 +14,24 @@ if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
 
-from code_gen.database import load_codegen_database
-from code_gen.database import CodegenDatabase
-from code_gen.cpp_backend import configure_cpp_backend
-from code_gen.gen_resolved_descriptor import (
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.database import CodegenDatabase
+from ptx_frontend.code_gen.cpp_backend import configure_cpp_backend
+from ptx_frontend.code_gen.gen_resolved_descriptor import (
     _emit_address_state_spaces,
     _emit_operand_binding_descriptor,
     generate_resolved_descriptor_source,
 )
-from code_gen.gen_resolved_checker_descriptor import (
+from ptx_frontend.code_gen.gen_resolved_checker_descriptor import (
     generate_resolved_checker_descriptor_source,
 )
-from code_gen.gen_resolved_ir import (
+from ptx_frontend.code_gen.gen_resolved_ir import (
     generate_resolved_dispatch_source,
     generate_resolved_ir_header,
     generate_resolved_ir_source,
 )
-from code_gen.normalize import normalize_instruction_spec
-from ir.resolved_ir import (
+from ptx_frontend.code_gen.normalize import normalize_instruction_spec
+from ptx_frontend.ir.resolved_ir import (
     ResolvedFieldOrigin,
     ResolvedFieldStorage,
     ResolvedOperandAccess,
@@ -44,7 +44,7 @@ from ir.resolved_ir import (
     ResolvedVectorTypePolicy,
     from_instruction_spec,
 )
-from code_gen.model import (
+from ptx_frontend.code_gen.model import (
     ImmediateMultipleOfConstraint,
     ImmediateRangeConstraint,
     ImmediateValueConstraint,

--- a/python/tests/ir/test_syntax_ast.py
+++ b/python/tests/ir/test_syntax_ast.py
@@ -14,22 +14,22 @@ PYTHON_ROOT = REPO_ROOT / "python"
 if str(PYTHON_ROOT) not in sys.path:
     sys.path.insert(0, str(PYTHON_ROOT))
 
-from base.utils import generated_at_comment
-from code_gen.cpp_backend import configure_cpp_backend
-from code_gen.database import load_codegen_database
-from code_gen.gen_syntax_ast_arch import (
+from ptx_frontend.base.utils import generated_at_comment
+from ptx_frontend.code_gen.cpp_backend import configure_cpp_backend
+from ptx_frontend.code_gen.database import load_codegen_database
+from ptx_frontend.code_gen.gen_syntax_ast_arch import (
     emit_check_end_instruction_descriptor_implementation,
     generate_syntax_descriptor_source,
 )
-from code_gen.load_yaml import expand_value_refs
-from code_gen.model import (
+from ptx_frontend.code_gen.load_yaml import expand_value_refs
+from ptx_frontend.code_gen.model import (
     MbarrierStateTokenForm,
     OperandRegisterWidthPolicy,
     OperandVectorTypePolicy,
 )
-from code_gen.normalize import normalize_instruction_spec
-from ir.syntax_ast import from_InstructionSpec
-from ir.syntax_ast import (
+from ptx_frontend.code_gen.normalize import normalize_instruction_spec
+from ptx_frontend.ir.syntax_ast import from_InstructionSpec
+from ptx_frontend.ir.syntax_ast import (
     ModifierPresence,
     OperandLayoutKind,
     OperandPresence,


### PR DESCRIPTION
## Summary

- export Python modules under the fully qualified `ptx_frontend` namespace
- map the existing source directories with explicit `package_dir` entries
- update codegen imports, CMake integration, tests, and bilingual documentation
- reject legacy top-level `base`, `code_gen`, and `ir` packages in the wheel smoke test

## Validation

- 223 Python tests passed
- editable-install import and CLI checks passed
- wheel build and isolated wheel smoke test passed, including packaged resources and generated outputs

## Consumer impact

Consumers must replace imports such as `code_gen.model` with `ptx_frontend.code_gen.model` when updating to this wheel.