### PR TITLE
perf(ci): refresh build caches and reduce repeated test work

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -4,10 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
-    paths:
-      - .github/workflows/linux-ci.yml
-      - vcpkg.json
+    # PR caches cannot warm other PRs; keep both integration branches warm.
+    branches: [dev, main]
   schedule:
     - cron: "0 0 1 * *"
   workflow_dispatch:
@@ -22,6 +20,7 @@ env:
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.cache/vcpkg/archives,readwrite"
   CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
   CCACHE_MAXSIZE: 1G
+  PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
 
 jobs:
   test:
@@ -88,11 +87,25 @@ jobs:
             zip
           sudo chmod -R a+rX "$APT_CACHE_DIR"
 
+      - name: Compute toolchain cache identity
+        id: toolchain
+        shell: bash
+        run: |
+          fingerprint=$( { printf '%s\n' "$ImageOS" "$ImageVersion"; g++ --version; cmake --version; } | sha256sum | cut -d ' ' -f 1)
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Python download cache
+        uses: actions/cache@v6
+        with:
+          path: .cache/pip
+          key: pip-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('requirements.txt', 'python/pyproject.toml', 'python/setup.cfg') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('requirements.txt', 'python/pyproject.toml', 'python/setup.cfg') }}-
+
       - name: Install Python generator dependencies
         shell: bash
         run: |
           python3 -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -r requirements.txt
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
 
@@ -102,9 +115,10 @@ jobs:
           path: |
             .cache/vcpkg/archives
             .cache/vcpkg/downloads
-          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}
+          # Refresh immutable snapshots so newly built ABIs survive this run.
+          key: vcpkg-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ runner.arch }}-
+            vcpkg-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('vcpkg.json') }}-
 
       - name: Prepare vcpkg cache directories
         shell: bash
@@ -122,14 +136,23 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .cache/ccache
-          key: ccache-v3-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-${{ steps.cache-epoch.outputs.month }}-${{ hashFiles('.github/workflows/linux-ci.yml', 'CMakeLists.txt', 'CMakePresets.json', '**/CMakeLists.txt', '**/*.cmake', 'vcpkg.json', 'requirements.txt', 'python/base/**/*.py', 'python/code_gen/**/*.py', 'python/ir/**/*.py', 'python/scripts/**/*.py', 'instructions/**/*.yaml') }}
+          # ccache validates source/header contents; snapshots must advance even
+          # when only C++ files change. Keep consumer and full-build caches separate.
+          key: ccache-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.preset }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            ccache-v3-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}-
-      - name: Run CMake workflow preset
+            ccache-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ matrix.preset }}-
+
+      - name: Configure
         shell: bash
         run: |
           ccache --zero-stats
-          cmake --workflow --preset "${{ matrix.preset }}"
+          cmake --preset "${{ matrix.preset }}"
+
+      - name: Build
+        run: cmake --build --preset "${{ matrix.preset }}"
+
+      - name: Test
+        run: ctest --preset "${{ matrix.preset }}" --output-on-failure
 
       - name: Verify archived PTX ISA baseline
         if: matrix.name == 'Debug' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/python-and-package-consumer.yml
+++ b/.github/workflows/python-and-package-consumer.yml
@@ -4,11 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   push:
-    branches: [main]
-    paths:
-      - .github/workflows/linux-ci.yml
-      - .github/workflows/python-and-package-consumer.yml
-      - vcpkg.json
+    # PR caches cannot warm other PRs; keep both integration branches warm.
+    branches: [dev, main]
   schedule:
     - cron: "0 0 1 * *"
   workflow_dispatch:
@@ -27,6 +24,7 @@ env:
   VCPKG_BINARY_SOURCES: "clear;files,${{ github.workspace }}/.cache/vcpkg/archives,readwrite"
   CCACHE_DIR: ${{ github.workspace }}/.cache/ccache
   CCACHE_MAXSIZE: 1G
+  PIP_CACHE_DIR: ${{ github.workspace }}/.cache/pip
 
 jobs:
   test:
@@ -80,11 +78,25 @@ jobs:
             zip
           sudo chmod -R a+rX "$APT_CACHE_DIR"
 
