### PR TITLE
fix: align PTX modifier order with explicit legacy aliases

### DIFF
--- a/docs/us-en/python_generator_model.md
+++ b/docs/us-en/python_generator_model.md
@@ -25,7 +25,7 @@ definitions of the same opcode. The minimal stable model in `ptx_frontend.code_g
 ```python
 InstructionSpec(opcode, variants, syntax_forms, source_categories,
                 codegen_category)
-VariantSpec(name, availability, modifiers, operand_layouts, rule)
+VariantSpec(name, availability, modifiers, operand_layouts, rule, ..., modifier_order_aliases)
 OperandLayoutSpec(name, operands)
 ModifierSpec(name, kind, presence, values, value, token, default)
 OperandSpec(name, kind, role, access, type_expression)
@@ -36,11 +36,13 @@ YAML documentation, examples, and constraints that have no generator consumer
 must not silently leak into the C++ representation.
 
 After merging an opcode, the database validates the selector language. Active
-modifier slots within one variant must have disjoint spelling sets, and the
-unordered spelling sets accepted by different variants must not overlap. Slot
-names are variant-local, so one spelling may bind different slots across
-variants. These checks make candidate-local C++ binding deterministic while
-remaining independent of modifier source order.
+modifier slots may share spellings only when required/fixed positions make
+ordered binding unambiguous. Canonical modifier sequences and explicit
+`modifier_order_aliases` must bind identically when they overlap within a
+variant; accepted sequences must not overlap across variants. Slot names are
+variant-local, so one spelling may bind different slots across variants. These
+checks keep candidate-local C++ binding deterministic without accepting
+arbitrary source order.
 
 ## Normalization
 
@@ -65,7 +67,7 @@ the compatibility boundary, not the emitters.
 
 ```python
 SyntaxInstructionDescriptor(opcode, variants)
-SyntaxVariantDescriptor(variant_id, modifiers, operand_layouts)
+SyntaxVariantDescriptor(variant_id, modifiers, operand_layouts, modifier_order_aliases=())
 SyntaxModifierDescriptor(kind_id, presence, allowed_spellings)
 SyntaxOperandLayoutDescriptor(layout_id, kind, slots)
 ```

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -354,12 +354,14 @@ be disguised as `Flat`.
 generated opcode-specific implementation. Shared logic performs these steps:
 
 1. The common matcher diagnoses spellings unknown to the whole syntax
-   descriptor, then binds spellings to unique active slots separately inside
-   each candidate variant. Reusing one slot is a user diagnostic; one spelling
-   owned by multiple active slots in a variant is a descriptor bug.
+   descriptor, then binds spellings to ordered slots separately inside each
+   candidate variant. Required/fixed slots may share a spelling when their
+   positions disambiguate it; repeated optional spellings are rejected by the
+   database. Reusing one slot is a user diagnostic.
 2. `selectVariant<T>` selects exactly one variant from those variant-local
    bindings. `absent`, `optional`, and `required/fixed` match by slot and
-   allowed value, independent of source modifier order.
+   allowed value in canonical or explicitly declared alias order. Order aliases
+   do not create new semantic variants or change field bindings.
 3. The selected variant chooses exactly one `OperandLayout` from AST shapes and
    arity.
 4. `resolve_fields` resolves the common execution predicate and converts

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -60,8 +60,8 @@ exception that combines PTX 9.7.1 through 9.7.5 under one category.
 Merging follows sorted spec-path and in-file declaration order. The file path is
 already the definition source, so no separate `fragment` ID is needed. Before
 emission, the database rejects duplicate variant IDs, PascalCase C++ variant
-name collisions, a spelling owned by multiple active modifier slots within one
-variant, and variants whose accepted unordered modifier sets overlap.
+name collisions, ambiguous modifier-slot bindings, and variants whose accepted
+ordered modifier sequences overlap (including declared order aliases).
 
 ## Variants and modifiers
 
@@ -146,10 +146,39 @@ source-absence defaults, not spellable modifier values.
 from `value` or `values`. `name` is the modifier-slot ID local to one variant,
 while `kind` determines the resolved value type. The same spelling may bind a
 different slot in another variant: `.f32` binds `type` in standard Add and
