### PR TITLE
Preserve resolved entry-parameter ABI metadata

### DIFF
--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -57,16 +57,34 @@ callers while retaining the strongly typed per-opcode structures.
 `resolveModule` first builds a `SymbolTable`, then constructs an explicit
 `ResolveContext` for each function scope. The resulting `ResolvedModule` owns
 that table, and each `ResolvedFunction` is identified by its function
-`SymbolId`. `ResolvedFunction::label_positions` records each function label as
+`SymbolId`. Entry functions additionally own source-ordered
+`entry_parameters` metadata for their input declarations; `.func` functions
+have an empty list.
+`ResolvedFunction::label_positions` records each function label as
 its bound `SymbolId` and a source-order boundary in the recursively flattened
 instruction body: labels before the first instruction are at zero, consecutive
 labels share a boundary, and a trailing label is at `body.size()`. Standalone
 `resolveInstruction` and `resolve<T>` remain declaration-free for
-single-instruction tools. Directives and declarations remain in the Syntax
+single-instruction tools. Raw directives and declarations remain in the Syntax
 AST/symbol table instead of being copied into Resolved IR as unresolved string
-fields. Bound `.file` and `.debug_str`
+fields; owned, normalized entry-input ABI metadata is the deliberate exception.
+Bound `.file` and `.debug_str`
 identities validate `.loc` metadata there, but `.loc`, `.section`, and
 `.pragma` do not add Resolved IR nodes or instruction attachment.
+
+`ResolvedEntryParameter` is an inspection boundary, not a launch-layout or
+runtime-policy model. Each item owns its normalized scalar PTX `type` spelling,
+the local-declaration `symbol_id`, optional effective byte `alignment`, optional
+`PointerProperties`, `is_array`, and optional constant `array_extent` in
+elements. The binding-derived alignment includes an explicit declaration
+alignment or a known natural alignment and is absent when it is unknown. A
+non-pointer has no pointer properties; a pointer with no pointed state space is
+generic, and a pointed alignment omitted in the source has the semantic default
+of four bytes. `is_array` distinguishes an unsized array from a scalar when
+`array_extent` is absent. The metadata owns all represented values, so clients
+can inspect it after the source text and Syntax AST have been destroyed. Its
+parameter IDs refer to each entry's function-local declaration scope, so
+separate entries can reuse parameter names while retaining distinct identities.
 
 Module resolution additionally performs direct and metadata-backed indirect
 call ABI and call-context work

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -47,14 +47,29 @@ resolveModule(const syntax_ast::AstModule& ast);
 `resolveInstruction` 根据指令数据库生成，并分发到现有的 `resolve<T>` 特化。调用者不再
 需要手写 opcode 分派，同时每个 opcode 仍保留强类型结构。`resolveModule` 先建立
 `SymbolTable`，再为每个 function scope 构造显式 `ResolveContext`；返回的
-`ResolvedModule` 拥有 symbol table，`ResolvedFunction` 以函数 `SymbolId` 标识。
+`ResolvedModule` 拥有 symbol table，`ResolvedFunction` 以函数 `SymbolId` 标识。entry
+function 还拥有按 source order 排列的 `entry_parameters` 输入声明 metadata；`.func` 的
+列表始终为空。
 `ResolvedFunction::label_positions` 以已绑定的 `SymbolId` 和 source-order 的 instruction
 boundary 记录每个 function label；boundary 基于递归展平的 body，首条 instruction 前为零、
 连续 label 共用一个 boundary、末尾 label 为 `body.size()`。standalone `resolveInstruction`
 与 `resolve<T>` 不要求声明上下文，继续服务单指令工具。directive 与 declaration 仍由
-Syntax AST/symbol table 保存，不复制成未解析的 Resolved IR 字符串字段。`.file` 与
+Syntax AST/symbol table 保存，不复制成未解析的 Resolved IR 字符串字段；唯一刻意保留的
+例外是拥有值的、已规范化 entry-input ABI metadata。`.file` 与
 `.debug_str` identity 会在那里验证 `.loc` metadata，
 但 `.loc`、`.section` 与 `.pragma` 不产生 Resolved IR node，也不附着到 instruction。