+      - name: Compute toolchain cache identity
+        id: toolchain
+        shell: bash
+        run: |
+          fingerprint=$( { printf '%s\n' "$ImageOS" "$ImageVersion"; g++ --version; cmake --version; } | sha256sum | cut -d ' ' -f 1)
+          echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
+
+      - name: Restore Python download cache
+        uses: actions/cache@v6
+        with:
+          path: .cache/pip
+          key: pip-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('requirements.txt', 'python/pyproject.toml', 'python/setup.cfg') }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            pip-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('requirements.txt', 'python/pyproject.toml', 'python/setup.cfg') }}-
+
       - name: Install Python generator dependencies
         shell: bash
         run: |
           python3 -m venv .venv
-          .venv/bin/python -m pip install --upgrade pip
           .venv/bin/python -m pip install -r requirements.txt
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
 
@@ -94,9 +106,10 @@ jobs:
           path: |
             .cache/vcpkg/archives
             .cache/vcpkg/downloads
-          key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('vcpkg.json') }}
+          # Refresh immutable snapshots so newly built ABIs survive this run.
+          key: vcpkg-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('vcpkg.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ runner.arch }}-
+            vcpkg-v2-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('vcpkg.json') }}-
 
       - name: Prepare vcpkg cache directories
         shell: bash
@@ -114,13 +127,22 @@ jobs:
         uses: actions/cache@v6
         with:
           path: .cache/ccache
-          key: ccache-v3-${{ runner.os }}-${{ runner.arch }}-ci-linux-gcc-debug-${{ steps.cache-epoch.outputs.month }}-${{ hashFiles('.github/workflows/python-and-package-consumer.yml', 'CMakeLists.txt', 'CMakePresets.json', '**/CMakeLists.txt', '**/*.cmake', 'vcpkg.json', 'requirements.txt', 'python/base/**/*.py', 'python/code_gen/**/*.py', 'python/ir/**/*.py', 'instructions/**/*.yaml') }}
+          # Save a fresh snapshot after source changes, independently of full Debug.
+          key: ccache-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-consumer-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            ccache-v3-${{ runner.os }}-${{ runner.arch }}-ci-linux-gcc-debug-
+            ccache-v4-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.fingerprint }}-consumer-
 
-      - name: Run Python and package-consumer workflow
+      - name: Configure
         shell: bash
-        run: cmake --workflow --preset ci-python-and-package-consumer
+        run: |
+          ccache --zero-stats
+          cmake --preset ci-linux-gcc-debug
+
+      - name: Build
+        run: cmake --build --preset ci-python-and-package-consumer
+
+      - name: Test Python and package consumer
+        run: ctest --preset ci-python-and-package-consumer --output-on-failure
 
       - name: Show compiler cache statistics
         if: always()

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -69,6 +69,8 @@ class ResolvedIrBuildTest(unittest.TestCase):
         database = load_codegen_database(
             spec_dir=REPO_ROOT / "instructions/ptx_spec",
         )