-`result_type` in mixed Add. Within one variant, each spelling must have one
-unique active owner. Matching ignores source order, and distinct variants must
-accept disjoint unordered modifier sets; the database rejects overlap before
-emission.
+`result_type` in mixed Add. Matching follows the `modifiers` declaration order;
+optional and absent slots may be skipped, but required slots may not. Repeated
+spellings are allowed only between required/fixed slots when their ordered
+positions disambiguate the binding. Distinct variants must accept disjoint
+ordered modifier sequences; the database rejects overlap before emission.
+
+Use the pinned PTX manual's **Syntax** order as the canonical declaration order.
+When compatibility evidence supports another spelling, a variant may declare
+`modifier_order_aliases`: each item is a complete permutation of its modifier
+slot names, including absent slots. For example, mixed Add/Sub use canonical
+`rounding, sat, result_type, input_type, ftz` and preserve the historical order:
+
+```yaml
+modifier_order_aliases:
+  - [rounding, result_type, input_type, ftz, sat]
+```
+
+Aliases select the same variant and bind the same semantic fields, defaults,
+and source locations; they do not permit arbitrary reordering or relax checker
+constraints. The database rejects incomplete permutations and aliases that
+give the same source sequence different slot bindings.
+
+This canonical-order policy resolves an inconsistency in the pinned
+[mixed-precision Sub documentation](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#mixed-precision-floating-point-instructions-sub):
+Syntax places `.sat` before the types, while an example places it after them.
+Both forms are retained; Syntax is not assumed to enumerate every spelling
+accepted by an assembler.
+
+Consumers generating code from the Python package should upgrade it together
+with the C++ frontend and regenerate/rebuild their artifacts. Stable variant
+IDs and field names do not imply binary-layout compatibility: canonical slot
+reordering also changes generated member order, and syntax descriptors now
+carry an additional alias span.
 
 One `values` item may be an object to add target availability for a semantic
 value:

--- a/docs/zh-han/python_generator_model.md
+++ b/docs/zh-han/python_generator_model.md
@@ -24,7 +24,7 @@ YAML files
 ```python
 InstructionSpec(opcode, variants, syntax_forms, source_categories,
                 codegen_category)
-VariantSpec(name, availability, modifiers, operand_layouts, rule)
+VariantSpec(name, availability, modifiers, operand_layouts, rule, ..., modifier_order_aliases)
 OperandLayoutSpec(name, operands)
 ModifierSpec(name, kind, presence, values, value, token, default)
 OperandSpec(name, kind, role, access, type_expression)
@@ -33,10 +33,11 @@ OperandSpec(name, kind, role, access, type_expression)
 该模型只保存生成当前 frontend 所需的字段。YAML 中的文档、example、constraint 等
 尚未被 generator 使用的元数据，不应悄悄混入 C++ 表示。
 
-database 在合并 opcode 后验证 selector 语言：每个 variant 内，活动 modifier slot 的
-spelling 集合必须两两不交；不同 variant 接受的无序 spelling 集合必须互斥。slot name
-只在 variant 内有意义，所以同一 spelling 可以跨 variant 绑定不同 slot。校验通过后，
-C++ matcher 才能对每个候选 variant 做确定性的局部绑定，同时保持 modifier 顺序无关。
+database 在合并 opcode 后验证 selector 语言：只有 required/fixed slot 的有序位置
+能够消除绑定歧义时，活动 modifier slot 才可以共享 spelling。同一 variant 的规范
+序列与显式 `modifier_order_aliases` 若有交集，必须产生相同绑定；不同 variant 接受
+的序列必须互斥。slot name 只在 variant 内有意义，所以同一 spelling 可以跨 variant
+绑定不同 slot。这些校验使 C++ matcher 能确定性地局部绑定，而不接受任意源码顺序。
 
 ## Normalization
 
@@ -60,7 +61,7 @@ C++ matcher 才能对每个候选 variant 做确定性的局部绑定，同时�
 
 ```python
 SyntaxInstructionDescriptor(opcode, variants)
-SyntaxVariantDescriptor(variant_id, modifiers, operand_layouts)
+SyntaxVariantDescriptor(variant_id, modifiers, operand_layouts, modifier_order_aliases=())
 SyntaxModifierDescriptor(kind_id, presence, allowed_spellings)
 SyntaxOperandLayoutDescriptor(layout_id, kind, slots)
 ```

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -288,10 +288,12 @@ tag/payload 不一致是损坏的 resolved IR，诊断种类为
 实现，公共逻辑依次执行：
 
 1. 公共 matcher 先用全部 syntax descriptor 诊断真正未知的 spelling，再分别在每个
-   候选 variant 内把 spelling 绑定到唯一活动 slot。重复占用一个 slot 会被诊断；单个
-   variant 内一个 spelling 归属多个活动 slot 则是 descriptor bug。
+   候选 variant 内把 spelling 绑定到有序 slot。required/fixed slot 可以通过位置
+   消除共享 spelling 的歧义；database 会拒绝涉及 optional slot 的重复 spelling。
+   重复占用一个 slot 会被诊断。
 2. `selectVariant<T>` 只依据上述 variant-local 绑定选择唯一 variant。`absent`、
-   `optional`、`required/fixed` 都按 slot 和允许值匹配，不依赖源码 modifier 顺序。
+   `optional`、`required/fixed` 都按 slot、允许值和规范或显式别名顺序匹配。
+   顺序别名不产生新的语义 variant，也不改变 field 绑定。
 3. 在选定 variant 内按 AST operand shape 与 arity 选择唯一 `OperandLayout`。
 4. `resolve_fields` 解析公共 execution predicate，并按 resolved descriptor 把 modifier 和
    operand 转换为带位置的 resolved 值；有 binding context 时，guard 必须绑定到 `.pred`

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -52,8 +52,8 @@ PTX 9.7.1 至 9.7.5 合并的例外。
 
 合并按 spec 文件路径及文件内声明顺序进行。文件路径本身就是定义来源，不再需要额外的
 `fragment` ID。database 会在发射代码前拒绝重复 variant ID、PascalCase 后冲突的
-C++ variant 名、同一 variant 内一个 spelling 归属多个活动 modifier slot，以及可接受
-同一无序 modifier 集合的重叠 variant。
+C++ variant 名、存在歧义的 modifier slot 绑定，以及可接受同一有序 modifier 序列
+（包括显式声明的顺序别名）的重叠 variant。
 
 ## Variant 与 modifier
 
@@ -133,9 +133,33 @@ default，不是可拼写的 modifier value。
 `flag` 通常给出 `token: ".sat"`；`type` 的 token 通常从 `value` 或 `values` 推导。
 `name` 是当前 variant 内的 modifier slot ID，`kind` 决定解析后的值类型。同一个
 spelling 可以在不同 variant 绑定不同 slot，例如 `.f32` 在普通 Add 中绑定 `type`，在
-mixed Add 中绑定 `result_type`；但在单个 variant 内必须唯一归属一个活动 slot。
-modifier matching 不依赖源码顺序。不同 variant 接受的无序 modifier 集合必须互斥，
-否则 database 会在生成前拒绝。
+mixed Add 中绑定 `result_type`。matching 遵循 `modifiers` 的声明顺序；可以跳过
+optional 和 absent slot，但不能跳过 required slot。只有 required/fixed slot 可以
+共享 spelling，且必须由有序位置消除绑定歧义。不同 variant 接受的有序 modifier
+序列必须互斥，否则 database 会在生成前拒绝。
+
+以固定版本 PTX 手册的 **Syntax** 顺序作为规范声明顺序。有兼容性证据支持其他拼写时，
+variant 可以声明 `modifier_order_aliases`：每项必须是全部 modifier slot 名称的完整
+排列，包括 absent slot。例如 mixed Add/Sub 的规范顺序是
+`rounding, sat, result_type, input_type, ftz`，同时保留历史顺序：
+
+```yaml
+modifier_order_aliases:
+  - [rounding, result_type, input_type, ftz, sat]
+```
+
+别名选择同一个 variant，绑定相同的语义 field、default 与源码位置；它不允许任意
+重排，也不放宽 checker 约束。database 会拒绝不完整的排列，以及让同一源码序列
+产生不同 slot 绑定的别名。
+
+此规范顺序策略用于解决固定版本
+[mixed-precision Sub 文档](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#mixed-precision-floating-point-instructions-sub)
+中的不一致：Syntax 将 `.sat` 放在 type 之前，而一个 example 将它放在 type 之后。
+两种形式都保留；这不意味着 Syntax 穷举了 assembler 接受的所有拼写。
+
+使用 Python 包生成代码的消费者应同步升级 C++ frontend，并重新生成、编译产物。
+variant ID 和 field 名称稳定不代表二进制布局兼容：规范 slot 重排也会改变生成成员的
+顺序，syntax descriptor 还增加了 alias span。
 
 `values` 的单项可改写为对象，为某个语义值追加 target availability：
 

--- a/instructions/schemas/ptx-instr-v1.schema.yaml
+++ b/instructions/schemas/ptx-instr-v1.schema.yaml
@@ -1478,6 +1478,19 @@ $defs:
         items:
           $ref: "#/$defs/modifier"
 
+      modifier_order_aliases:
+        description: >
+          Complete historical source orders for this variant's modifier slots.
+          Each entry is semantically validated as a unique permutation of the
+          canonical modifiers list, including absent slots.
+        type: array
+        uniqueItems: true
+        items:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/$defs/schema_identifier"
+
       operands:
         description: >
           Either a $name operand-pattern reference or an explicit operand list. If omitted,

--- a/python/code_gen/_frontend/gen_syntax_ast_arch.py
+++ b/python/code_gen/_frontend/gen_syntax_ast_arch.py
@@ -145,7 +145,13 @@ def _emit_variant_storage(
         for index, modifier in enumerate(variant.modifiers)
         if modifier.allowed_spellings
     )
-    modifiers = _emit_modifier_array(name, variant.modifiers)
+    modifiers = _emit_modifier_array(
+        f"{name}_modifiers",
+        name,
+        variant.modifiers,
+        tuple(range(len(variant.modifiers))),
+    )
+    modifier_order_aliases = _emit_modifier_order_alias_arrays(name, variant)
     slot_arrays = "\n\n".join(
         _emit_operand_slot_array(name, index, layout)
         for index, layout in enumerate(variant.operand_layouts)
@@ -154,7 +160,13 @@ def _emit_variant_storage(
 
     parts = [
         part
-        for part in (allowed_value_arrays, modifiers, slot_arrays, layouts)
+        for part in (
+            allowed_value_arrays,
+            modifiers,
+            modifier_order_aliases,
+            slot_arrays,
+            layouts,
+        )
         if part
     ]
     return "\n\n".join(parts)
@@ -174,16 +186,52 @@ def _emit_allowed_value_array(
 
 
 def _emit_modifier_array(
-    variant_name: str,
+    array_name: str,
+    canonical_variant_name: str,
     modifiers: tuple[SyntaxModifierDescriptor, ...],
+    canonical_indexes: tuple[int, ...],
 ) -> str:
     entries = ",\n".join(
-        _emit_modifier_entry(variant_name, index, modifier)
-        for index, modifier in enumerate(modifiers)
+        _emit_modifier_entry(canonical_variant_name, index, modifier)
+        for index, modifier in zip(canonical_indexes, modifiers, strict=True)
     )
     return f"""\
   inline static constexpr std::array<check_end::SyntaxModifierDescriptor, {len(modifiers)}>
-      {variant_name}_modifiers = {{
+      {array_name} = {{
+{entries}
+      }};"""
+
+
+def _emit_modifier_order_alias_arrays(
+    variant_name: str, variant: SyntaxVariantDescriptor
+) -> str:
+    """Emit complete historical modifier orders using canonical value storage."""
+
+    if not variant.modifier_order_aliases:
+        return ""
+
+    canonical_indexes = {
+        modifier.kind_id: index for index, modifier in enumerate(variant.modifiers)
+    }
+    arrays = "\n\n".join(
+        _emit_modifier_array(
+            f"{variant_name}_modifier_order_alias_{alias_index}",
+            variant_name,
+            alias,
+            tuple(canonical_indexes[modifier.kind_id] for modifier in alias),
+        )
+        for alias_index, alias in enumerate(variant.modifier_order_aliases)
+    )
+    entries = ",\n".join(
+        "          check_end::SyntaxModifierOrderDescriptor{"
+        f".modifiers = {variant_name}_modifier_order_alias_{alias_index}" "}"
+        for alias_index in range(len(variant.modifier_order_aliases))
+    )
+    return f"""\
+{arrays}
+
+  inline static constexpr std::array<check_end::SyntaxModifierOrderDescriptor, {len(variant.modifier_order_aliases)}>
+      {variant_name}_modifier_order_aliases = {{
 {entries}
       }};"""
 
@@ -276,11 +324,17 @@ def _emit_variant_descriptor(
     opcode: str,
 ) -> str:
     name = to_file_stem(variant.variant_id)
+    modifier_order_aliases = (
+        f"{name}_modifier_order_aliases"
+        if variant.modifier_order_aliases
+        else "{}"
+    )
     return f"""\
           check_end::SyntaxVariantDescriptor{{
               .variant_name = {_cpp_string(_cpp_variant_name(opcode, variant.variant_id))},
               .modifiers = {name}_modifiers,
               .operand_layouts = {name}_operand_layouts,
+              .modifier_order_aliases = {modifier_order_aliases},
           }}"""
 
 

--- a/python/code_gen/database.py
+++ b/python/code_gen/database.py
@@ -10,7 +10,7 @@ from typing import Any, TypeVar
 
 from ptx_frontend.base.utils import file_stem_to_pascal_case
 from .load_yaml import load_yaml
-from .model import InstructionSpec, VariantSpec, modifier_spellings
+from .model import InstructionSpec, ModifierSpec, VariantSpec, modifier_spellings
 from .normalize import normalize_instruction_spec
 from jsonschema import Draft202012Validator
 
@@ -190,17 +190,10 @@ def _validate_variant_modifier_exclusivity(instruction: InstructionSpec) -> None
 def _variant_modifier_language(
     opcode: str, variant: VariantSpec
 ) -> set[tuple[str, ...]]:
-    """Return every ordered source-modifier sequence accepted by one variant.
-
-    A spelling may bind to multiple required/fixed variant-local slots when
-    source order makes that binding unambiguous. Optional slots may not share
-    a spelling: generated descriptors rely on this invariant to bind greedily
-    without backtracking.
-    """
+    """Return the union of canonical and declared alias modifier languages."""
 
     slot_names: set[str] = set()
     owners_by_spelling: dict[str, list[tuple[str, str]]] = {}
-    language: set[tuple[str, ...]] = {()}
     for modifier in variant.modifiers:
         if modifier.name in slot_names:
             raise ValueError(
@@ -210,22 +203,18 @@ def _variant_modifier_language(
         slot_names.add(modifier.name)
 
         spellings = set(modifier_spellings(modifier))
-        if modifier.presence == "absent":
-            choices: set[str | None] = {None}
-        elif modifier.presence == "optional":
+        if modifier.presence == "optional":
             if not spellings:
                 raise ValueError(
                     f"opcode {opcode!r} variant {variant.name!r} optional "
                     f"modifier {modifier.name!r} has no source spelling"
                 )
-            choices = {None, *spellings}
-        else:
+        elif modifier.presence != "absent":
             if not spellings:
                 raise ValueError(
                     f"opcode {opcode!r} variant {variant.name!r} active "
                     f"modifier {modifier.name!r} has no source spelling"
                 )
-            choices = set(spellings)
 
         if modifier.presence != "absent":
             for spelling in spellings:
@@ -241,14 +230,47 @@ def _variant_modifier_language(
                     )
                 owners.append((modifier.name, modifier.presence))
 
+    modifiers_by_name = {modifier.name: modifier for modifier in variant.modifiers}
+    languages: dict[tuple[str, ...], tuple[str, ...]] = {}
+    orders = (
+        tuple(modifier.name for modifier in variant.modifiers),
+        *variant.modifier_order_aliases,
+    )
+    for order in orders:
+        language = _modifier_order_language(
+            tuple(modifiers_by_name[slot_name] for slot_name in order)
+        )
+        for sequence, binding in language.items():
+            previous_binding = languages.setdefault(sequence, binding)
+            if previous_binding != binding:
+                raise ValueError(
+                    f"opcode {opcode!r} variant {variant.name!r} modifier "
+                    f"order aliases bind {sequence!r} to different slot identities"
+                )
+    return set(languages)
+
+
+def _modifier_order_language(
+    modifiers: tuple[ModifierSpec, ...],
+) -> dict[tuple[str, ...], tuple[str, ...]]:
+    """Return source sequences and their slot bindings for one complete order."""
+
+    language: dict[tuple[str, ...], tuple[str, ...]] = {(): ()}
+    for modifier in modifiers:
+        spellings = set(modifier_spellings(modifier))
+        if modifier.presence == "absent":
+            choices: set[str | None] = {None}
+        elif modifier.presence == "optional":
+            choices = {None, *spellings}
+        else:
+            choices = set(spellings)
+
         language = {
-            combination
-            if choice is None
-            else (*combination, choice)
-            for combination in language
+            sequence if choice is None else (*sequence, choice):
+            binding if choice is None else (*binding, modifier.name)
+            for (sequence, binding) in language.items()
             for choice in choices
         }
-
     return language
 
 

--- a/python/code_gen/model.py
+++ b/python/code_gen/model.py
@@ -259,6 +259,10 @@ class VariantSpec:
     immediate_value: ImmediateValueConstraint | None = None
     immediate_ranges: tuple[ImmediateRangeConstraint, ...] = ()
     immediate_multiple_of: ImmediateMultipleOfConstraint | None = None
+    # Complete historical source orders for the variant-local modifier slots.
+    # The canonical order remains ``modifiers``; each alias includes absent
+    # slots so it can be validated as a permutation of that order.
+    modifier_order_aliases: tuple[tuple[str, ...], ...] = ()
 
 
 @dataclass(frozen=True)

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -734,6 +734,53 @@ def normalize_operand_layouts(
     return normalized_layouts
 
 
+def normalize_modifier_order_aliases(
+    raw_variant: dict[str, Any], modifiers: tuple[ModifierSpec, ...]
+) -> tuple[tuple[str, ...], ...]:
+    """Validate complete historical orders for one variant's modifier slots."""
+
+    raw_aliases = raw_variant.get("modifier_order_aliases", [])
+    if not isinstance(raw_aliases, list):
+        raise TypeError("modifier_order_aliases must be a list")
+
+    canonical_order = tuple(modifier.name for modifier in modifiers)
+    slot_names = set(canonical_order)
+    aliases: list[tuple[str, ...]] = []
+    for raw_alias in raw_aliases:
+        if not isinstance(raw_alias, list) or not all(
+            isinstance(slot, str) for slot in raw_alias
+        ):
+            raise TypeError("modifier_order_aliases entries must be slot-name lists")
+        alias = tuple(raw_alias)
+        unknown_slots = set(alias) - slot_names
+        if unknown_slots:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: modifier order alias names "
+                f"unknown slots {sorted(unknown_slots)!r}"
+            )
+        if len(set(alias)) != len(alias):
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: modifier order alias "
+                "repeats a modifier slot"
+            )
+        if len(alias) != len(canonical_order) or set(alias) != slot_names:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: modifier order alias must "
+                "contain every modifier slot"
+            )
+        if alias == canonical_order:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: modifier order alias "
+                "duplicates the canonical modifier order"
+            )
+        if alias in aliases:
+            raise ValueError(
+                f"variant {raw_variant['name']!r}: duplicate modifier order alias"
+            )
+        aliases.append(alias)
+    return tuple(aliases)
+
+
 def _modern_pack_interval(operand: OperandSpec) -> tuple[int, int] | None:
     if operand.minimum_elements is None:
         return None
@@ -1421,6 +1468,9 @@ def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, .
                 normalize_modifier(modifier, reusable_value_sets)
                 for modifier in raw_variant.get("modifiers", ())
             )
+            modifier_order_aliases = normalize_modifier_order_aliases(
+                raw_variant, modifiers
+            )
             operand_layouts = normalize_operand_layouts(
                 raw_variant, default_operands, operand_patterns
             )
@@ -1434,6 +1484,7 @@ def normalize_instruction_spec(spec: dict[str, Any]) -> tuple[InstructionSpec, .
                     availability=normalize_availability(raw_variant["availability"]),
                     modifiers=modifiers,
                     operand_layouts=operand_layouts,
+                    modifier_order_aliases=modifier_order_aliases,
                     rule=raw_variant.get("rule"),
                     operand_type_compatibilities=(
                         _normalize_operand_type_compatibilities(

--- a/python/code_gen/resources/ptx-instr-v1.schema.yaml
+++ b/python/code_gen/resources/ptx-instr-v1.schema.yaml
@@ -1478,6 +1478,19 @@ $defs:
         items:
           $ref: "#/$defs/modifier"
 
+      modifier_order_aliases:
+        description: >
+          Complete historical source orders for this variant's modifier slots.
+          Each entry is semantically validated as a unique permutation of the
+          canonical modifiers list, including absent slots.
+        type: array
+        uniqueItems: true
+        items:
+          type: array
+          uniqueItems: true
+          items:
+            $ref: "#/$defs/schema_identifier"
+
       operands:
         description: >
           Either a $name operand-pattern reference or an explicit operand list. If omitted,

--- a/python/code_gen/resources/ptx_spec/arithmetic.yaml
+++ b/python/code_gen/resources/ptx_spec/arithmetic.yaml
@@ -433,6 +433,12 @@ instructions:
             values:
               - $rounding_modes
 
+          - name: sat
+            kind: flag
+            presence: optional
+            default: false
+            token: .sat
+
           - name: result_type
             kind: type
             domain: scalar_types
@@ -451,17 +457,14 @@ instructions:
             kind: flag
             presence: absent
 
-          - name: sat
-            kind: flag
-            presence: optional
-            default: false
-            token: .sat
+        modifier_order_aliases:
+          - [rounding, result_type, input_type, ftz, sat]
         rule: mixed_precision.add
 
         examples:
           - ptx: "add.f32.f16 d, a, c;"
             valid: true
-          - ptx: "add.rz.f32.bf16.sat d, a, c;"
+          - ptx: "add.rz.sat.f32.bf16 d, a, c;"
             valid: true
 
   - opcode: sub
@@ -711,6 +714,12 @@ instructions:
             values:
               - $rounding_modes
 
+          - name: sat
+            kind: flag
+            presence: optional
+            default: false
+            token: .sat
+
           - name: result_type
             kind: type
             domain: scalar_types
@@ -729,17 +738,14 @@ instructions:
             kind: flag
             presence: absent
 
-          - name: sat
-            kind: flag
-            presence: optional
-            default: false
-            token: .sat
+        modifier_order_aliases:
+          - [rounding, result_type, input_type, ftz, sat]
         rule: mixed_precision.sub
 
         examples:
           - ptx: "sub.f32.f16 d, a, c;"
             valid: true
-          - ptx: "sub.rz.f32.bf16.sat d, a, c;"
+          - ptx: "sub.rz.sat.f32.bf16 d, a, c;"
             valid: true
 
   - opcode: mul

--- a/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
+++ b/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
@@ -1015,6 +1015,15 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - &memory_mmio
+            name: mmio
+            kind: flag
+            presence: optional
+            values:
+              - value: true
+                token: .mmio
+                availability: {ptx: "8.2", sm: 70}
+            default: false
           - &ld_semantics
             name: semantics
             kind: semantics
@@ -1046,15 +1055,6 @@ instructions:
               - value: sys
                 availability: {ptx: "6.0", sm: 70}
             default: none
-          - &memory_mmio
-            name: mmio
-            kind: flag
-            presence: optional
-            values:
-              - value: true
-                token: .mmio
-                availability: {ptx: "8.2", sm: 70}
-            default: false
           - name: cache
             kind: cache
             domain: cache_operators
@@ -1070,6 +1070,8 @@ instructions:
             values:
               - $ld_st_scalar_types
               - f64
+        modifier_order_aliases:
+          - [semantics, scope, mmio, cache, type]
         operands: $ld_scalar
         rule: data_movement.ld_generic
         constraints:
@@ -1094,6 +1096,9 @@ instructions:
           ptx: "1.0"
           sm: 0
         modifiers:
+          - *memory_mmio
+          - *ld_semantics
+          - *memory_scope
           - name: state_space
             kind: state_space
             domain: state_spaces
@@ -1107,9 +1112,6 @@ instructions:
               - value: $ld_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
-          - *ld_semantics
-          - *memory_scope
-          - *memory_mmio
           - name: type
             kind: type
             domain: scalar_types
@@ -1120,6 +1122,8 @@ instructions:
                 availability:
                   ptx: "1.0"
                   sm: 13
+        modifier_order_aliases:
+          - [state_space, cache, semantics, scope, mmio, type]
         operands: $ld_explicit_scalar
         rule: data_movement.ld_explicit
         constraints:
@@ -1265,6 +1269,8 @@ instructions:
           ptx: "1.0"
           sm: 0
         modifiers:
+          - *ld_semantics
+          - *memory_scope
           - name: state_space
             kind: state_space
             domain: state_spaces
@@ -1278,8 +1284,6 @@ instructions:
               - value: $ld_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
-          - *ld_semantics
-          - *memory_scope
           - name: vector
             kind: vector
             domain: vector_arities
@@ -1298,6 +1302,8 @@ instructions:
                 availability:
                   ptx: "1.0"
                   sm: 13
+        modifier_order_aliases:
+          - [state_space, cache, semantics, scope, vector, type]
         operands: $ld_explicit_vector
         rule: data_movement.ld_explicit
         constraints:
@@ -1701,6 +1707,7 @@ instructions:
           ptx: "2.0"
           sm: 20
         modifiers:
+          - *memory_mmio
           - &st_semantics
             name: semantics
             kind: semantics
@@ -1709,7 +1716,6 @@ instructions:
             values: [{value: weak, availability: {ptx: "6.0", sm: 70}}, {value: volatile, availability: {ptx: "1.1"}}, {value: relaxed, availability: {ptx: "6.0", sm: 70}}, {value: release, availability: {ptx: "6.0", sm: 70}}]
             default: omitted
           - *memory_scope
-          - *memory_mmio
           - name: cache
             kind: cache
             domain: cache_operators
@@ -1725,6 +1731,8 @@ instructions:
             values:
               - $ld_st_scalar_types
               - f64
+        modifier_order_aliases:
+          - [semantics, scope, mmio, cache, type]
         operands: $st_scalar
         rule: data_movement.st_generic
         constraints:
@@ -1747,6 +1755,9 @@ instructions:
           ptx: "1.0"
           sm: 0
         modifiers:
+          - *memory_mmio
+          - *st_semantics
+          - *memory_scope
           - name: state_space
             kind: state_space
             domain: state_spaces
@@ -1760,9 +1771,6 @@ instructions:
               - value: $st_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
-          - *st_semantics
-          - *memory_scope
-          - *memory_mmio
           - name: type
             kind: type
             domain: scalar_types
@@ -1773,6 +1781,8 @@ instructions:
                 availability:
                   ptx: "1.0"
                   sm: 13
+        modifier_order_aliases:
+          - [state_space, cache, semantics, scope, mmio, type]
         operands: $st_explicit_scalar
         rule: data_movement.st_explicit
         constraints:
@@ -1918,6 +1928,8 @@ instructions:
           ptx: "1.0"
           sm: 0
         modifiers:
+          - *st_semantics
+          - *memory_scope
           - name: state_space
             kind: state_space
             domain: state_spaces
@@ -1931,8 +1943,6 @@ instructions:
               - value: $st_cache_operators
                 availability: {ptx: "2.0", sm: 20}
             default: unspecified
-          - *st_semantics
-          - *memory_scope
           - name: vector
             kind: vector
             domain: vector_arities
@@ -1951,6 +1961,8 @@ instructions:
                 availability:
                   ptx: "1.0"
                   sm: 13
+        modifier_order_aliases:
+          - [state_space, cache, semantics, scope, vector, type]
         operands: $st_explicit_vector
         rule: data_movement.st_explicit
         constraints:

--- a/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
+++ b/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
@@ -1120,17 +1120,12 @@ instructions:
   - opcode: atom
     section: "9.7.14.5"
     doc: "Atomic operation, limited to relaxed CTA global add.u32."
-    syntax: "atom.global.relaxed.cta.add.u32 dst, [address], src"
+    syntax: "atom.relaxed.cta.global.add.u32 dst, [address], src"
 
     variants:
       - name: atom_global_relaxed_cta_add_u32
         availability: {ptx: "6.0", sm: 70}
         modifiers:
-          - name: state_space
-            kind: state_space
-            domain: state_spaces
-            presence: fixed
-            value: global
           - name: semantics
             kind: semantics
             domain: memory_consistencies
@@ -1141,6 +1136,11 @@ instructions:
             domain: memory_scopes
             presence: fixed
             value: cta
+          - name: state_space
+            kind: state_space
+            domain: state_spaces
+            presence: fixed
+            value: global
           - name: add
             kind: flag
             presence: fixed
@@ -1151,6 +1151,8 @@ instructions:
             domain: scalar_types
             presence: fixed
             value: u32
+        modifier_order_aliases:
+          - [state_space, semantics, scope, add, type]
         operands: $atom_global_scalar
         rule: parallel_sync_and_communication.atom
         constraints:
@@ -1159,23 +1161,18 @@ instructions:
             type_modifier: type
 
         examples:
-          - ptx: "atom.global.relaxed.cta.add.u32 %r0, [global_value], %r1;"
+          - ptx: "atom.relaxed.cta.global.add.u32 %r0, [global_value], %r1;"
             valid: true
 
   - opcode: red
     section: "9.7.14.6"
     doc: "Reduction operation, limited to relaxed CTA global add.u32."
-    syntax: "red.global.relaxed.cta.add.u32 [address], src"
+    syntax: "red.relaxed.cta.global.add.u32 [address], src"
 
     variants:
       - name: red_global_relaxed_cta_add_u32
         availability: {ptx: "6.0", sm: 70}
         modifiers:
-          - name: state_space
-            kind: state_space
-            domain: state_spaces
-            presence: fixed
-            value: global
           - name: semantics
             kind: semantics
             domain: memory_consistencies
@@ -1186,6 +1183,11 @@ instructions:
             domain: memory_scopes
             presence: fixed
             value: cta
+          - name: state_space
+            kind: state_space
+            domain: state_spaces
+            presence: fixed
+            value: global
           - name: add
             kind: flag
             presence: fixed
@@ -1196,6 +1198,8 @@ instructions:
             domain: scalar_types
             presence: fixed
             value: u32
+        modifier_order_aliases:
+          - [state_space, semantics, scope, add, type]
         operands: $red_global_scalar
         rule: parallel_sync_and_communication.red
         constraints:
@@ -1204,7 +1208,7 @@ instructions:
             type_modifier: type
 
         examples:
-          - ptx: "red.global.relaxed.cta.add.u32 [global_value], %r0;"
+          - ptx: "red.relaxed.cta.global.add.u32 [global_value], %r0;"
             valid: true
 
   - opcode: activemask

--- a/python/ir/syntax_ast.py
+++ b/python/ir/syntax_ast.py
@@ -99,6 +99,7 @@ class SyntaxVariantDescriptor:
     variant_id: str
     modifiers: tuple[SyntaxModifierDescriptor, ...]
     operand_layouts: tuple[SyntaxOperandLayoutDescriptor, ...]
+    modifier_order_aliases: tuple[tuple[SyntaxModifierDescriptor, ...], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -171,11 +172,15 @@ OPERAND_SYNTAX_SHAPES = {
 def _build_variant_descriptor_view(
     variant: VariantSpec,
 ) -> SyntaxVariantDescriptor:
+    modifiers = tuple(
+        _build_modifier_descriptor_view(modifier) for modifier in variant.modifiers
+    )
+    modifiers_by_name = {
+        modifier.kind_id: modifier for modifier in modifiers
+    }
     return SyntaxVariantDescriptor(
         variant_id=variant.name,
-        modifiers=tuple(
-            _build_modifier_descriptor_view(modifier) for modifier in variant.modifiers
-        ),
+        modifiers=modifiers,
         operand_layouts=tuple(
             SyntaxOperandLayoutDescriptor(
                 layout_id=layout.name,
@@ -192,6 +197,10 @@ def _build_variant_descriptor_view(
                 ),
             )
             for layout in variant.operand_layouts
+        ),
+        modifier_order_aliases=tuple(
+            tuple(modifiers_by_name[slot_name] for slot_name in alias)
+            for alias in variant.modifier_order_aliases
         ),
     )
 

--- a/python/tests/code_gen/test_database.py
+++ b/python/tests/code_gen/test_database.py
@@ -452,6 +452,115 @@ class CodegenDatabaseMergeTests(unittest.TestCase):
             ["add_first", "add_second"],
         )
 
+    def test_accepts_complete_modifier_order_alias(self) -> None:
+        spec = _spec(
+            category="floating_point",
+            codegen_category="arithmetic",
+            variant_name="add_mixed",
+            type_value="f32",
+        )
+        variant = cast(
+            list[dict[str, Any]],
+            cast(list[dict[str, Any]], spec["instructions"])[0]["variants"],
+        )[0]
+        variant["modifiers"] = [
+            {
+                "name": "result_type", "kind": "type", "presence": "fixed",
+                "domain": "scalar_types", "value": "f32",
+            },
+            {
+                "name": "input_type", "kind": "type", "presence": "fixed",
+                "domain": "scalar_types", "value": "f16",
+            },
+        ]
+        variant["modifier_order_aliases"] = [["input_type", "result_type"]]
+
+        database = self._load(spec)
+
+        self.assertEqual(
+            database.instructions[0].variants[0].modifier_order_aliases,
+            (("input_type", "result_type"),),
+        )
+
+    def test_rejects_invalid_modifier_order_aliases(self) -> None:
+        for alias, message in (
+            (["missing"], "unknown slots"),
+            (["type", "type"], "non-unique elements"),
+            ([], "contain every modifier slot"),
+            (["type"], "duplicates the canonical"),
+        ):
+            with self.subTest(alias=alias):
+                spec = _spec(
+                    category="floating_point",
+                    codegen_category="arithmetic",
+                    variant_name="add_alias",
+                    type_value="f32",
+                )
+                variant = cast(
+                    list[dict[str, Any]],
+                    cast(list[dict[str, Any]], spec["instructions"])[0]["variants"],
+                )[0]
+                variant["modifier_order_aliases"] = [alias]
+                with self.assertRaisesRegex(ValueError, message):
+                    self._load(spec)
+
+    def test_rejects_ambiguous_alias_binding_and_cross_variant_overlap(self) -> None:
+        ambiguous = _spec(
+            category="floating_point",
+            codegen_category="arithmetic",
+            variant_name="add_repeated",
+            type_value="f16",
+        )
+        ambiguous_variant = cast(
+            list[dict[str, Any]],
+            cast(list[dict[str, Any]], ambiguous["instructions"])[0]["variants"],
+        )[0]
+        ambiguous_variant["modifiers"] = [
+            {
+                "name": "first_type", "kind": "type", "presence": "fixed",
+                "domain": "scalar_types", "value": "f16",
+            },
+            {
+                "name": "second_type", "kind": "type", "presence": "fixed",
+                "domain": "scalar_types", "value": "f16",
+            },
+        ]
+        ambiguous_variant["modifier_order_aliases"] = [["second_type", "first_type"]]
+        with self.assertRaisesRegex(ValueError, "different slot identities"):
+            self._load(ambiguous)
+
+        first = _spec(
+            category="floating_point",
+            codegen_category="arithmetic",
+            variant_name="add_first",
+            type_value="f32",
+        )
+        first_variant = cast(
+            list[dict[str, Any]],
+            cast(list[dict[str, Any]], first["instructions"])[0]["variants"],
+        )[0]
+        first_variant["modifiers"].append({
+            "name": "input_type", "kind": "type", "presence": "fixed",
+            "domain": "scalar_types", "value": "f16",
+        })
+        first_variant["modifier_order_aliases"] = [["input_type", "type"]]
+        second = _spec(
+            category="floating_point",
+            codegen_category="arithmetic",
+            variant_name="add_second",
+            type_value="f16",
+        )
+        second_variant = cast(
+            list[dict[str, Any]],
+            cast(list[dict[str, Any]], second["instructions"])[0]["variants"],
+        )[0]
+        second_variant["modifiers"].append({
+            "name": "input_type", "kind": "type", "presence": "fixed",
+            "domain": "scalar_types", "value": "f32",
+        })
+        with self.assertRaisesRegex(ValueError, "overlapping modifier combination"):
+            self._load(first, second)
+
 
 class AvailabilityNormalizationTests(unittest.TestCase):
     def test_vector_sink_payload_requires_an_enabled_sink(self) -> None:

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -388,9 +388,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ],
             [
                 ("rounding", "WithLocs<RoundingMode>", ResolvedFieldStorage.INSTANCE),
+                ("saturate", "WithLocs<bool>", ResolvedFieldStorage.INSTANCE),
                 ("result_type", "ScalarType", ResolvedFieldStorage.STATIC_CONSTANT),
                 ("input_type", "WithLocs<ScalarType>", ResolvedFieldStorage.INSTANCE),
-                ("saturate", "WithLocs<bool>", ResolvedFieldStorage.INSTANCE),
             ],
         )
         self.assertEqual(
@@ -1965,9 +1965,14 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 "GlobalNcL1NoAllocateU32",
             ],
         )
-        self.assertEqual(ld.variants[1].modifiers[0].presence, "required")
+        explicit_state_space = next(
+            modifier
+            for modifier in ld.variants[1].modifiers
+            if modifier.name == "state_space"
+        )
+        self.assertEqual(explicit_state_space.presence, "required")
         self.assertEqual(
-            [value.value for value in ld.variants[1].modifiers[0].values],
+            [value.value for value in explicit_state_space.values],
             [
                 "const",
                 "global",
@@ -2026,15 +2031,22 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ld.variants[0], ld.variants[1], ld.variants[4], ld.variants[5]
         ):
             self.assertEqual(
-                [value.value for value in syntax_variant.modifiers[-1].values],
+                [
+                    value.value
+                    for value in next(
+                        modifier
+                        for modifier in syntax_variant.modifiers
+                        if modifier.name == "type"
+                    ).values
+                ],
                 expected_types,
             )
         self.assertEqual(
             [(field.name, field.cpp_type) for field in variant.fields],
             [
+                ("mmio", "WithLocs<bool>"),
                 ("semantics", "WithLocs<MemoryConsistency>"),
                 ("scope", "WithLocs<MemoryScope>"),
-                ("mmio", "WithLocs<bool>"),
                 ("cache", "WithLocs<CacheOperator>"),
                 ("type", "WithLocs<ScalarType>"),
                 ("dst", "WithLocs<ResolvedRegisterRef>"),
@@ -2146,11 +2158,16 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIsNone(address_binding.state_space_modifier_field_id)
 
         self.assertEqual(explicit_variant.cpp_name, "ExplicitScalar")
+        explicit_state_space_field = next(
+            field
+            for field in explicit_variant.modifier_fields
+            if field.name == "state_space"
+        )
         self.assertEqual(
             (
-                explicit_variant.modifier_fields[0].name,
-                explicit_variant.modifier_fields[0].cpp_type,
-                explicit_variant.modifier_fields[0].storage,
+                explicit_state_space_field.name,
+                explicit_state_space_field.cpp_type,
+                explicit_state_space_field.storage,
             ),
             (
                 "state_space",
@@ -2158,11 +2175,21 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 ResolvedFieldStorage.INSTANCE,
             ),
         )
+        explicit_cache_field = next(
+            field
+            for field in explicit_variant.modifier_fields
+            if field.name == "cache"
+        )
+        explicit_cache_binding = next(
+            binding
+            for binding in explicit_variant.modifier_bindings
+            if binding.source_kind_id == "cache"
+        )
         self.assertEqual(
             (
-                explicit_variant.modifier_fields[1].name,
-                explicit_variant.modifier_fields[1].cpp_type,
-                explicit_variant.modifier_bindings[1].default_value.value,
+                explicit_cache_field.name,
+                explicit_cache_field.cpp_type,
+                explicit_cache_binding.default_value.value,
             ),
             ("cache", "WithLocs<CacheOperator>", "unspecified"),
         )
@@ -2256,8 +2283,13 @@ class ResolvedIrBuildTest(unittest.TestCase):
             if instruction.opcode == "st"
         )
         store = from_instruction_spec(st)
+        explicit_store_state_space = next(
+            modifier
+            for modifier in st.variants[1].modifiers
+            if modifier.name == "state_space"
+        )
         self.assertEqual(
-            [value.value for value in st.variants[1].modifiers[0].values],
+            [value.value for value in explicit_store_state_space.values],
             ["global", "local", "param", "param::func", "shared"],
         )
         self.assertEqual(
@@ -2275,12 +2307,19 @@ class ResolvedIrBuildTest(unittest.TestCase):
             st.variants[0], st.variants[1], st.variants[4], st.variants[5]
         ):
             self.assertEqual(
-                [value.value for value in syntax_variant.modifiers[-1].values],
+                [
+                    value.value
+                    for value in next(
+                        modifier
+                        for modifier in syntax_variant.modifiers
+                        if modifier.name == "type"
+                    ).values
+                ],
                 expected_types,
             )
         self.assertEqual(
             [field.name for field in store.variants[0].fields],
-            ["semantics", "scope", "mmio", "cache", "type", "address", "src"],
+            ["mmio", "semantics", "scope", "cache", "type", "address", "src"],
         )
         self.assertEqual(
             next(binding for binding in store.variants[0].modifier_bindings
@@ -2313,7 +2352,11 @@ class ResolvedIrBuildTest(unittest.TestCase):
             "state_space",
         )
         self.assertEqual(
-            store.variants[1].modifier_bindings[1].default_value.value,
+            next(
+                binding.default_value.value
+                for binding in store.variants[1].modifier_bindings
+                if binding.source_kind_id == "cache"
+            ),
             "unspecified",
         )
         self.assertEqual(
@@ -3087,9 +3130,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             [(field.name, field.cpp_type) for field in variant.fields],
             [
-                ("state_space", "MemoryStateSpace"),
                 ("semantics", "MemoryConsistency"),
                 ("scope", "MemoryScope"),
+                ("state_space", "MemoryStateSpace"),
                 ("add", "bool"),
                 ("type", "ScalarType"),
                 ("dst", "WithLocs<ResolvedRegisterRef>"),
@@ -3126,9 +3169,9 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             [(field.name, field.cpp_type) for field in variant.fields],
             [
-                ("state_space", "MemoryStateSpace"),
                 ("semantics", "MemoryConsistency"),
                 ("scope", "MemoryScope"),
+                ("state_space", "MemoryStateSpace"),
                 ("add", "bool"),
                 ("type", "ScalarType"),
                 ("address", "WithLocs<ResolvedAddress>"),

--- a/python/tests/ir/test_syntax_ast.py
+++ b/python/tests/ir/test_syntax_ast.py
@@ -224,11 +224,16 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
                     ModifierPresence.OPTIONAL,
                     (".rn", ".rz", ".rm", ".rp"),
                 ),
+                ("sat", ModifierPresence.OPTIONAL, (".sat",)),
                 ("result_type", ModifierPresence.REQUIRED, (".f32",)),
                 ("input_type", ModifierPresence.REQUIRED, (".f16", ".bf16")),
                 ("ftz", ModifierPresence.ABSENT, ()),
-                ("sat", ModifierPresence.OPTIONAL, (".sat",)),
             ],
+        )
+        self.assertEqual(
+            [[modifier.kind_id for modifier in alias]
+            for alias in mixed.modifier_order_aliases],
+            [["rounding", "result_type", "input_type", "ftz", "sat"]],
         )
 
     def test_add_binary_flat_operand_layout(self) -> None:

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -153,10 +153,19 @@ struct SyntaxModifierDescriptor {
   bool check(std::string modifier_str) const;
 };
 
+/** One complete, explicitly accepted historical modifier-slot order. */
+struct SyntaxModifierOrderDescriptor {
+  /** Static descriptors ordered as they may appear in source. */
+  std::span<const SyntaxModifierDescriptor> modifiers;
+};
+
 struct SyntaxVariantDescriptor {
   std::string_view variant_name;
+  /** Canonical source order for this variant's modifier slots. */
   std::span<const SyntaxModifierDescriptor> modifiers;
   std::span<const SyntaxOperandLayoutDescriptor> operand_layouts;
+  /** Additional complete source orders accepted for this same variant. */
+  std::span<const SyntaxModifierOrderDescriptor> modifier_order_aliases{};
 
   int32_t get_required_modifier_num() const;
 };

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -2253,11 +2253,12 @@ struct ModifierBindingAttempt {
  * descriptors in order; optional and absent slots may be skipped, but required
  * slots may not.
  */
-ModifierBindingAttempt bind_variant_modifiers(
+ModifierBindingAttempt bind_modifier_order(
     const syntax_ast::AstInstruction& ast,
-    const SyntaxVariantDescriptor& variant) {
+    const SyntaxVariantDescriptor& variant,
+    std::span<const SyntaxModifierDescriptor> modifiers) {
   std::unordered_set<std::string_view> slot_ids;
-  for (const auto& descriptor : variant.modifiers) {
+  for (const auto& descriptor : modifiers) {
     if (!slot_ids.insert(descriptor.kind_id).second) {
       throw ResolveException(
           fmt::format("Variant '{}' contains duplicate modifier slot '{}'.",
@@ -2267,7 +2268,7 @@ ModifierBindingAttempt bind_variant_modifiers(
 
   ActualModifierTable result;
   size_t actual_index = 0;
-  for (const auto& descriptor : variant.modifiers) {
+  for (const auto& descriptor : modifiers) {
     if (descriptor.presence == check_end::PresenceRequirement::Absent)
       continue;
     if (actual_index < ast.modifiers.size() &&
@@ -2285,8 +2286,8 @@ ModifierBindingAttempt bind_variant_modifiers(
     return ModifierBindingAttempt{.modifiers = std::move(result)};
 
   const auto& extra = ast.modifiers[actual_index];
-  for (auto descriptor = variant.modifiers.rbegin();
-       descriptor != variant.modifiers.rend(); ++descriptor) {
+  for (auto descriptor = modifiers.rbegin(); descriptor != modifiers.rend();
+       ++descriptor) {
     if (descriptor->presence != check_end::PresenceRequirement::Absent &&
         result.contains(std::string(descriptor->kind_id)) &&
         std::ranges::contains(descriptor->allowed_values, extra.syntax.text)) {
@@ -2297,6 +2298,36 @@ ModifierBindingAttempt bind_variant_modifiers(
     }
   }
   return {};
+}
+
+/**
+ * Bind against the canonical modifier order and every declared historical
+ * order for one semantic variant.
+ */
+ModifierBindingAttempt bind_variant_modifiers(
+    const syntax_ast::AstInstruction& ast,
+    const SyntaxVariantDescriptor& variant) {
+  ModifierBindingAttempt result;
+  const auto try_order = [&](std::span<const SyntaxModifierDescriptor> order) {
+    auto attempt = bind_modifier_order(ast, variant, order);
+    if (attempt.modifiers) {
+      if (result.modifiers && *result.modifiers != *attempt.modifiers) {
+        throw ResolveException(fmt::format(
+            "Variant '{}' has modifier orders with ambiguous slot bindings.",
+            variant.variant_name));
+      }
+      if (!result.modifiers)
+        result.modifiers = std::move(attempt.modifiers);
+    } else if (result.duplicate == nullptr && attempt.duplicate != nullptr) {
+      result.duplicate = attempt.duplicate;
+      result.duplicate_slot = attempt.duplicate_slot;
+    }
+  };
+
+  try_order(variant.modifiers);
+  for (const auto& alias : variant.modifier_order_aliases)
+    try_order(alias.modifiers);
+  return result;
 }
 
 bool is_known_modifier_spelling(const SyntaxInstructionDescriptor& instruction,

--- a/submod/resolved_ir/test/package_consumer/main.cpp
+++ b/submod/resolved_ir/test/package_consumer/main.cpp
@@ -77,6 +77,24 @@ int main() {
   if (!integer_add.dst.value.symbol_id)
     return 11;
 
+  bool add_has_legacy_mixed_precision_order = false;
+  for (const auto& variant :
+       ptx_frontend::resolved_ir::Add::get_syntax_descriptor().variants) {
+    if (variant.variant_name != "MixedF32" ||
+        variant.modifier_order_aliases.size() != 1 ||
+        variant.modifier_order_aliases.front().modifiers.size() != 5) {
+      continue;
+    }
+    const auto& legacy_order = variant.modifier_order_aliases.front().modifiers;
+    add_has_legacy_mixed_precision_order =
+        legacy_order[0].kind_id == "rounding" &&
+        legacy_order[1].kind_id == "result_type" &&
+        legacy_order[2].kind_id == "input_type" &&
+        legacy_order[4].kind_id == "sat";
+  }
+  if (!add_has_legacy_mixed_precision_order)
+    return 30;
+
   ptx_frontend::PtxSyntaxParser call_parser(
       "call (%result), callee, (%argument, 1);");
   const auto call = call_parser.parseInstruction();

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -247,6 +247,152 @@ TEST(ResolvedModule, ResolvesAndChecksM12I06FrozenSubForms) {
   }
 }
 
+TEST(ResolvedModule, PreservesMixedPrecisionModifierOrderCompatibility) {
+  constexpr std::array<std::string_view, 5> roundings{
+      "", ".rn", ".rz", ".rm", ".rp"};
+  constexpr std::array rounding_modes{
+      RoundingMode::Rn, RoundingMode::Rn, RoundingMode::Rz,
+      RoundingMode::Rm, RoundingMode::Rp};
+  constexpr std::array input_types{"f16", "bf16"};
+  constexpr std::array input_type_values{ScalarType::F16, ScalarType::BF16};
+  constexpr std::array input_registers{"%h0", "%bf0"};
+
+  std::string source = R"ptx(
+.entry kernel() {
+  .reg .f32 %f<2>;
+  .reg .f16 %h0;
+  .reg .bf16 %bf0;
+)ptx";
+  const auto append_instruction = [&](std::string_view opcode,
+                                      std::string_view rounding,
+                                      std::string_view before_types,
+                                      std::string_view input_type,
+                                      std::string_view after_types,
+                                      std::string_view input_register) {
+    source += "  ";
+    source += opcode;
+    source += rounding;
+    source += before_types;
+    source += ".f32.";
+    source += input_type;
+    source += after_types;
+    source += " %f0, ";
+    source += input_register;
+    source += ", %f1;\n";
+  };
+  const auto append_forms = [&](std::string_view opcode) {
+    for (size_t type_index = 0; type_index != input_types.size(); ++type_index) {
+      for (const std::string_view rounding : roundings) {
+        append_instruction(opcode, rounding, "", input_types[type_index], "",
+                           input_registers[type_index]);
+        append_instruction(opcode, rounding, ".sat", input_types[type_index],
+                           "", input_registers[type_index]);
+        append_instruction(opcode, rounding, "", input_types[type_index], ".sat",
+                           input_registers[type_index]);
+      }
+    }
+  };
+  append_forms("add");
+  append_forms("sub");
+  source += "}\n";
+
+  const auto ast = parseModule(source);
+  const auto resolved = resolveModule(ast);
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& body = resolved->functions.front().body;
+  constexpr size_t forms_per_opcode =
+      input_types.size() * roundings.size() * 3U;
+  ASSERT_EQ(body.size(), forms_per_opcode * 2U);
+  const auto& syntax_function =
+      std::get<syntax_ast::AstFunction>(ast.items.back());
+  const checker::Context context{
+      .target = {.ptx_version = {8, 6}, .sm_version = 100},
+      .instruction_range = ast.range,
+  };
+
+  const auto expect_fields = [&](const WithLocs<RoundingMode>& rounding,
+                                 const WithLocs<ScalarType>& input_type,
+                                 const WithLocs<bool>& saturate,
+                                 const syntax_ast::AstInstruction& instruction,
+                                 const size_t type_index,
+                                 const size_t rounding_index,
+                                 const bool expected_saturate,
+                                 const size_t input_modifier_index,
+                                 const size_t saturate_modifier_index) {
+    EXPECT_EQ(rounding.value, rounding_modes[rounding_index]);
+    if (roundings[rounding_index].empty()) {
+      EXPECT_TRUE(rounding.locs.empty());
+    } else {
+      ASSERT_EQ(rounding.locs.size(), 1U);
+      EXPECT_EQ(rounding.locs.front(), instruction.modifiers.front().syntax.range);
+    }
+    EXPECT_EQ(input_type.value, input_type_values[type_index]);
+    ASSERT_EQ(input_type.locs.size(), 1U);
+    EXPECT_EQ(input_type.locs.front(),
+              instruction.modifiers[input_modifier_index].syntax.range);
+    EXPECT_EQ(saturate.value, expected_saturate);
+    if (expected_saturate) {
+      ASSERT_EQ(saturate.locs.size(), 1U);
+      EXPECT_EQ(saturate.locs.front(),
+                instruction.modifiers[saturate_modifier_index].syntax.range);
+    } else {
+      EXPECT_TRUE(saturate.locs.empty());
+    }
+  };
+
+  const auto expect_instruction =
+      [&](const ResolvedInstruction& resolved_instruction,
+          const syntax_ast::AstInstruction& syntax_instruction,
+          const size_t type_index, const size_t rounding_index,
+          const bool expected_saturate, const size_t input_modifier_index,
+          const size_t saturate_modifier_index) {
+        if (const auto* add = std::get_if<Add>(&resolved_instruction)) {
+          const auto& mixed = std::get<Add::MixedF32>(add->variant);
+          expect_fields(mixed.rounding, mixed.input_type, mixed.saturate,
+                        syntax_instruction, type_index, rounding_index,
+                        expected_saturate, input_modifier_index,
+                        saturate_modifier_index);
+          EXPECT_TRUE(checker::check(*add, context).has_value());
+        } else {
+          const auto& sub = std::get<Sub>(resolved_instruction);
+          const auto& mixed = std::get<Sub::MixedF32>(sub.variant);
+          expect_fields(mixed.rounding, mixed.input_type, mixed.saturate,
+                        syntax_instruction, type_index, rounding_index,
+                        expected_saturate, input_modifier_index,
+                        saturate_modifier_index);
+          EXPECT_TRUE(checker::check(sub, context).has_value());
+        }
+      };
+
+  size_t instruction_index = 0;
+  for (size_t opcode_index = 0; opcode_index != 2U; ++opcode_index) {
+    for (size_t type_index = 0; type_index != input_types.size(); ++type_index) {
+      for (size_t rounding_index = 0; rounding_index != roundings.size();
+           ++rounding_index) {
+        const size_t type_modifier_index =
+            roundings[rounding_index].empty() ? 0U : 1U;
+        const auto& nonsat_syntax = std::get<syntax_ast::AstInstruction>(
+            syntax_function.body[3U + instruction_index]);
+        const auto& canonical_syntax = std::get<syntax_ast::AstInstruction>(
+            syntax_function.body[4U + instruction_index]);
+        const auto& legacy_syntax = std::get<syntax_ast::AstInstruction>(
+            syntax_function.body[5U + instruction_index]);
+
+        expect_instruction(body[instruction_index], nonsat_syntax, type_index,
+                           rounding_index, false, type_modifier_index + 1U, 0U);
+        expect_instruction(body[instruction_index + 1U], canonical_syntax,
+                           type_index, rounding_index, true,
+                           type_modifier_index + 2U, type_modifier_index);
+        expect_instruction(body[instruction_index + 2U], legacy_syntax,
+                           type_index, rounding_index, true,
+                           type_modifier_index + 1U,
+                           type_modifier_index + 2U);
+        instruction_index += 3U;
+      }
+    }
+  }
+}
+
 TEST(ResolvedModule, ResolvesNegativeUnsignedImmediatesAtTargetWidth) {
   const auto resolved = resolveModule(parseModule(R"ptx(
 .entry kernel() {
@@ -2146,14 +2292,20 @@ TEST(ResolvedModule, ResolvesAndChecksAtomGlobalRelaxedCtaAddU32Slice) {
 .global .align 4 .u32 global_value;
 .entry kernel() {
   .reg .u32 %r<2>;
+  atom.relaxed.cta.global.add.u32 %r0, [global_value], %r1;
   atom.global.relaxed.cta.add.u32 %r0, [global_value], %r1;
 }
 )ptx");
   const auto resolved = resolveModule(ast);
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
-  const auto& instruction = std::get<Atom>(resolved->functions.front().body.front());
+  const auto& body = resolved->functions.front().body;
+  ASSERT_EQ(body.size(), 2U);
+  const auto& instruction = std::get<Atom>(body.front());
+  const auto& legacy_instruction = std::get<Atom>(body.back());
   const auto& atom =
       std::get<Atom::GlobalRelaxedCtaAddU32>(instruction.variant);
+  const auto& legacy_atom =
+      std::get<Atom::GlobalRelaxedCtaAddU32>(legacy_instruction.variant);
   EXPECT_EQ(atom.state_space, MemoryStateSpace::Global);
   EXPECT_EQ(atom.semantics, MemoryConsistency::Relaxed);
   EXPECT_EQ(atom.scope, MemoryScope::Cta);
@@ -2161,8 +2313,20 @@ TEST(ResolvedModule, ResolvesAndChecksAtomGlobalRelaxedCtaAddU32Slice) {
   EXPECT_EQ(atom.type, ScalarType::U32);
   EXPECT_EQ(atom.dst.value.declared_type, ScalarType::U32);
   EXPECT_EQ(atom.src.value.declared_type, ScalarType::U32);
+  EXPECT_EQ(legacy_atom.state_space, atom.state_space);
+  EXPECT_EQ(legacy_atom.semantics, atom.semantics);
+  EXPECT_EQ(legacy_atom.scope, atom.scope);
+  EXPECT_EQ(legacy_atom.add, atom.add);
+  EXPECT_EQ(legacy_atom.type, atom.type);
   EXPECT_TRUE(checker::check(
                   instruction,
+                  checker::Context{
+                      .target = {.ptx_version = {6, 0}, .sm_version = 70},
+                      .instruction_range = ast.range,
+                  })
+                  .has_value());
+  EXPECT_TRUE(checker::check(
+                  legacy_instruction,
                   checker::Context{
                       .target = {.ptx_version = {6, 0}, .sm_version = 70},
                       .instruction_range = ast.range,
@@ -2254,21 +2418,39 @@ TEST(ResolvedModule, ResolvesAndChecksRedGlobalRelaxedCtaAddU32Slice) {
 .global .align 4 .u32 global_value;
 .entry kernel() {
   .reg .u32 %r0;
+  red.relaxed.cta.global.add.u32 [global_value], %r0;
   red.global.relaxed.cta.add.u32 [global_value], %r0;
 }
 )ptx");
   const auto resolved = resolveModule(ast);
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
-  const auto& instruction = std::get<Red>(resolved->functions.front().body.front());
+  const auto& body = resolved->functions.front().body;
+  ASSERT_EQ(body.size(), 2U);
+  const auto& instruction = std::get<Red>(body.front());
+  const auto& legacy_instruction = std::get<Red>(body.back());
   const auto& red = std::get<Red::GlobalRelaxedCtaAddU32>(instruction.variant);
+  const auto& legacy_red =
+      std::get<Red::GlobalRelaxedCtaAddU32>(legacy_instruction.variant);
   EXPECT_EQ(red.state_space, MemoryStateSpace::Global);
   EXPECT_EQ(red.semantics, MemoryConsistency::Relaxed);
   EXPECT_EQ(red.scope, MemoryScope::Cta);
   EXPECT_TRUE(red.add);
   EXPECT_EQ(red.type, ScalarType::U32);
   EXPECT_EQ(red.src.value.declared_type, ScalarType::U32);
+  EXPECT_EQ(legacy_red.state_space, red.state_space);
+  EXPECT_EQ(legacy_red.semantics, red.semantics);
+  EXPECT_EQ(legacy_red.scope, red.scope);
+  EXPECT_EQ(legacy_red.add, red.add);
+  EXPECT_EQ(legacy_red.type, red.type);
   EXPECT_TRUE(checker::check(
                   instruction,
+                  checker::Context{
+                      .target = {.ptx_version = {6, 0}, .sm_version = 70},
+                      .instruction_range = ast.range,
+                  })
+                  .has_value());
+  EXPECT_TRUE(checker::check(
+                  legacy_instruction,
                   checker::Context{
                       .target = {.ptx_version = {6, 0}, .sm_version = 70},
                       .instruction_range = ast.range,

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -1428,6 +1428,18 @@ TEST(SelectVariantLoadStore, SelectsLegalCacheOperatorsAndRejectsWrongOnes) {
               Ld::VariantType::GenericVector);
   expect_load("ld.shared.ca.v4.u16 {%h0, %h1, %h2, %h3}, [%rd0];",
               Ld::VariantType::ExplicitVector);
+  expect_load("ld.relaxed.cta.global.u32 %r0, [%rd0];",
+              Ld::VariantType::ExplicitScalar);
+  expect_load("ld.global.relaxed.cta.u32 %r0, [%rd0];",
+              Ld::VariantType::ExplicitScalar);
+  expect_load("ld.relaxed.cta.global.v2.u32 {%r0, %r1}, [%rd0];",
+              Ld::VariantType::ExplicitVector);
+  expect_load("ld.global.relaxed.cta.v2.u32 {%r0, %r1}, [%rd0];",
+              Ld::VariantType::ExplicitVector);
+  expect_load("ld.mmio.relaxed.sys.global.u32 %r0, [%rd0];",
+              Ld::VariantType::ExplicitScalar);
+  expect_load("ld.global.relaxed.sys.mmio.u32 %r0, [%rd0];",
+              Ld::VariantType::ExplicitScalar);
 
   const auto invalid_load = parse_instruction("ld.wb.u32 %r0, [%rd0];");
   const auto invalid_load_selected = selectVariant<Ld>(invalid_load);
@@ -1449,6 +1461,18 @@ TEST(SelectVariantLoadStore, SelectsLegalCacheOperatorsAndRejectsWrongOnes) {
                St::VariantType::GenericVector);
   expect_store("st.shared.cg.v4.u16 [%rd0], {%h0, %h1, %h2, %h3};",
                St::VariantType::ExplicitVector);
+  expect_store("st.release.sys.global.u32 [%rd0], %r0;",
+               St::VariantType::ExplicitScalar);
+  expect_store("st.global.release.sys.u32 [%rd0], %r0;",
+               St::VariantType::ExplicitScalar);
+  expect_store("st.release.sys.global.v2.u32 [%rd0], {%r0, %r1};",
+               St::VariantType::ExplicitVector);
+  expect_store("st.global.release.sys.v2.u32 [%rd0], {%r0, %r1};",
+               St::VariantType::ExplicitVector);
+  expect_store("st.mmio.relaxed.sys.global.u32 [%rd0], %r0;",
+               St::VariantType::ExplicitScalar);
+  expect_store("st.global.relaxed.sys.mmio.u32 [%rd0], %r0;",
+               St::VariantType::ExplicitScalar);
 
   const auto invalid_store = parse_instruction("st.ca.u32 [%rd0], %r0;");
   const auto invalid_store_selected = selectVariant<St>(invalid_store);
@@ -2594,6 +2618,32 @@ TEST(ResolveLoadStore, ChecksMemoryConsistencyCrossRules) {
   EXPECT_EQ(relaxed_local_check.error().back().kind,
             checker::CheckDiagnosticKind::MemoryConsistencyViolation);
 
+  const auto canonical_relaxed_local = resolve<Ld>(
+      parse_instruction("ld.relaxed.cta.local.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(canonical_relaxed_local.has_value())
+      << canonical_relaxed_local.error().message;
+  const auto canonical_relaxed_local_check =
+      checker::check(*canonical_relaxed_local, context);
+  ASSERT_FALSE(canonical_relaxed_local_check.has_value());
+  EXPECT_EQ(canonical_relaxed_local_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const auto canonical_cache = resolve<Ld>(
+      parse_instruction("ld.relaxed.cta.global.ca.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(canonical_cache.has_value()) << canonical_cache.error().message;
+  const auto canonical_cache_check = checker::check(*canonical_cache, context);
+  ASSERT_FALSE(canonical_cache_check.has_value());
+  EXPECT_EQ(canonical_cache_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
+  const auto canonical_mmio = resolve<Ld>(
+      parse_instruction("ld.mmio.relaxed.cta.global.u32 %r0, [%rd0];"));
+  ASSERT_TRUE(canonical_mmio.has_value()) << canonical_mmio.error().message;
+  const auto canonical_mmio_check = checker::check(*canonical_mmio, context);
+  ASSERT_FALSE(canonical_mmio_check.has_value());
+  EXPECT_EQ(canonical_mmio_check.error().back().kind,
+            checker::CheckDiagnosticKind::MemoryConsistencyViolation);
+
   const auto unknown_generic = resolve<Ld>(
       parse_instruction("ld.acquire.gpu.u32 %r0, [%rd0];"));
   ASSERT_TRUE(unknown_generic.has_value()) << unknown_generic.error().message;
@@ -2618,6 +2668,24 @@ TEST(CollectActualModifiersAdd, BindsSpellingsToSelectedVariantSlots) {
   EXPECT_EQ(actual->at("sat"), &ast.modifiers[3]);
 }
 
+TEST(CollectActualModifiersAdd, BindsCanonicalMixedPrecisionSlots) {
+  const auto ast = parse_instruction("add.rz.sat.f32.bf16 %f0, %h1, %f2;");
+  const auto& instruction = Add::get_syntax_descriptor();
+  const auto mixed = std::ranges::find_if(
+      instruction.variants,
+      [](auto variant) { return variant.variant_name == "MixedF32"; });
+  ASSERT_NE(mixed, instruction.variants.end());
+
+  const auto actual = collect_actual_modifiers(ast, *mixed);
+
+  ASSERT_TRUE(actual.has_value()) << actual.error().message;
+  ASSERT_EQ(actual->size(), 4U);
+  EXPECT_EQ(actual->at("rounding"), &ast.modifiers[0]);
+  EXPECT_EQ(actual->at("sat"), &ast.modifiers[1]);
+  EXPECT_EQ(actual->at("result_type"), &ast.modifiers[2]);
+  EXPECT_EQ(actual->at("input_type"), &ast.modifiers[3]);
+}
+
 TEST(CollectActualModifiersAdd, RejectsOutOfOrderMixedSlots) {
   const auto ast = parse_instruction("add.rz.f32.sat.bf16 %f0, %h1, %f2;");
   const auto& instruction = Add::get_syntax_descriptor();
@@ -2631,6 +2699,24 @@ TEST(CollectActualModifiersAdd, RejectsOutOfOrderMixedSlots) {
   ASSERT_FALSE(actual.has_value());
   EXPECT_EQ(actual.error().message,
             "Modifier combination does not match instruction variant 'MixedF32'.");
+}
+
+TEST(SelectVariantMixedPrecision, RejectsUnsupportedReorderingAndDuplicates) {
+  for (const std::string_view opcode : {"add", "sub"}) {
+    for (const std::string_view suffix : {
+             ".rz.f32.sat.bf16", ".rz.sat.bf16.f32", ".sat.sat.f32.bf16",
+             ".rn.rz.f32.bf16", ".sat.f32.f16.sat",
+         }) {
+      const std::string source =
+          std::string(opcode) + std::string(suffix) + " %f0, %h1, %f2;";
+      SCOPED_TRACE(source);
+      const auto ast = parse_instruction(source);
+      if (opcode == "add")
+        EXPECT_FALSE(selectVariant<Add>(ast).has_value());
+      else
+        EXPECT_FALSE(selectVariant<Sub>(ast).has_value());
+    }
+  }
 }
 
 TEST(CollectActualModifiers, BindsRepeatedSpellingsToOrderedSlots) {


### PR DESCRIPTION
## Summary

- Match the pinned PTX 9.3 Syntax order for mixed `add/sub`, `atom/red`, and supported `ld/st` memory qualifiers, including scalar MMIO.
- Preserve existing source spellings through explicitly declared modifier-order aliases. Both orders resolve to the same stable variant, with unchanged semantic constraints, defaults, and source locations; arbitrary reordering remains rejected.
- Validate alias permutations, ambiguous slot bindings, and cross-variant overlaps before code generation. Update bilingual generator/resolver contracts and add regression coverage.

Refs #48. Updating ptxsim's dependency pin and its execution tests remains downstream work.

## Consumer compatibility

Variant IDs and semantic field names remain unchanged. New Python fields are optional and appended to preserve existing positional constructors. This is not a binary-layout compatibility promise: generated member order and the C++ syntax descriptor layout change. Consumers should upgrade the Python package and C++ frontend together, regenerate code, and rebuild.

## Syntax versus compatibility evidence

The pinned [PTX 9.3 mixed Sub section](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#mixed-precision-floating-point-instructions-sub) places `.sat` before the types in Syntax but after the types in an example. We use Syntax as the canonical declaration order, not as proof that the historical spelling is invalid.

Prior audit probes used NVIDIA `ptxas` V12.8.93 (CUDA 12.8), `.version 8.6`, `.target sm_100`, and `ptxas -arch=sm_100 input.ptx -o output.cubin`:

- All 60 mixed add/sub combinations passed: f16/bf16 × default/rn/rz/rm/rp × non-saturating/canonical saturation/historical saturation.
- Canonical and historical scalar ld/st, MMIO ld/st, atom, and red spellings passed.
- The assembler accepts some additional permutations and duplicate flags; this PR deliberately does not generalize that permissiveness into the frontend grammar.

CUDA 13.3 ptxas was not available; the assembler evidence is compatibility evidence from CUDA 12.8, while documentation remains pinned to PTX 9.3.

## Verification

- Debug: 613 C++/integration tests passed; final focused mixed-precision checks also passed after test-only edits.
- Python: all 227 tests passed.
- Installed C++ package consumer passed, including access to generated legacy-order descriptors.
- Built a wheel, installed it into an isolated temporary directory, and successfully rendered ptxsim's existing Exec IR, lowering, and execution-engine artifacts in memory against that wheel. No ptxsim source or dependency files changed; its full C++ build and execution tests were not run.
- Release: all 613 C++/integration tests passed.
- `git diff --check` passed. Independent review found no material runtime/generator/spec correctness issue.