+
+`ResolvedEntryParameter` 是 inspection boundary，而非 launch layout 或 runtime policy
+model。每个条目拥有规范化标量 PTX `type` spelling、local-declaration `symbol_id`、可选的
+有效字节 `alignment`、可选 `PointerProperties`、`is_array` 与以 element 为单位的可选常量
+`array_extent`。binding 推导的 alignment 包括显式 declaration alignment 或已知 natural
+alignment；无法确定时为空。non-pointer 没有 pointer properties；未写 pointed state space 的
+pointer 为 generic，source 未写 pointed alignment 时采用四字节的语义默认值。`array_extent`
+为空时，
+`is_array` 用于区分 unsized array 与 scalar。metadata 拥有其所表示的全部值，因此 source
+text 与 Syntax AST 销毁后仍可供 client 检查。parameter ID 指向每个 entry 的
+function-local declaration scope；不同 entry 可以复用 parameter name，同时保留不同的
+identity。
 
 module resolution 还负责不能放入 generated single-instruction checker 的 direct 与 metadata-backed
 indirect-call ABI 以及

--- a/python/code_gen/_frontend/gen_resolved_ir.py
+++ b/python/code_gen/_frontend/gen_resolved_ir.py
@@ -164,6 +164,8 @@ struct ResolvedFunction {{
   std::vector<ResolvedInstruction> body;
   std::vector<ResolvedLabelPosition> label_positions;
   SourceRange range;
+  /** Owned input metadata in source order for .entry; empty for .func. */
+  std::vector<ResolvedEntryParameter> entry_parameters;
 }};
 
 struct ResolvedModule {{

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -17,6 +17,7 @@
 #include <ptx_frontend/common/source_loc.hpp>
 #include <ptx_frontend/common/utils.hpp>
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir_checker.hpp>
+#include <ptx_frontend/semantic/ptx_call_argument_compatibility.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_ast.hpp>
 
 namespace ptx_frontend::declaration_semantics {
@@ -36,6 +37,23 @@ using base::MbarrierLayout;
 using base::MbarrierPhaseType;
 using base::AsyncProxyKind;
 using base::ProxyKindPair;
+
+/** Owned declaration metadata for one entry input parameter; no launch layout. */
+struct ResolvedEntryParameter {
+  /** Input parameter identity in the owning ResolvedModule's symbol table. */
+  binding::SymbolId symbol_id;
+  /** Normalized PTX scalar type spelling, including the leading dot. */
+  std::string type;
+  /** Explicit or natural byte alignment; absent if binding cannot determine it. */
+  std::optional<uint64_t> alignment;
+  /** Pointee contract; absent for non-pointers, absent pointed space is generic. */
+  std::optional<call_argument_compatibility::PointerProperties> pointer;
+  /** Distinguishes an unsized array from a scalar when array_extent is absent. */
+  bool is_array{};
+  /** Constant element count, not bytes; absent for scalars and unsized arrays. */
+  std::optional<uint64_t> array_extent;
+};
+
 namespace check_end {
 
 using OperandShape = checker::OperandShape;

--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -807,6 +807,27 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
         .is_prototype = function->is_prototype,
         .range = function->range,
     };
+    if (function->is_entry) {
+      resolved_function.entry_parameters.reserve(function->parameters.size());
+      for (const auto& parameter : function->parameters) {
+        const auto parameter_lookup =
+            binding_result.table.lookup(scope, parameter.name.syntax.text);
+        if (!parameter_lookup)
+          throw ResolveException("Bound entry parameter has no local symbol.");
+        const auto& parameter_symbol =
+            binding_result.table.symbol(parameter_lookup->symbol);
+        const auto& properties =
+            call_argument_properties.at(parameter_symbol.id.value);
+        resolved_function.entry_parameters.push_back({
+            .symbol_id = parameter_symbol.id,
+            .type = properties.type_spelling,
+            .alignment = parameter_symbol.address_alignment,
+            .pointer = properties.pointer,
+            .is_array = properties.is_array,
+            .array_extent = properties.array_size,
+        });
+      }
+    }
     resolve_body(function->body, context, binding_result.table, signatures,
                  call_argument_properties, resolved_function, diagnostics);
     check_call_staging_body(*function, function->body, binding_result.table,

--- a/submod/resolved_ir/test/package_consumer/main.cpp
+++ b/submod/resolved_ir/test/package_consumer/main.cpp
@@ -1,4 +1,7 @@
+#include <optional>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 
 #include <ptx_frontend/binding/ptx_symbol_table.hpp>
@@ -7,6 +10,90 @@
 #include <ptx_frontend/semantic/ptx_call_argument_compatibility.hpp>
 #include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+/** Verify entry input metadata through only the installed resolved-IR API. */
+int check_entry_parameter_metadata() {
+  std::optional<ptx_frontend::resolved_ir::ResolvedModule> resolved_module;
+  {
+    const std::string fixture = R"ptx(
+.entry declared(.param .u16 scalar,
+                 .param .align 8 .b8 declaration_unsized[]) { }
+.entry defined(.param .u32 scalar, .param .align 16 .u64 aligned,
+               .param .u64 .ptr generic_pointer,
+               .param .u64 .ptr .global .align 32 global_pointer,
+               .param .align 8 .b8 values[2 * 4]) { }
+.func device_only(.param .u32 ignored) { }
+)ptx";
+    ptx_frontend::PtxSyntaxParser parser(fixture);
+    const auto ast = parser.parseModule();
+    if (!ast || !ast.diagnostics.empty())
+      return 31;
+    auto resolved = ptx_frontend::resolved_ir::resolveModule(*ast);
+    if (!resolved)
+      return 32;
+    resolved_module = std::move(*resolved);
+  }
+
+  const auto& functions = resolved_module->functions;
+  if (functions.size() != 3 || !functions[0].is_entry ||
+      functions[0].is_prototype || !functions[1].is_entry ||
+      functions[1].is_prototype || functions[2].is_entry ||
+      !functions[2].entry_parameters.empty()) {
+    return 33;
+  }
+
+  const auto& declared = functions[0].entry_parameters;
+  const auto& defined = functions[1].entry_parameters;
+  if (declared.size() != 2 || defined.size() != 5 ||
+      declared[0].type != ".u16" || declared[0].alignment != 2 ||
+      declared[0].is_array || declared[0].array_extent || declared[0].pointer ||
+      declared[1].type != ".b8" || declared[1].alignment != 8 ||
+      !declared[1].is_array || declared[1].array_extent ||
+      declared[1].pointer || defined[0].type != ".u32" ||
+      defined[0].alignment != 4 || defined[0].is_array ||
+      defined[0].array_extent || defined[0].pointer ||
+      defined[1].type != ".u64" || defined[1].alignment != 16 ||
+      defined[1].is_array || defined[1].array_extent || defined[1].pointer ||
+      defined[2].type != ".u64" || defined[2].alignment != 8 ||
+      !defined[2].pointer || defined[2].pointer->pointed_state_space ||
+      defined[2].pointer->pointed_alignment != 4 || defined[3].type != ".u64" ||
+      defined[3].alignment != 8 || !defined[3].pointer ||
+      defined[3].pointer->pointed_state_space !=
+          ptx_frontend::call_argument_compatibility::PointedStateSpace::
+              Global ||
+      defined[3].pointer->pointed_alignment != 32 || defined[4].type != ".b8" ||
+      defined[4].alignment != 8 || !defined[4].is_array ||
+      defined[4].array_extent != 8 || defined[4].pointer) {
+    return 34;
+  }
+
+  const auto declared_function_scope =
+      resolved_module->symbols.symbol(functions[0].symbol_id).owned_scope;
+  const auto defined_function_scope =
+      resolved_module->symbols.symbol(functions[1].symbol_id).owned_scope;
+  if (!declared_function_scope || !defined_function_scope ||
+      resolved_module->symbols.symbol(declared[0].symbol_id).name !=
+          "scalar" ||
+      resolved_module->symbols.symbol(declared[1].symbol_id).name !=
+          "declaration_unsized" ||
+      resolved_module->symbols.symbol(defined[0].symbol_id).name != "scalar" ||
+      resolved_module->symbols.symbol(defined[1].symbol_id).name != "aligned" ||
+      resolved_module->symbols.symbol(defined[2].symbol_id).name !=
+          "generic_pointer" ||
+      resolved_module->symbols.symbol(defined[3].symbol_id).name !=
+          "global_pointer" ||
+      resolved_module->symbols.symbol(defined[4].symbol_id).name != "values" ||
+      resolved_module->symbols.symbol(declared[0].symbol_id).scope !=
+          *declared_function_scope ||
+      resolved_module->symbols.symbol(defined[0].symbol_id).scope !=
+          *defined_function_scope ||
+      resolved_module->symbols.symbol(defined[4].symbol_id).scope !=
+          *defined_function_scope ||
+      declared[0].symbol_id == defined[0].symbol_id) {
+    return 35;
+  }
+  return 0;
+}
 
 int main() {
   constexpr std::string_view source = "add.u32 %r0, %r1, 1;";
@@ -94,6 +181,11 @@ int main() {
   }
   if (!add_has_legacy_mixed_precision_order)
     return 30;
+
+  if (const int metadata_result = check_entry_parameter_metadata();
+      metadata_result != 0) {
+    return metadata_result;
+  }
 
   ptx_frontend::PtxSyntaxParser call_parser(
       "call (%result), callee, (%argument, 1);");

--- a/submod/resolved_ir/test/test_entry_parameter_metadata.cpp
+++ b/submod/resolved_ir/test/test_entry_parameter_metadata.cpp
@@ -1,0 +1,190 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string>
+#include <string_view>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Resolve owned input, destroying both source and AST before returning metadata. */
+std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveSource(
+    std::string source) {
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  EXPECT_TRUE(ast.has_value());
+  EXPECT_TRUE(ast.diagnostics.empty());
+  if (!ast || !ast.diagnostics.empty())
+    return std::unexpected(
+        ModuleResolveDiagnostics{{.message = ast.diagnostics.front().message}});
+  return resolveModule(*ast);
+}
+
+/** Entry metadata remains usable after the source and syntax tree are gone. */
+TEST(ResolvedEntryParameters, RetainsSingleParameterWithoutAst) {
+  const auto resolved =
+      resolveSource(".entry kernel(.param .u32 count) { ret; }");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& parameters = resolved->functions.front().entry_parameters;
+  ASSERT_EQ(parameters.size(), 1u);
+  const auto& parameter = parameters.front();
+  EXPECT_EQ(parameter.type, ".u32");
+  EXPECT_EQ(parameter.alignment, 4u);
+  EXPECT_FALSE(parameter.pointer);
+  EXPECT_FALSE(parameter.is_array);
+  EXPECT_FALSE(parameter.array_extent);
+  const auto& symbol = resolved->symbols.symbol(parameter.symbol_id);
+  EXPECT_EQ(symbol.name, "count");
+  EXPECT_EQ(symbol.kind, binding::SymbolKind::InputParameter);
+  EXPECT_EQ(symbol.state_space, syntax_ast::AstStateSpace::Parameter);
+  EXPECT_EQ(resolved->symbols.scope(symbol.scope).owner,
+            resolved->functions.front().symbol_id);
+}
+
+/** Representative GEMM inputs retain declaration order and separate alignments. */
+TEST(ResolvedEntryParameters, RetainsGemmMetadataInSourceOrder) {
+  const auto resolved = resolveSource(R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.visible .entry gemm(
+    .param .align 16 .u64 .ptr .global .align 32 A,
+    .param .u64 .ptr .global .align 16 B,
+    .param .u64 .ptr .global .align 16 C,
+    .param .u32 M,
+    .param .u32 N,
+    .param .u32 K,
+    .param .u32 lda,
+    .param .u32 ldb,
+    .param .u32 ldc) { ret; }
+)ptx");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& function = resolved->functions.front();
+  const auto& parameters = function.entry_parameters;
+  constexpr std::array<std::string_view, 9> names{"A", "B",   "C",   "M",  "N",
+                                                  "K", "lda", "ldb", "ldc"};
+  ASSERT_EQ(parameters.size(), names.size());
+  for (size_t index = 0; index < names.size(); ++index) {
+    SCOPED_TRACE(names[index]);
+    const auto& parameter = parameters[index];
+    const auto& symbol = resolved->symbols.symbol(parameter.symbol_id);
+    EXPECT_EQ(symbol.name, names[index]);
+    EXPECT_EQ(symbol.kind, binding::SymbolKind::InputParameter);
+    EXPECT_EQ(resolved->symbols.scope(symbol.scope).owner, function.symbol_id);
+    EXPECT_EQ(parameter.type, index < 3 ? ".u64" : ".u32");
+    EXPECT_EQ(parameter.alignment, index == 0 ? 16u : index < 3 ? 8u : 4u);
+    EXPECT_FALSE(parameter.is_array);
+    EXPECT_FALSE(parameter.array_extent);
+    if (index < 3) {
+      ASSERT_TRUE(parameter.pointer);
+      EXPECT_EQ(parameter.pointer->pointed_state_space,
+                call_argument_compatibility::PointedStateSpace::Global);
+      EXPECT_EQ(parameter.pointer->pointed_alignment, index == 0 ? 32u : 16u);
+    } else {
+      EXPECT_FALSE(parameter.pointer);
+    }
+  }
+}
+
+/** Pointer defaults and all concrete target spaces survive contract lowering. */
+TEST(ResolvedEntryParameters, RetainsPointerTargetSpacesAndDefaults) {
+  const auto resolved = resolveSource(R"ptx(
+.entry pointers(
+    .param .u64 raw_address,
+    .param .u64 .ptr generic_address,
+    .param .u64 .ptr .local local_address,
+    .param .u64 .ptr .shared .align 8 shared_address,
+    .param .u64 .ptr .const .align 16 constant_address) { ret; }
+)ptx");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& parameters = resolved->functions.front().entry_parameters;
+  ASSERT_EQ(parameters.size(), 5u);
+  EXPECT_FALSE(parameters[0].pointer);
+  ASSERT_TRUE(parameters[1].pointer);
+  EXPECT_FALSE(parameters[1].pointer->pointed_state_space);
+  EXPECT_EQ(parameters[1].pointer->pointed_alignment, 4u);
+  using call_argument_compatibility::PointedStateSpace;
+  constexpr std::array spaces{PointedStateSpace::Local,
+                              PointedStateSpace::Shared,
+                              PointedStateSpace::Constant};
+  for (size_t index = 0; index < spaces.size(); ++index) {
+    ASSERT_TRUE(parameters[index + 2].pointer);
+    EXPECT_EQ(parameters[index + 2].pointer->pointed_state_space,
+              spaces[index]);
+    EXPECT_EQ(parameters[index + 2].pointer->pointed_alignment, 4u << index);
+    EXPECT_EQ(parameters[index + 2].alignment, 8u);
+  }
+}
+
+/** Array extents are element counts; unsized arrays remain distinguishable. */
+TEST(ResolvedEntryParameters, RetainsArrayShapeAndNormalizedExtent) {
+  const auto resolved = resolveSource(R"ptx(
+.entry arrays(.param .align 16 .b8 bytes[2 * 8],
+              .param .u32 words[2 + 1],
+              .param .align 8 .b8 unsized[],
+              .param .b8 scalar) { ret; }
+)ptx");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& parameters = resolved->functions.front().entry_parameters;
+  ASSERT_EQ(parameters.size(), 4u);
+  EXPECT_EQ(parameters[0].type, ".b8");
+  EXPECT_EQ(parameters[0].alignment, 16u);
+  EXPECT_TRUE(parameters[0].is_array);
+  EXPECT_EQ(parameters[0].array_extent, 16u);
+  EXPECT_EQ(parameters[1].type, ".u32");
+  EXPECT_EQ(parameters[1].alignment, 4u);
+  EXPECT_TRUE(parameters[1].is_array);
+  EXPECT_EQ(parameters[1].array_extent, 3u);
+  EXPECT_EQ(parameters[2].alignment, 8u);
+  EXPECT_TRUE(parameters[2].is_array);
+  EXPECT_FALSE(parameters[2].array_extent);
+  EXPECT_EQ(parameters[3].alignment, 1u);
+  EXPECT_FALSE(parameters[3].is_array);
+  EXPECT_FALSE(parameters[3].array_extent);
+}
+
+/** Repeated parameter names identify each entry's own inputs, not nested locals. */
+TEST(ResolvedEntryParameters, RetainsParametersPerEntryScope) {
+  const auto resolved = resolveSource(R"ptx(
+.entry first(.param .u32 input) { ret; }
+.entry second(.param .u32 input) {
+  { .reg .u32 input; }
+  ret;
+}
+.entry empty() { ret; }
+.func (.param .u32 result) helper(.param .u32 input);
+.func (.param .u32 result) helper(.param .u32 input) { ret; }
+)ptx");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  ASSERT_EQ(resolved->functions.size(), 5u);
+  ASSERT_EQ(resolved->functions[0].entry_parameters.size(), 1u);
+  ASSERT_EQ(resolved->functions[1].entry_parameters.size(), 1u);
+  const auto& first = resolved->symbols.symbol(
+      resolved->functions[0].entry_parameters[0].symbol_id);
+  const auto& second = resolved->symbols.symbol(
+      resolved->functions[1].entry_parameters[0].symbol_id);
+  EXPECT_NE(first.id, second.id);
+  EXPECT_NE(first.scope, second.scope);
+  EXPECT_EQ(first.name, "input");
+  EXPECT_EQ(second.name, "input");
+  EXPECT_EQ(first.kind, binding::SymbolKind::InputParameter);
+  EXPECT_EQ(second.kind, binding::SymbolKind::InputParameter);
+  EXPECT_EQ(resolved->symbols.scope(first.scope).owner,
+            resolved->functions[0].symbol_id);
+  EXPECT_EQ(resolved->symbols.scope(second.scope).owner,
+            resolved->functions[1].symbol_id);
+  EXPECT_TRUE(resolved->functions[2].entry_parameters.empty());
+  EXPECT_TRUE(resolved->functions[3].entry_parameters.empty());
+  EXPECT_TRUE(resolved->functions[4].entry_parameters.empty());
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir


### PR DESCRIPTION
## Change

Downstream consumers previously lost entry parameter order and ABI shape when using `ResolvedModule`. Add owned, source-ordered `ResolvedFunction::entry_parameters` with symbol identity, type spelling, effective alignment, pointer target space/alignment, and array shape/constant extent, reusing existing declaration-contract normalization.

The metadata remains usable after source text and AST destruction. Tests include GEMM A/B/C pointers, M/N/K and leading dimensions, separate parameter/pointee alignments, and entry-local symbol identity. Installed public headers and bilingual design documentation expose the contract.

This is the targeted metadata change: it does not introduce argument byte packing, simulator addresses, launch allocation, or claim complete PTX `.param` syntax/legality coverage. Broader coverage gaps are tracked separately in #55.

Closes #43

## Validation

- Debug build and `ctest --preset ci-linux-gcc-debug --output-on-failure -j 4`: 618 tests passed, including five new metadata regressions.
- `python_test` with Debug configuration: 227 Python tests passed.
- `ptx_frontend.package_consumer` with Debug configuration: passed, including installed/relocated consumer checks.
- `git diff --check`: passed.
- Release configuration and hosted CI were not run locally.