+        # Repository specs remain unchanged.
+        # Tests needing mutation load their own fixture.
         cls.database = database
         add = next(
             instruction
@@ -774,9 +776,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
     def test_bar_sync_uses_distinct_modifier_variants_and_operand_layouts(
         self,
     ) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         bar = next(
             instruction
             for instruction in database.instructions
@@ -882,9 +882,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_barrier_cluster_model_defaults_and_availability(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         barrier = next(
             instruction
             for instruction in database.instructions
@@ -928,9 +926,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             self.assertEqual(variant.operand_layouts[0].fields, ())
 
     def test_match_sync_model_layouts_and_availability(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         match = next(
             instruction
             for instruction in database.instructions
@@ -1002,9 +998,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
 
     def test_redux_sync_model_variants_and_availability(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         redux = next(
             instruction
             for instruction in database.instructions
@@ -1053,9 +1047,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
 
     def test_griddepcontrol_model_has_two_zero_operand_actions(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         griddepcontrol = next(
             instruction
             for instruction in database.instructions
@@ -1081,9 +1073,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
 
     def test_elect_sync_model_allows_only_its_destination_sink(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         elect = next(
             instruction
             for instruction in database.instructions
@@ -1117,9 +1107,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn('.allow_destination_sink = true,', source)
 
     def test_bra_uses_a_binding_aware_branch_target(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         bra = next(
             instruction
             for instruction in database.instructions
@@ -1152,9 +1140,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.rule, "control_flow.bra")
 
     def test_brx_uses_a_u32_register_and_branch_target_set(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         brx = next(
             instruction
             for instruction in database.instructions
@@ -1188,9 +1174,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.rule, "control_flow.brx_idx")
 
     def test_ret_uses_a_bare_zero_operand_variant(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         ret = next(
             instruction
             for instruction in database.instructions
@@ -1207,9 +1191,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_exit_uses_a_bare_zero_operand_variant(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         exit_instruction = next(
             instruction
             for instruction in database.instructions
@@ -1226,9 +1208,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_trap_uses_a_bare_zero_operand_variant(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         trap = next(
             instruction
             for instruction in database.instructions
@@ -1245,9 +1225,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_and_uses_a_fixed_b32_binary_variant(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         and_instruction = next(
             instruction
             for instruction in database.instructions
@@ -1266,9 +1244,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_or_uses_a_fixed_b32_binary_variant(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         or_instruction = next(
             instruction
             for instruction in database.instructions
@@ -1285,7 +1261,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_xor_uses_a_fixed_b32_binary_variant(self) -> None:
-        database = load_codegen_database(spec_dir=REPO_ROOT / "instructions/ptx_spec")
+        database = self.database
         xor = next(item for item in database.instructions if item.opcode == "xor")
         instruction = from_instruction_spec(xor)
         self.assertEqual(instruction.cpp_name, "Xor")
@@ -1297,7 +1273,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_not_uses_a_fixed_b32_unary_variant(self) -> None:
-        database = load_codegen_database(spec_dir=REPO_ROOT / "instructions/ptx_spec")
+        database = self.database
         not_instruction = next(item for item in database.instructions if item.opcode == "not")
         instruction = from_instruction_spec(not_instruction)
         self.assertEqual(instruction.cpp_name, "Not")
@@ -1309,7 +1285,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_shl_uses_fixed_b32_data_and_u32_amount(self) -> None:
-        database = load_codegen_database(spec_dir=REPO_ROOT / "instructions/ptx_spec")
+        database = self.database
         shl = next(item for item in database.instructions if item.opcode == "shl")
         instruction = from_instruction_spec(shl)
         self.assertEqual(instruction.cpp_name, "Shl")
@@ -1321,7 +1297,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_shr_uses_fixed_u32_data_and_count(self) -> None:
-        database = load_codegen_database(spec_dir=REPO_ROOT / "instructions/ptx_spec")
+        database = self.database
         shr = next(item for item in database.instructions if item.opcode == "shr")
         instruction = from_instruction_spec(shr)
         self.assertEqual(instruction.cpp_name, "Shr")
@@ -1333,9 +1309,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_mov_uses_scalar_and_predicate_sources(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         mov = next(
             instruction
             for instruction in database.instructions
@@ -1473,9 +1447,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
 
     def test_mapa_uses_cluster_address_without_function_symbols(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         mapa = next(
             instruction
             for instruction in database.instructions
@@ -1524,9 +1496,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_getctarank_uses_cluster_address_and_u32_rank_destination(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         getctarank = next(
             instruction
             for instruction in database.instructions
@@ -1974,9 +1944,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
                              ResolvedRegisterWidthPolicy.EXACT)
 
     def test_ld_and_st_scalar_model_constraints(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         ld = next(
             instruction
             for instruction in database.instructions
@@ -2424,9 +2392,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_ldu_global_u32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         ldu = next(
             instruction
             for instruction in database.instructions
@@ -2459,9 +2425,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_prefetch_global_l1_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         prefetch = next(
             instruction
             for instruction in database.instructions
@@ -2489,9 +2453,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_prefetchu_l1_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         prefetchu = next(
             instruction
             for instruction in database.instructions
@@ -2514,9 +2476,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_createpolicy_fractional_l2_evict_last_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         createpolicy = next(
             instruction
             for instruction in database.instructions
@@ -2548,9 +2508,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_applypriority_global_l2_evict_normal_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         applypriority = next(
             instruction
             for instruction in database.instructions
@@ -2578,9 +2536,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.address_alignments[0].alignment, 128)
 
     def test_discard_global_l2_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         discard = next(
             instruction
             for instruction in database.instructions
@@ -2607,9 +2563,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.address_alignments[0].alignment, 128)
 
     def test_setmaxnreg_inc_sync_aligned_model_and_generator(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         setmaxnreg = next(
             instruction
             for instruction in database.instructions
@@ -2673,9 +2627,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn(".divisor = uint64_t{8ULL},", descriptor)
 
     def test_cp_async_ca_shared_global_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         cp = next(instruction for instruction in database.instructions if instruction.opcode == "cp")
         resolved = from_instruction_spec(cp)
         variant = resolved.variants[0]
@@ -2717,9 +2669,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_cp_async_mbarrier_arrive_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         cp = next(instruction for instruction in database.instructions if instruction.opcode == "cp")
         variants = from_instruction_spec(cp).variants[4:8]
 
@@ -2755,7 +2705,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             self.assertEqual(alignment.alignment, 8)
 
     def test_clusterlaunchcontrol_try_cancel_model(self) -> None:
-        database = load_codegen_database(spec_dir=REPO_ROOT / "instructions/ptx_spec")
+        database = self.database
         instruction = next(
             instruction
             for instruction in database.instructions
@@ -2842,9 +2792,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_cp_async_commit_group_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         cp = next(instruction for instruction in database.instructions if instruction.opcode == "cp")
         variant = from_instruction_spec(cp).variants[1]
 
@@ -2857,9 +2805,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_cp_async_wait_group_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         cp = next(instruction for instruction in database.instructions if instruction.opcode == "cp")
         variant = from_instruction_spec(cp).variants[2]
 
@@ -2881,9 +2827,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_cp_async_wait_all_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         cp = next(instruction for instruction in database.instructions if instruction.opcode == "cp")
         variant = from_instruction_spec(cp).variants[3]
 
@@ -2896,9 +2840,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_ldmatrix_sync_aligned_m8n8_x2_shared_b16_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         ldmatrix = next(
             instruction for instruction in database.instructions if instruction.opcode == "ldmatrix"
         )
@@ -2939,9 +2881,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(alignment.alignment, 16)
 
     def test_mma_sync_aligned_m16n8k8_row_col_f32_f16_f16_f32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         mma = next(
             instruction for instruction in database.instructions if instruction.opcode == "mma"
         )
@@ -3001,9 +2941,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("std::expected<Mma, ResolveDiagnostic>", source)
 
     def test_cp_generator_emits_immediate_value_checker(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_data_movement.gen.cpp"
             descriptor_path = Path(directory) / "resolved_ir_checker_descriptor.gen.cpp"
@@ -3049,9 +2987,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn('.maximum = ~uint64_t{0},', descriptor)
 
     def test_membar_cta_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         membar = next(
             instruction
             for instruction in database.instructions
@@ -3072,9 +3008,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(variant.operand_layouts[0].bindings, ())
 
     def test_fence_acq_rel_cta_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         fence = next(
             instruction
             for instruction in database.instructions
@@ -3135,9 +3069,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(release_sync.operand_layouts[0].bindings, ())
 
     def test_atom_global_relaxed_cta_add_u32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         atom = next(
             instruction
             for instruction in database.instructions
@@ -3176,9 +3108,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(bindings[1].state_space_modifier_field_id, "state_space")
 
     def test_red_global_relaxed_cta_add_u32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         red = next(
             instruction
             for instruction in database.instructions
@@ -3213,9 +3143,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(bindings[0].state_space_modifier_field_id, "state_space")
 
     def test_activemask_b32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         activemask = next(
             instruction
             for instruction in database.instructions
@@ -3239,9 +3167,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_vote_sync_ballot_b32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         vote = next(
             instruction
             for instruction in database.instructions
@@ -3272,9 +3198,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_shfl_sync_idx_b32_model(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         shfl = next(
             instruction
             for instruction in database.instructions
@@ -3309,9 +3233,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
 
     def test_shfl_generator_emits_pair_operand_view(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_data_movement.gen.cpp"
             generate_resolved_ir_source(
@@ -3328,9 +3250,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("selected.dst.value.data\n                      ?", source)
 
     def test_setp_generator_emits_predicate_pair_operand_view(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_arithmetic.gen.cpp"
             generate_resolved_ir_source(
@@ -3348,9 +3268,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("selected.dst.value.second.register_ref.declared_type", source)
 
     def test_ld_and_st_cache_defaults_use_unspecified_sentinel(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         for opcode in ("ld", "st"):
             spec = next(
@@ -3379,9 +3297,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 self.assertEqual(cache_binding.default_value.value, "unspecified")
 
     def test_generate_resolved_ir_header(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir.gen.hpp"
@@ -3535,9 +3451,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("}  // namespace ptx_frontend::resolved_ir", source)
 
     def test_generate_resolved_instruction_dispatch_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_dispatch.gen.cpp"
@@ -3624,9 +3538,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("Unknown PTX opcode", source)
 
     def test_generate_control_flow_resolved_ir_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_control_flow.gen.cpp"
@@ -3651,9 +3563,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("CheckResult check<Trap>(", source)
 
     def test_generate_data_movement_resolved_ir_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_data_movement.gen.cpp"
@@ -3730,9 +3640,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn("check_memory_vector(", source)
 
     def test_generate_category_resolved_ir_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_arithmetic.gen.cpp"
@@ -3818,9 +3726,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             self.assertNotIn(opcode_wrapper, checker_source)
 
     def test_generate_private_resolved_descriptor_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_descriptor.gen.cpp"
@@ -3939,9 +3845,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn('.capabilities = {{"tensor"}}', parameter_source)
 
     def test_generate_private_checker_descriptor_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "resolved_ir_checker_descriptor.gen.cpp"

--- a/python/tests/ir/test_syntax_ast.py
+++ b/python/tests/ir/test_syntax_ast.py
@@ -47,6 +47,9 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         database = load_codegen_database(
             spec_dir=REPO_ROOT / "instructions/ptx_spec",
         )
+        # Repository specs remain unchanged.
+        # Tests needing mutation load their own fixture.
+        cls.database = database
         add = next(
             instruction
             for instruction in database.instructions
@@ -278,9 +281,7 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         )
 
     def test_mov_source_layout_covers_data_and_address_forms(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         mov = next(
             instruction
             for instruction in database.instructions
@@ -307,9 +308,7 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         )
 
     def test_mapa_cluster_source_layout_allows_register_symbol_or_address_forms(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         mapa = next(
             instruction
             for instruction in database.instructions
@@ -337,9 +336,7 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         )
 
     def test_ld_layout_requires_address_syntax(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
         ld = next(
             instruction
             for instruction in database.instructions
@@ -1818,9 +1815,7 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         self.assertTrue(source.endswith("}"))
 
     def test_generate_private_syntax_descriptor_source(self) -> None:
-        database = load_codegen_database(
-            spec_dir=REPO_ROOT / "instructions/ptx_spec",
-        )
+        database = self.database
 
         with tempfile.TemporaryDirectory() as directory:
             output_path = Path(directory) / "syntax_descriptor.gen.cpp"

--- a/submod/resolved_ir/CMakeLists.txt
+++ b/submod/resolved_ir/CMakeLists.txt
@@ -79,11 +79,22 @@ if(BUILD_TESTING)
         VERBATIM)
     add_custom_target(modern_operand_resolved_ir_codegen
         DEPENDS ${PTX_MODERN_OPERAND_TEST_GENERATED_FILES})
+    # Build these objects once for both the fixture executable and the topology
+    # regression, which directly compiles the same generated source set.
+    add_library(modern_operand_resolved_ir_generated OBJECT
+        ${PTX_MODERN_OPERAND_TEST_GENERATED_SRCS})
+    add_dependencies(modern_operand_resolved_ir_generated
+        modern_operand_resolved_ir_codegen)
+    target_include_directories(modern_operand_resolved_ir_generated
+        PUBLIC "${PTX_MODERN_OPERAND_TEST_GENERATED_PUBLIC}"
+               "$<TARGET_PROPERTY:resolved_ir,INTERFACE_INCLUDE_DIRECTORIES>"
+        PRIVATE "${PTX_MODERN_OPERAND_TEST_GENERATED_PRIVATE}")
+    target_link_libraries(modern_operand_resolved_ir_generated
+        PRIVATE ptx_frontend::base ptx_frontend::binding ptx_frontend::syntax
+                ptx_frontend::common ptx_frontend::semantic fmt::fmt)
     add_library(modern_operand_resolved_ir STATIC
         ${resolved_ir_srcs}
-        ${PTX_MODERN_OPERAND_TEST_GENERATED_SRCS})
-    add_dependencies(modern_operand_resolved_ir
-        modern_operand_resolved_ir_codegen)
+        $<TARGET_OBJECTS:modern_operand_resolved_ir_generated>)
     target_include_directories(modern_operand_resolved_ir
         PUBLIC "${PTX_MODERN_OPERAND_TEST_GENERATED_PUBLIC}"
                "$<TARGET_PROPERTY:resolved_ir,INTERFACE_INCLUDE_DIRECTORIES>"

--- a/submod/resolved_ir/test/codegen_topology_reconfigure.cmake
+++ b/submod/resolved_ir/test/codegen_topology_reconfigure.cmake
@@ -108,7 +108,7 @@ endif()
 
 set(_build_command
     "${CMAKE_COMMAND}" --build "${_nested_binary_dir}"
-    --target modern_operand_resolved_ir)
+    --target modern_operand_resolved_ir_generated)
 if(DEFINED PTX_TEST_CONFIG AND NOT PTX_TEST_CONFIG STREQUAL "")
     list(APPEND _build_command --config "${PTX_TEST_CONFIG}")
 endif()
@@ -132,8 +132,8 @@ string(REPLACE "codegen_category: test" "codegen_category: topology"
     _fixture_after "${_fixture_before}")
 file(WRITE "${_fixture}" "${_fixture_after}")
 file(GLOB_RECURSE _old_partition_objects
-    "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir.dir/*/resolved_ir_test.gen.cpp.o"
-    "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir.dir/*/resolved_ir_test.gen.cpp.obj")
+    "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir_generated.dir/*/resolved_ir_test.gen.cpp.o"
+    "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir_generated.dir/*/resolved_ir_test.gen.cpp.obj")
 
 execute_process(
     COMMAND ${_build_command}
@@ -153,8 +153,8 @@ endif()
 
 if(_failure STREQUAL "")
     file(GLOB_RECURSE _new_partition_objects
-        "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir.dir/*/resolved_ir_topology.gen.cpp.o"
-        "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir.dir/*/resolved_ir_topology.gen.cpp.obj")
+        "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir_generated.dir/*/resolved_ir_topology.gen.cpp.o"
+        "${_nested_binary_dir}/submod/resolved_ir/CMakeFiles/modern_operand_resolved_ir_generated.dir/*/resolved_ir_topology.gen.cpp.obj")
     list(LENGTH _new_partition_objects _new_partition_object_count)
     if(_new_partition_object_count EQUAL 0)
         string(APPEND _failure

--- a/submod/resolved_ir/test/package_consumer/CMakeLists.txt
+++ b/submod/resolved_ir/test/package_consumer/CMakeLists.txt
@@ -69,6 +69,18 @@ endif()
 if(NOT EXISTS "${ptx_frontend_PTX_SPEC_SCHEMA}")
     message(FATAL_ERROR "Installed PTX schema is missing")
 endif()
+if(DEFINED PTX_FRONTEND_TEST_EXPECTED_PTX_SPEC_DIR)
+    if(NOT "${ptx_frontend_PTX_SPEC_DIR}" STREQUAL
+           "${PTX_FRONTEND_TEST_EXPECTED_PTX_SPEC_DIR}")
+        message(FATAL_ERROR "Installed PTX spec path did not preserve custom data dir")
+    endif()
+    get_filename_component(_expected_ptx_data_dir
+        "${PTX_FRONTEND_TEST_EXPECTED_PTX_SPEC_DIR}" DIRECTORY)
+    if(NOT "${ptx_frontend_PTX_SPEC_SCHEMA}" STREQUAL
+           "${_expected_ptx_data_dir}/ptx-instr-v1.schema.yaml")
+        message(FATAL_ERROR "Installed PTX schema path did not preserve custom data dir")
+    endif()
+endif()
 if(COMMAND ptx_frontend_generate)
     message(FATAL_ERROR "Installed package unexpectedly exports codegen")
 endif()

--- a/submod/resolved_ir/test/package_consumer/run_test.cmake
+++ b/submod/resolved_ir/test/package_consumer/run_test.cmake
@@ -180,18 +180,49 @@ if(DEFINED PTX_MAGIC_ENUM_DIR AND NOT PTX_MAGIC_ENUM_DIR STREQUAL "")
         "-Dmagic_enum_DIR=${PTX_MAGIC_ENUM_DIR}")
 endif()
 execute_process(COMMAND ${_nondefault_configure_command} COMMAND_ERROR_IS_FATAL ANY)
-execute_process(COMMAND "${CMAKE_COMMAND}" --build "${_nondefault_build_dir}"
-    --parallel --target resolved_ir COMMAND_ERROR_IS_FATAL ANY)
-execute_process(COMMAND "${CMAKE_COMMAND}" --install "${_nondefault_build_dir}"
-    --prefix "${_nondefault_install_dir}" COMMAND_ERROR_IS_FATAL ANY)
+
+# Reuse the default prefix's compiled targets. The custom-data configure only
+# needs to install ptx_spec and replace the package config that records its
+# relocated data path.
+file(COPY "${_install_dir}/" DESTINATION "${_nondefault_install_dir}")
+file(REMOVE_RECURSE
+    "${_nondefault_install_dir}/share/ptx_frontend/ptx_spec")
+file(REMOVE "${_nondefault_install_dir}/share/ptx_frontend/ptx-instr-v1.schema.yaml")
+set(_nondefault_install_command
+    "${CMAKE_COMMAND}" --install "${_nondefault_build_dir}"
+    --prefix "${_nondefault_install_dir}" --component ptx_spec)
+if(DEFINED PTX_TEST_CONFIG AND NOT PTX_TEST_CONFIG STREQUAL "")
+    list(APPEND _nondefault_install_command --config "${PTX_TEST_CONFIG}")
+endif()
+execute_process(COMMAND ${_nondefault_install_command} COMMAND_ERROR_IS_FATAL ANY)
+
+set(_nondefault_package_config
+    "${_nondefault_build_dir}/ptx_frontendConfig.cmake")
+set(_nondefault_installed_package_config
+    "${_nondefault_install_dir}/lib/cmake/ptx_frontend/ptx_frontendConfig.cmake")
+if(NOT EXISTS "${_nondefault_package_config}")
+    message(FATAL_ERROR "Custom-data package config was not generated")
+endif()
+file(READ "${_nondefault_package_config}" _nondefault_package_config_content)
+if(NOT _nondefault_package_config_content MATCHES
+       "custom-data/ptx_frontend/ptx_spec")
+    message(FATAL_ERROR "Custom-data package config does not record the PTX spec path")
+endif()
+file(COPY_FILE "${_nondefault_package_config}"
+    "${_nondefault_installed_package_config}" ONLY_IF_DIFFERENT)
 
 if(NOT EXISTS "${_nondefault_install_dir}/custom-data/ptx_frontend/ptx_spec/arithmetic.yaml")
     message(FATAL_ERROR "Non-default PTX spec install location is missing")
+endif()
+if(EXISTS "${_nondefault_install_dir}/share/ptx_frontend/ptx_spec" OR
+   EXISTS "${_nondefault_install_dir}/share/ptx_frontend/ptx-instr-v1.schema.yaml")
+    message(FATAL_ERROR "Non-default install retained default PTX spec resources")
 endif()
 set(_nondefault_consumer_command
     "${CMAKE_COMMAND}" -S "${_relocated_source_dir}" -B "${_nondefault_consumer_build_dir}"
     ${_nested_generator_args}
     "-DCMAKE_PREFIX_PATH=${_nondefault_install_dir}"
+    "-DPTX_FRONTEND_TEST_EXPECTED_PTX_SPEC_DIR=${_nondefault_install_dir}/custom-data/ptx_frontend/ptx_spec"
     ${_consumer_dependency_args})
 execute_process(COMMAND ${_nondefault_consumer_command} COMMAND_ERROR_IS_FATAL ANY)
 


### PR DESCRIPTION
CI repeatedly rebuilt dependencies and project objects because integration-branch caches were stale and immutable cache keys discarded newly compiled results. Refresh caches on dev/main pushes, isolate them by runner/toolchain identity, and save rolling snapshots. Cache Python downloads and expose configure/build/test as separate timed steps.

Reduce repeated test work while retaining coverage: reuse unchanged Python class fixtures, compile generated topology objects through the same object library used by the fixture executable, and reuse installed binaries for the custom-data consumer check. The latter still exercises real resource installation, exact spec/schema paths, relocation, and negative cases.

Validation:

- Debug and Release builds passed; 610/610 C++ tests passed in each configuration.
- Package consumer tests passed in both configurations.
- Full Python suite passed: 224 tests. An idle, same-environment comparison of the same 83 resolved-IR tests improved from 38.987s to 1.112s.
- Workflow syntax, cache-key/trigger checks, and git diff checks passed. Actionlint's unsupported existing ubuntu-26.04 label diagnostic was excluded; no runner label was changed.

End-to-end hosted CI improvement remains to be measured. The new cache namespace starts cold; subsequent runs and PRs targeting warmed dev/main branches should benefit.
