### PR TITLE
feat(resolved-ir)!: unify validated parameter declaration metadata

### DIFF
--- a/.agents/project_roadmap.v2.md
+++ b/.agents/project_roadmap.v2.md
@@ -529,6 +529,11 @@ family scope，绝不表示整部 PTX ISA。
 global/constant/shared/local declaration 的 identity、shape、size/alignment 与 typed
 initializer 信息；内存布局、分配及 CTA/thread instance 仍属于 consumer。
 
+`.param` 的声明覆盖与公共 metadata 边界另见 [parameter coverage](../docs/us-en/parameter_declarations.md)
+与[中文契约](../docs/zh-han/parameter_declarations.md)：保留 entry/device input、device return
+与 body-local parameter 的 typed shape、size/alignment、role 和 lexical identity；opaque 与
+其他 unsupported form 明确诊断，不扩展为 launch packing 或 simulator allocation。
+
 ## M3：值、地址与 `mov`
 
 | ID | 状态 | Issue | 闭环摘要 |

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ The frontend currently provides:
   initializer, and instruction forms;
 - module/function symbol scopes, reference classification, and declaration
   semantics;
+- owned [parameter-declaration metadata](docs/us-en/parameter_declarations.md)
+  for entry/device inputs, device returns, and body-local `.param` declarations,
+  with typed shapes, checked byte extents, and an explicit supported ISA boundary;
 - owned [storage-declaration metadata](docs/us-en/storage_declarations.md) for
   global, constant, shared, and local data: declaration identity, lexical owner,
   type/shape, checked byte extent, alignment, linkage, and typed initializer

--- a/docs/us-en/declaration_semantics_design.md
+++ b/docs/us-en/declaration_semantics_design.md
@@ -73,6 +73,14 @@ Module resolution converts a valid prototype to the same canonical signature
 as a function and reuses the validated first `.calltargets` member signature
 for indirect-call ABI checking. ABI suffix availability remains later work.
 
+## Parameter declarations
+
+Parameters have a context-aware [coverage and validation contract](parameter_declarations.md),
+including supported types, unsized-array placement, pointer attributes, and
+statically decidable ISA version/target and entry-size limits. This applies to
+entry/device headers, call-prototype formals, and body-local `.param`
+declarations; retained type spelling or array syntax alone does not establish validity.
+
 ## Entry resource constraints
 
 For the supported entry-header `.maxnreg`, `.maxntid`, `.reqntid`, and

--- a/docs/us-en/parameter_declarations.md
+++ b/docs/us-en/parameter_declarations.md
@@ -1,0 +1,109 @@
+# Parameter declarations
+
+This is the frontend's PTX ISA 9.3 declaration boundary, not a launch ABI,
+instruction-completeness claim, or runtime allocation model. Parsing alone does
+not establish that a declaration is valid. `resolveModule()` runs declaration
+validation before publishing metadata.
+
+## Coverage matrix
+
+| Form / context | Parser | Declaration validation | Installed public metadata |
+| --- | --- | --- | --- |
+| Entry header scalar / sized 1-D array | Retained | Fundamental non-predicate types, constant positive extents, alignment, pointer attributes, version and total-size checks | Ordered typed `parameter_declarations` with `EntryInput` role |
+| Device input / return scalar / sized 1-D array | Retained | Same type/extent checks; `.param` needs PTX 2.0 / SM 20; modern functions have at most one return | `parameter_declarations`, `DeviceInput` / `DeviceReturn` |
+| Final device input `.param .b8 bytes[]` | Retained | Only final input; PTX 6.0 / SM 30 minimum | One unknown extent and unknown byte extent, distinct from a scalar |
+| Unsized entry, return, non-final input, or non-`.b8` input | Retained | Rejected | No resolved module |
+| Body-local scalar / sized array, including multiple dimensions | Retained | Fundamental non-predicate type, positive constant extents, checked size, alignment, PTX 2.0 / SM 20 | `parameter_declarations`, `BodyLocal`, lexical scope and full array shape |
+| Unsized body-local `.param` | Retained | Rejected | No resolved module |
+| `.callprototype` scalar / array formals | Retained | Device signature rules; prototype itself requires PTX 2.1 / SM 20 | Owned `declaration_semantics::FunctionSignature` from the semantic API; not a declaration table entry |
+| Header vector / multidimensional array | Explicit unsupported parse diagnostic | Not reached | None |
+| Body-local vector `.param` | Retained | Explicit unsupported diagnostic | None |
+| `.f16x2` / opaque `.texref`, `.samplerref`, `.surfref` | Type spelling retained | Explicit unsupported diagnostic | None; no invented opaque size/alignment |
+| `.pred`, unknown or instruction-only type spelling | Type spelling retained | Rejected for `.param` | None |
+| Module-scope `.param` | Retained | Rejected | None |
+
+Supported parameter elements are `.s8/.s16/.s32/.s64`, `.u8/.u16/.u32/.u64`,
+`.b8/.b16/.b32/.b64/.b128`, and `.f16/.f32/.f64`. The public
+`declaration_semantics::parameterScalarType()` classifies this supported set;
+its result is a type classification, not validation of context or availability.
+Instruction alternate formats such as `.bf16` and `.tf32` do not become legal
+declaration types by retaining their spelling. `.reg` formals retain their
+existing separate signature/address path; they are not `.param` table entries.
+
+## Alignment, pointers, and size
+
+Explicit declaration and pointee alignments must be positive powers of two.
+Omitted declaration alignment is natural element alignment; an explicit value
+is retained separately from whether it equals that natural value. The frontend
+does not infer a maximum alignment from the ABI's wording about multiples of
+1, 2, 4, 8, or 16 bytes.
+
+`.ptr` belongs to entry inputs and requires PTX 2.2. The supported scalar pointer
+types are `.u32` and `.u64`. Pointed state space may be `.const`, `.global`,
+`.local`, or `.shared`; omission denotes generic space. Omitted pointee alignment
+defaults to four bytes. Parameter storage alignment and pointee alignment are
+different fields. No host pointer width or launch-address policy is inferred.
+Canonical function signatures compare effective alignments: omitted natural
+alignment and an explicit equal value are compatible. Declaration metadata still
+retains the explicit-alignment distinction. Direct and metadata-backed indirect
+array calls use the same natural-alignment default.
+Formal `.param` objects cannot be used directly as call actuals. Load an input
+(including an entry pointer) into a register or stage it through a body-local
+`.param` object first. Device formals do not acquire an entry-only `.ptr` attribute.
+
+Entry header parameters require PTX 1.4. For normal, non-opaque entry parameters,
+statically computed aggregate storage includes inter-parameter alignment padding.
+The version-selected limit is 256 bytes at PTX 1.4, 4352 bytes at PTX 1.5–8.0,
+and 32764 bytes at PTX 8.1 and later. Checked arithmetic rejects overflowing
+declaration extents and aggregates. These are ISA limits, not CUDA/OpenCL
+driver-specific limits; byte extents are not packed offsets or allocated memory.
+Missing version/target information cannot prove an availability violation.
+Legacy PTX 1.0–1.3 entry inputs declared inside the body are unsupported; the
+body-local metadata role describes call argument/return objects, not those inputs.
+Body-local `.param` initializers are rejected by the parser; semantic validation
+also guards against them in directly constructed ASTs.
+Calls may omit a validated final unsized byte input when there is no payload;
+other required input and return arguments remain subject to exact arity checks.
+
+## Owned metadata and remaining scope
+
+Each function owns `parameter_declarations` in return-list, input-list, then
+body lexical traversal order. Entries retain symbol and lexical-scope identities,
+role, scalar type enum, vector width, ordered array extents, declared bytes,
+effective alignment, explicit-alignment provenance, and optional pointer
+properties. Values remain inspectable after source and AST destruction. Nested
+same-name body declarations have distinct identities. This is the sole owned
+parameter declaration table. Consumers select `ParameterDeclarationRole::EntryInput`
+to inspect entry header inputs in source order; other roles are not launch slots.
+
+The former `ResolvedFunction::entry_parameters` member and `ResolvedEntryParameter`
+type have been removed. This is a breaking C++ API change: consumers must migrate
+and rebuild, not merely rename the member. Use `scalar_type` instead of the old
+type string, the effective non-optional `alignment`, and `array_extents` /
+`byte_extent` instead of `is_array` / `array_extent`. An empty extent list denotes
+a scalar; an unknown axis denotes a supported unsized array. ABI layout and
+packing remain consumer responsibilities.
+
+Opaque entry parameters are legal ISA objects but require a dedicated name-only
+texture/surface access contract: ordinary `ld.param` cannot load them. Their
+physical layout is intentionally hidden. Supporting these objects, `.f16x2`,
+header vectors, and higher-rank header grammar is follow-up work requiring both
+context-specific conformance evidence and matching typed metadata. Current
+unsupported diagnostics are not claims that all these forms are ISA-illegal.
+Body-local parameterized declaration groups are also outside the supported
+metadata boundary. No instruction families, simulator execution, argument packing,
+or physical allocation are added here.
+
+## Evidence and regressions
+
+The authority is the archived [PTX ISA 9.3](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html):
+[parameter state space](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#parameter-state-space),
+[fundamental types](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#fundamental-types),
+[entry](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#kernel-and-function-directives-entry),
+[device functions](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#kernel-and-function-directives-func),
+and [call prototypes](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#control-flow-directives-callprototype).
+Assembler observations supplement, but do not replace, these contracts.
+
+Regressions cover explicit parser boundaries, semantic type/role/version/size
+validation, resolved declaration identity and lifetime, and a separately compiled
+installed-package consumer. GPU execution is not a declaration-validation gate.

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -57,9 +57,9 @@ callers while retaining the strongly typed per-opcode structures.
 `resolveModule` first builds a `SymbolTable`, then constructs an explicit
 `ResolveContext` for each function scope. The resulting `ResolvedModule` owns
 that table, and each `ResolvedFunction` is identified by its function
-`SymbolId`. Entry functions additionally own source-ordered
-`entry_parameters` metadata for their input declarations; `.func` functions
-have an empty list.
+`SymbolId`. Each function owns a single `parameter_declarations` table for its
+validated `.param` declarations. Filtering by `ParameterDeclarationRole::EntryInput`
+selects entry header inputs in source order.
 `ResolvedFunction::label_positions` records each function label as
 its bound `SymbolId` and a source-order boundary in the recursively flattened
 instruction body: labels before the first instruction are at zero, consecutive
@@ -67,24 +67,28 @@ labels share a boundary, and a trailing label is at `body.size()`. Standalone
 `resolveInstruction` and `resolve<T>` remain declaration-free for
 single-instruction tools. Raw directives and declarations remain in the Syntax
 AST/symbol table instead of being copied into Resolved IR as unresolved string
-fields; owned, normalized entry-input ABI metadata is the deliberate exception.
+fields; owned, normalized parameter and storage metadata are deliberate exceptions.
 Bound `.file` and `.debug_str`
 identities validate `.loc` metadata there, but `.loc`, `.section`, and
 `.pragma` do not add Resolved IR nodes or instruction attachment.
 
-`ResolvedEntryParameter` is an inspection boundary, not a launch-layout or
-runtime-policy model. Each item owns its normalized scalar PTX `type` spelling,
-the local-declaration `symbol_id`, optional effective byte `alignment`, optional
-`PointerProperties`, `is_array`, and optional constant `array_extent` in
-elements. The binding-derived alignment includes an explicit declaration
-alignment or a known natural alignment and is absent when it is unknown. A
-non-pointer has no pointer properties; a pointer with no pointed state space is
-generic, and a pointed alignment omitted in the source has the semantic default
-of four bytes. `is_array` distinguishes an unsized array from a scalar when
-`array_extent` is absent. The metadata owns all represented values, so clients
-can inspect it after the source text and Syntax AST have been destroyed. Its
-parameter IDs refer to each entry's function-local declaration scope, so
-separate entries can reuse parameter names while retaining distinct identities.
+`ResolvedFunction::parameter_declarations` owns validated `.param`
+declarations: return formals first, input formals next, then body-local declarators
+in lexical traversal order (including nested blocks). Each
+`ResolvedParameterDeclaration` retains its `symbol_id`, `scope_id`, role
+(`EntryInput`, `DeviceInput`, `DeviceReturn`, or `BodyLocal`), fundamental
+`scalar_type`, effective byte `alignment`, `explicit_alignment`, `vector_width`,
+outer-to-inner `array_extents`, checked `byte_extent`, and optional pointee
+properties. Scalar shapes have no array extents; supported unsized device input
+arrays have a null extent and no byte extent. The owning function and symbol
+table preserve lexical identity even for shadowed local names. Values remain
+inspectable after source text and Syntax AST destruction. A non-pointer has no
+pointer properties; a pointer with no pointed state space is generic, and omitted
+pointee alignment defaults to four bytes. This sole parameter table does not
+include `.reg` formals or `.callprototype` signatures. See the
+[parameter coverage and migration contract](parameter_declarations.md)
+for declaration validation, unsupported forms, and version boundaries. None of
+these fields describes packed argument offsets or a runtime allocation.
 
 Module resolution additionally performs direct and metadata-backed indirect
 call ABI and call-context work

--- a/docs/us-en/storage_declarations.md
+++ b/docs/us-en/storage_declarations.md
@@ -8,7 +8,8 @@ may be destroyed after successful resolution.
 
 This is a declaration-to-consumer contract, not a memory allocator or a claim
 of complete PTX declaration conformance. Parameters remain separate:
-`ResolvedFunction::entry_parameters` continues to describe entry inputs.
+`ResolvedFunction::parameter_declarations` describes `.param` declarations;
+the `EntryInput` role identifies entry inputs.
 Registers and call parameters do not enter the storage list.
 
 ## Identity and layout inputs

--- a/docs/zh-han/declaration_semantics_design.md
+++ b/docs/zh-han/declaration_semantics_design.md
@@ -62,6 +62,13 @@ binding 负责。module resolution 会把有效 prototype 转为与 function 相
 并复用已验证的首个 `.calltargets` member signature 进行 indirect-call ABI checking；ABI suffix
 availability 仍留给后续工作。
 
+## 参数声明
+
+参数另有按上下文区分的[覆盖与验证契约](parameter_declarations.md)，包括支持的类型、
+unsized array 位置、pointer attribute，以及可静态判定的 ISA version/target 与 entry
+大小限制。该契约适用于 entry/device header、call-prototype formal 与 body-local `.param`
+声明；保留 type spelling 或 array syntax 本身不表示声明合法。
+
 ## Entry resource constraint
 
 对已支持的 entry-header `.maxnreg`、`.maxntid`、`.reqntid` 与 `.minnctapersm`，本 pass

--- a/docs/zh-han/parameter_declarations.md
+++ b/docs/zh-han/parameter_declarations.md
@@ -1,0 +1,94 @@
+# 参数声明
+
+本文描述 frontend 的 PTX ISA 9.3 声明支持边界，不代表 launch ABI、指令全集或运行时
+分配模型。能 parse 不等于声明合法；`resolveModule()` 在发布 metadata 前执行声明验证。
+
+## 覆盖矩阵
+
+| 形式 / 上下文 | Parser | 声明验证 | Installed public metadata |
+| --- | --- | --- | --- |
+| Entry header scalar / 有界一维数组 | 保留 | 基础非 predicate 类型、正整数常量维度、alignment、pointer attribute、版本与总大小 | 有序 typed `parameter_declarations`，role 为 `EntryInput` |
+| Device input / return scalar / 有界一维数组 | 保留 | 同类 type/extent 检查；`.param` 要求 PTX 2.0 / SM 20；现代函数至多一个返回值 | `parameter_declarations`，role 为 `DeviceInput` / `DeviceReturn` |
+| 最后一个 device input `.param .b8 bytes[]` | 保留 | 仅限最后一个 input；最低 PTX 6.0 / SM 30 | 单个未知 extent，byte extent 未知，与 scalar 可区分 |
+| Unsized entry、return、非末尾 input 或非 `.b8` input | 保留 | 拒绝 | 不生成 resolved module |
+| Body-local scalar / 有界数组，含多维数组 | 保留 | 基础非 predicate 类型、正整数常量维度、大小溢出检查、alignment、PTX 2.0 / SM 20 | `parameter_declarations`，role 为 `BodyLocal`，保留词法 scope 与完整 shape |
+| Unsized body-local `.param` | 保留 | 拒绝 | 不生成 resolved module |
+| `.callprototype` scalar / array formal | 保留 | Device signature 规则；prototype 本身要求 PTX 2.1 / SM 20 | Semantic API 可生成拥有自身数据的 `declaration_semantics::FunctionSignature`；不进入声明表 |
+| Header vector / 多维数组 | 明确的 unsupported parse diagnostic | 不进入 | 无 |
+| Body-local vector `.param` | 保留 | 明确的 unsupported diagnostic | 无 |
+| `.f16x2` / opaque `.texref`、`.samplerref`、`.surfref` | 保留 type spelling | 明确的 unsupported diagnostic | 无；不臆造 opaque size/alignment |
+| `.pred`、未知或仅用于指令的 type spelling | 保留 type spelling | 在 `.param` 中拒绝 | 无 |
+| Module-scope `.param` | 保留 | 拒绝 | 无 |
+
+支持的 parameter element 为 `.s8/.s16/.s32/.s64`、`.u8/.u16/.u32/.u64`、
+`.b8/.b16/.b32/.b64/.b128` 与 `.f16/.f32/.f64`。公开的
+`declaration_semantics::parameterScalarType()` 对该支持集合进行分类；结果只表示类型
+分类，不表示上下文或版本已通过验证。`.bf16`、`.tf32` 等 instruction alternate format
+不会因为 spelling 被保留就成为合法 declaration type。`.reg` formal 继续使用既有
+signature/address 路径，不属于 `.param` 声明表。
+
+## Alignment、pointer 与大小
+
+显式 declaration / pointee alignment 必须为正的二次幂。省略 declaration alignment 时
+采用 element 的自然对齐；即使显式值恰好等于自然值，也单独保留显式指定这一事实。
+Frontend 不会从 ABI 关于 1、2、4、8 或 16 字节倍数的表述推断最大 alignment。
+
+`.ptr` 属于 entry input，要求 PTX 2.2。受支持的 scalar pointer type 为 `.u32` 与 `.u64`。
+Pointed state space 可为 `.const`、`.global`、`.local` 或 `.shared`，省略时表示 generic。
+Pointee alignment 省略时默认为四字节。Parameter storage alignment 与 pointee alignment
+是不同字段，不推断 host pointer width 或 launch address policy。
+Canonical function signature 比较有效 alignment：省略的自然对齐与显式指定的同值对齐
+兼容；声明 metadata 仍保留是否显式指定的区别。Direct 与基于 metadata 的 indirect array
+call 使用相同的自然对齐默认值。
+Formal `.param` object 不能直接作为 call actual。应先将 input（包括 entry pointer）
+加载到 register，或通过 body-local `.param` object 暂存；device formal 不会取得
+entry 专属的 `.ptr` attribute。
+
+Entry header parameter 要求 PTX 1.4。对普通非 opaque entry parameter，静态计算的总空间
+包含参数之间的 alignment padding。PTX 1.4 的上限为 256 字节，PTX 1.5–8.0 为 4352 字节，
+PTX 8.1 及以后为 32764 字节。Checked arithmetic 拒绝单个声明或累计大小溢出。
+这些是 ISA 限制，不是 CUDA/OpenCL driver 专属限制；byte extent 不是 packed offset 或
+已分配内存。缺失 version/target 时不能证明 availability 违规。
+PTX 1.0–1.3 将 entry input 声明放在 body 中的旧形式不受支持；body-local metadata role
+描述的是 call argument/return object，而非这些旧式 input。
+Parser 会拒绝 body-local `.param` initializer；对直接构造的 AST，semantic validation
+也会拒绝该形式。
+没有 payload 时，call 可以省略通过验证的末尾 unsized byte input；其他必需的 input
+与 return argument 仍检查准确的参数数量。
+
+## Owned metadata 与后续范围
+
+每个 function 按 return-list、input-list、body 词法遍历的顺序拥有
+`parameter_declarations`。条目保留 symbol / lexical-scope identity、role、scalar type
+enum、vector width、有序 array extent、声明字节数、有效 alignment、显式 alignment
+来源与可选 pointer property。Source 与 AST 销毁后仍可检查这些值。嵌套 body 中的同名
+声明具有不同 identity。这是唯一拥有自身数据的 parameter declaration table。
+Consumer 按 `ParameterDeclarationRole::EntryInput` 筛选即可按源码顺序检查 entry header
+input；其他 role 不是 launch slot。
+
+原有 `ResolvedFunction::entry_parameters` 成员与 `ResolvedEntryParameter` 类型已删除。
+这是破坏性的 C++ API 变更，consumer 需要迁移并重新构建，不能只重命名成员。使用
+`scalar_type` 代替旧 type string，使用非 optional 的有效 `alignment`，并以
+`array_extents` / `byte_extent` 代替 `is_array` / `array_extent`。空维度列表表示 scalar；
+未知维度表示受支持的 unsized array。ABI layout 与 packing 仍由 consumer 负责。
+
+Opaque entry parameter 是合法 ISA object，但需要专门的、按名称使用的 texture/surface
+access contract，普通 `ld.param` 不能加载它们，其物理 layout 刻意隐藏。支持这些对象、
+`.f16x2`、header vector 与更高 rank 的 header grammar 属于后续工作，需要上下文相关的
+conformance evidence 及匹配的 typed metadata。当前 unsupported diagnostic 不代表这些形式
+全部违反 ISA。Body-local parameterized declaration group 同样超出当前 metadata 支持边界。
+本工作不增加指令族、simulator execution、argument packing 或物理分配。
+
+## 依据与回归
+
+规范依据为归档的 [PTX ISA 9.3](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html)：
+[parameter state space](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#parameter-state-space)、
+[fundamental types](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#fundamental-types)、
+[entry](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#kernel-and-function-directives-entry)、
+[device function](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#kernel-and-function-directives-func) 与
+[call prototype](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html#control-flow-directives-callprototype)。
+Assembler 实验只补充证据，不取代规范。
+
+回归覆盖明确的 parser 边界、semantic type/role/version/size 验证、resolved declaration
+identity/lifetime，以及单独编译的 installed-package consumer。GPU execution 不属于声明
+验证 gate。

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -47,29 +47,30 @@ resolveModule(const syntax_ast::AstModule& ast);
 `resolveInstruction` 根据指令数据库生成，并分发到现有的 `resolve<T>` 特化。调用者不再
 需要手写 opcode 分派，同时每个 opcode 仍保留强类型结构。`resolveModule` 先建立
 `SymbolTable`，再为每个 function scope 构造显式 `ResolveContext`；返回的
-`ResolvedModule` 拥有 symbol table，`ResolvedFunction` 以函数 `SymbolId` 标识。entry
-function 还拥有按 source order 排列的 `entry_parameters` 输入声明 metadata；`.func` 的
-列表始终为空。
+`ResolvedModule` 拥有 symbol table，`ResolvedFunction` 以函数 `SymbolId` 标识。每个
+function 以唯一的 `parameter_declarations` 表拥有通过验证的 `.param` 声明。
+按 `ParameterDeclarationRole::EntryInput` 筛选即可按源码顺序取得 entry header input。
 `ResolvedFunction::label_positions` 以已绑定的 `SymbolId` 和 source-order 的 instruction
 boundary 记录每个 function label；boundary 基于递归展平的 body，首条 instruction 前为零、
 连续 label 共用一个 boundary、末尾 label 为 `body.size()`。standalone `resolveInstruction`
 与 `resolve<T>` 不要求声明上下文，继续服务单指令工具。directive 与 declaration 仍由
-Syntax AST/symbol table 保存，不复制成未解析的 Resolved IR 字符串字段；唯一刻意保留的
-例外是拥有值的、已规范化 entry-input ABI metadata。`.file` 与
+Syntax AST/symbol table 保存，不复制成未解析的 Resolved IR 字符串字段；刻意保留的
+例外是拥有值的、已规范化 parameter 与 storage metadata。`.file` 与
 `.debug_str` identity 会在那里验证 `.loc` metadata，
 但 `.loc`、`.section` 与 `.pragma` 不产生 Resolved IR node，也不附着到 instruction。
 
-`ResolvedEntryParameter` 是 inspection boundary，而非 launch layout 或 runtime policy
-model。每个条目拥有规范化标量 PTX `type` spelling、local-declaration `symbol_id`、可选的
-有效字节 `alignment`、可选 `PointerProperties`、`is_array` 与以 element 为单位的可选常量
-`array_extent`。binding 推导的 alignment 包括显式 declaration alignment 或已知 natural
-alignment；无法确定时为空。non-pointer 没有 pointer properties；未写 pointed state space 的
-pointer 为 generic，source 未写 pointed alignment 时采用四字节的语义默认值。`array_extent`
-为空时，
-`is_array` 用于区分 unsized array 与 scalar。metadata 拥有其所表示的全部值，因此 source
-text 与 Syntax AST 销毁后仍可供 client 检查。parameter ID 指向每个 entry 的
-function-local declaration scope；不同 entry 可以复用 parameter name，同时保留不同的
-identity。
+`ResolvedFunction::parameter_declarations` 拥有通过验证的 `.param` 声明：先按列表顺序
+保存 return formal，再保存 input formal，最后按词法遍历顺序保存 body-local declarator
+（含嵌套 block）。每个 `ResolvedParameterDeclaration` 保留 `symbol_id`、`scope_id`、role
+（`EntryInput`、`DeviceInput`、`DeviceReturn` 或 `BodyLocal`）、基础 `scalar_type`、有效字节
+`alignment`、`explicit_alignment`、`vector_width`、从外到内的 `array_extents`、经溢出检查的
+`byte_extent` 与可选 pointee property。scalar 的维度列表为空；受支持的 unsized device input
+array 的维度值及 byte extent 为空。所属 function 与 symbol table 即使在局部同名遮蔽时仍
+保留词法 identity。Source text 与 Syntax AST 销毁后仍可检查这些值。Non-pointer 没有
+pointer property；未写 pointed state space 的 pointer 为 generic，省略 pointee alignment
+时默认为四字节。该唯一 parameter table 不包含 `.reg` formal 或 `.callprototype`
+signature。声明验证、unsupported form、版本边界及迁移契约见
+[参数覆盖矩阵](parameter_declarations.md)。这些字段均不描述参数打包偏移或运行时分配。
 
 module resolution 还负责不能放入 generated single-instruction checker 的 direct 与 metadata-backed
 indirect-call ABI 以及

--- a/docs/zh-han/storage_declarations.md
+++ b/docs/zh-han/storage_declarations.md
@@ -6,7 +6,8 @@ declarator 提供拥有自身数据的元信息。数据类型位于
 通常的 resolved-IR header 使用。成功解析后可以销毁源码及 Syntax AST。
 
 这是从声明到 consumer 的契约，不是内存分配器，也不表示完整 PTX 声明合法性已验证。
-参数继续独立处理：`ResolvedFunction::entry_parameters` 仍描述 entry 输入参数；
+参数继续独立处理：`ResolvedFunction::parameter_declarations` 描述 `.param` 声明，
+其中 `EntryInput` role 标识 entry 输入参数；
 register 与 call parameter 不进入存储列表。
 
 ## 身份与布局输入

--- a/python/code_gen/_frontend/gen_resolved_ir.py
+++ b/python/code_gen/_frontend/gen_resolved_ir.py
@@ -164,8 +164,11 @@ struct ResolvedFunction {{
   std::vector<ResolvedInstruction> body;
   std::vector<ResolvedLabelPosition> label_positions;
   SourceRange range;
-  /** Owned input metadata in source order for .entry; empty for .func. */
-  std::vector<ResolvedEntryParameter> entry_parameters;
+  /**
+   * Owned .param returns, inputs, then body declarations in lexical traversal order.
+   * Filter ParameterDeclarationRole::EntryInput for source-ordered entry inputs.
+   */
+  std::vector<ResolvedParameterDeclaration> parameter_declarations;
 }};
 
 struct ResolvedModule {{

--- a/submod/cst/src/ptx_cst_parser.cpp
+++ b/submod/cst/src/ptx_cst_parser.cpp
@@ -1122,6 +1122,11 @@ PtxCstParser::parseFunctionParameter() {
   auto type = expect(TokenKind::DotIdent, "parameter type");
   if (!type)
     return std::unexpected(type.error());
+  if (token(*type).text == ".v2" || token(*type).text == ".v4") {
+    return std::unexpected(CstParseDiagnostic{
+        token(*type).range,
+        "vector function parameters are not supported"});
+  }
 
   std::optional<TokenId> pointer_directive;
   std::optional<TokenId> pointer_space;
@@ -1166,6 +1171,11 @@ PtxCstParser::parseFunctionParameter() {
       return std::unexpected(close.error());
     right_bracket = *close;
     last = *close;
+  }
+  if (token(peek()).kind == TokenKind::LBracket) {
+    return std::unexpected(CstParseDiagnostic{
+        token(peek()).range,
+        "multidimensional function parameters are not supported"});
   }
 
   return syntax_cst::CstFunctionParameter{

--- a/submod/cst/test/test_ptx_cst_parser.cpp
+++ b/submod/cst/test/test_ptx_cst_parser.cpp
@@ -1,8 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <initializer_list>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <variant>
 
 #include <ptx_frontend/cst/ptx_cst_parser.hpp>
@@ -933,6 +935,29 @@ TEST(PtxCstParser, ParsesParameterAttributesArraysAndPrototype) {
   ASSERT_TRUE(pointer.pointer_alignment.has_value());
   EXPECT_EQ(result->token(*pointer.pointer_alignment).text, "16");
   EXPECT_EQ(result->sourceText(), source);
+}
+
+/** Parameter syntax restrictions report their boundary before generic token errors. */
+TEST(PtxCstParser, RejectsUnsupportedParameterDeclarationForms) {
+  for (const auto& [source, message] :
+       std::initializer_list<std::pair<std::string_view, std::string_view>>{
+           {".entry kernel(.param .v2 .u32 input) { }",
+            "vector function parameters are not supported"},
+           {".func (.param .v4 .b8 result) helper();",
+            "vector function parameters are not supported"},
+           {".entry kernel(.param .u32 input[2][3]) { }",
+            "multidimensional function parameters are not supported"},
+           {".func (.param .u32 result[2][3]) helper();",
+            "multidimensional function parameters are not supported"},
+           {".entry kernel() { .param .b8 bytes[] = {1}; }",
+            "variable initializer requires '.global' or '.const' state space"}}) {
+    PtxCstParser parser(source);
+    const auto result = parser.parseModule();
+
+    ASSERT_TRUE(result.has_value()) << source;
+    ASSERT_FALSE(result.diagnostics.empty()) << source;
+    EXPECT_EQ(result.diagnostics.front().message, message) << source;
+  }
 }
 
 TEST(PtxCstParser, RejectsUnsupportedFunctionHeaderTokens) {

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -36,20 +36,36 @@ using base::MbarrierPhaseType;
 using base::AsyncProxyKind;
 using base::ProxyKindPair;
 
-/** Owned declaration metadata for one entry input parameter; no launch layout. */
-struct ResolvedEntryParameter {
-  /** Input parameter identity in the owning ResolvedModule's symbol table. */
+/** Declaration role, independent of how a body-local parameter is used by calls. */
+enum class ParameterDeclarationRole : uint8_t {
+  EntryInput,
+  DeviceInput,
+  DeviceReturn,
+  BodyLocal,
+};
+
+/** Owned, validated .param declaration data; contains no ABI offsets or storage. */
+struct ResolvedParameterDeclaration {
+  /** Declaration identity in the owning module's symbol table. */
   binding::SymbolId symbol_id;
-  /** Normalized PTX scalar type spelling, including the leading dot. */
-  std::string type;
-  /** Explicit or natural byte alignment; absent if binding cannot determine it. */
-  std::optional<uint64_t> alignment;
-  /** Pointee contract; absent for non-pointers, absent pointed space is generic. */
+  /** Lexical declaration scope; disambiguates shadowed body-local names. */
+  binding::ScopeId scope_id;
+  /** Header direction or body-local declaration role, not runtime call usage. */
+  ParameterDeclarationRole role{};
+  /** Validated fundamental element type, never Invalid or Pred. */
+  ScalarType scalar_type{ScalarType::Invalid};
+  /** Natural or explicitly requested byte alignment. */
+  uint64_t alignment{};
+  /** Retains whether the declaration requested its alignment explicitly. */
+  bool explicit_alignment{};
+  /** Number of scalar elements in a vector; one for scalar declarations. */
+  uint32_t vector_width{1};
+  /** Outer-to-inner element counts; empty for scalars, null for an unsized axis. */
+  std::vector<std::optional<uint64_t>> array_extents;
+  /** Total declared bytes, absent only for a supported unsized parameter. */
+  std::optional<uint64_t> byte_extent;
+  /** Pointee properties, not parameter storage alignment or allocation policy. */
   std::optional<call_argument_compatibility::PointerProperties> pointer;
-  /** Distinguishes an unsized array from a scalar when array_extent is absent. */
-  bool is_array{};
-  /** Constant element count, not bytes; absent for scalars and unsized arrays. */
-  std::optional<uint64_t> array_extent;
 };
 
 namespace check_end {

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -1099,6 +1099,17 @@ resolve_call_parameter(const syntax_ast::AstIdentifierRef& identifier,
                                identifier.syntax.text),
     });
   }
+  if (*symbol.state_space == syntax_ast::AstStateSpace::Parameter &&
+      (symbol.kind == binding::SymbolKind::InputParameter ||
+       symbol.kind == binding::SymbolKind::ReturnParameter)) {
+    return std::unexpected(ResolveDiagnostic{
+        .range = identifier.syntax.range,
+        .message = fmt::format(
+            "Formal .param parameter '{}' cannot be used directly as a call "
+            "argument; use a register or body-local .param object.",
+            identifier.syntax.text),
+    });
+  }
   resolved.symbol_id = lookup->symbol;
   resolved.parameterized_index = lookup->parameterized_index;
   resolved.state_space = symbol.state_space;

--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -85,12 +85,14 @@ std::optional<uint64_t> contract_array_size(
 
 CallArgumentProperties call_argument_properties(
     const declaration_semantics::FunctionParameterContract& contract) {
+  const auto scalar = declaration_semantics::parameterScalarType(contract.type);
+  const uint64_t natural_alignment = scalar ? base::scalar_size_of(*scalar) : 1;
   CallArgumentProperties properties{
       .state_space = *call_state_space(contract.state_space),
       .type_spelling = contract.type,
       .array_alignment = contract.alignment
-                             ? unsigned_value(*contract.alignment).value_or(1)
-                             : 1,
+                             ? unsigned_value(*contract.alignment).value_or(natural_alignment)
+                             : natural_alignment,
       .is_array = contract.is_array,
       .array_size = contract_array_size(contract),
   };
@@ -361,7 +363,13 @@ void check_call_abi(const syntax_ast::AstInstruction& call,
                                const auto& formals) {
     const size_t actual_count =
         actuals == nullptr ? 0 : actuals->parameters.size();
-    if (actual_count != formals.size()) {
+    // A validated final unsized byte input can be omitted for an empty payload.
+    const bool omitted_unsized_input =
+        kind == "input" && !formals.empty() &&
+        actual_count == formals.size() - 1 && formals.back().is_array &&
+        !formals.back().array_extent && formals.back().type == ".b8" &&
+        formals.back().state_space == syntax_ast::AstStateSpace::Parameter;
+    if (actual_count != formals.size() && !omitted_unsized_input) {
       diagnostics.push_back(ResolveDiagnostic{
           .range = actuals == nullptr ? target_range : actuals->range,
           .message = fmt::format("{} has {} {} argument{} but callee requires {}.",
@@ -664,15 +672,107 @@ void check_call_staging_body(
   }
 }
 
-void resolve_body(
-    const std::vector<syntax_ast::AstFunctionBodyItem>& body,
-    const ResolveContext& context, const binding::SymbolTable& symbols,
-    const FunctionSignatureIndex& signatures,
-    const CallArgumentPropertyIndex& call_argument_properties,
-    ResolvedFunction& resolved_function, ModuleResolveDiagnostics& diagnostics) {
+/** Compute declared bytes after semantic validation, without allocating ABI slots. */
+std::optional<uint64_t> parameter_byte_extent(
+    ScalarType type, uint32_t vector_width,
+    const std::vector<std::optional<uint64_t>>& extents) {
+  uint64_t bytes = base::scalar_size_of(type) * vector_width;
+  for (const auto extent : extents) {
+    if (!extent)
+      return std::nullopt;
+    if (*extent != 0 && bytes > std::numeric_limits<uint64_t>::max() / *extent)
+      throw ResolveException("Validated parameter byte extent overflows.");
+    bytes *= *extent;
+  }
+  return bytes;
+}
+
+/** Project a validated header .param while preserving its declaration role. */
+ResolvedParameterDeclaration resolve_parameter_declaration(
+    const syntax_ast::AstFunctionParameter& parameter,
+    ParameterDeclarationRole role, const binding::Symbol& symbol,
+    const CallArgumentProperties& properties) {
+  const auto type =
+      declaration_semantics::parameterScalarType(parameter.type.text);
+  if (!type || !symbol.address_alignment)
+    throw ResolveException(
+        "Validated parameter has no scalar type or alignment.");
+  std::vector<std::optional<uint64_t>> extents;
+  if (parameter.is_array)
+    extents.push_back(
+        parameter.array_size
+            ? declaration_semantics::constantArrayExtent(*parameter.array_size)
+            : std::nullopt);
+  const auto bytes = parameter_byte_extent(*type, 1, extents);
+  return {
+      .symbol_id = symbol.id,
+      .scope_id = symbol.scope,
+      .role = role,
+      .scalar_type = *type,
+      .alignment = *symbol.address_alignment,
+      .explicit_alignment = parameter.alignment.has_value(),
+      .array_extents = std::move(extents),
+      .byte_extent = bytes,
+      .pointer = properties.pointer,
+  };
+}
+
+/** Project one body-local .param declarator with owned multidimensional shape. */
+ResolvedParameterDeclaration resolve_parameter_declaration(
+    const syntax_ast::AstVariableDeclaration& declaration,
+    const syntax_ast::AstVariableDeclarator& declarator,
+    const binding::Symbol& symbol) {
+  const auto type =
+      declaration_semantics::parameterScalarType(declaration.type.text);
+  if (!type || !symbol.address_alignment)
+    throw ResolveException(
+        "Validated parameter has no scalar type or alignment.");
+  const uint32_t lanes = declaration.vector_type
+                             ? (declaration.vector_type->text == ".v2" ? 2 : 4)
+                             : 1;
+  std::vector<std::optional<uint64_t>> extents;
+  extents.reserve(declarator.array_dimensions.size());
+  for (const auto& dimension : declarator.array_dimensions)
+    extents.push_back(
+        dimension.size
+            ? declaration_semantics::constantArrayExtent(*dimension.size)
+            : std::nullopt);
+  const auto bytes = parameter_byte_extent(*type, lanes, extents);
+  return {
+      .symbol_id = symbol.id,
+      .scope_id = symbol.scope,
+      .role = ParameterDeclarationRole::BodyLocal,
+      .scalar_type = *type,
+      .alignment = *symbol.address_alignment,
+      .explicit_alignment = declaration.alignment.has_value(),
+      .vector_width = lanes,
+      .array_extents = std::move(extents),
+      .byte_extent = bytes,
+  };
+}
+
+void resolve_body(const std::vector<syntax_ast::AstFunctionBodyItem>& body,
+                  const ResolveContext& context,
+                  const binding::SymbolTable& symbols,
+                  const FunctionSignatureIndex& signatures,
+                  const CallArgumentPropertyIndex& call_argument_properties,
+                  ResolvedFunction& resolved_function,
+                  ModuleResolveDiagnostics& diagnostics) {
   for (const auto& body_item : body) {
-    if (const auto* instruction =
-            std::get_if<syntax_ast::AstInstruction>(&body_item)) {
+    if (const auto* declaration =
+            std::get_if<syntax_ast::AstVariableDeclaration>(&body_item);
+        declaration &&
+        declaration->state_space == syntax_ast::AstStateSpace::Parameter) {
+      for (const auto& declarator : declaration->declarators) {
+        const auto symbol = declared_symbol(symbols, context.scope, declarator);
+        if (!symbol)
+          throw ResolveException("Bound body parameter has no local symbol.");
+        resolved_function.parameter_declarations.push_back(
+            resolve_parameter_declaration(*declaration, declarator,
+                                          symbols.symbol(*symbol)));
+      }
+    } else if (const auto* instruction =
+                   std::get_if<syntax_ast::AstInstruction>(&body_item)) {
       auto resolved = resolveInstruction(*instruction, context);
       if (!resolved) {
         diagnostics.push_back(std::move(resolved.error()));
@@ -824,27 +924,31 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
         .is_prototype = function->is_prototype,
         .range = function->range,
     };
-    if (function->is_entry) {
-      resolved_function.entry_parameters.reserve(function->parameters.size());
-      for (const auto& parameter : function->parameters) {
-        const auto parameter_lookup =
-            binding_result.table.lookup(scope, parameter.name.syntax.text);
-        if (!parameter_lookup)
-          throw ResolveException("Bound entry parameter has no local symbol.");
-        const auto& parameter_symbol =
-            binding_result.table.symbol(parameter_lookup->symbol);
-        const auto& properties =
-            call_argument_properties.at(parameter_symbol.id.value);
-        resolved_function.entry_parameters.push_back({
-            .symbol_id = parameter_symbol.id,
-            .type = properties.type_spelling,
-            .alignment = parameter_symbol.address_alignment,
-            .pointer = properties.pointer,
-            .is_array = properties.is_array,
-            .array_extent = properties.array_size,
-        });
-      }
-    }
+    /** Append header declarations in return-list then input-list order. */
+    const auto append_parameters =
+        [&](const std::vector<syntax_ast::AstFunctionParameter>& parameters,
+            ParameterDeclarationRole role) {
+          for (const auto& parameter : parameters) {
+            if (parameter.state_space != syntax_ast::AstStateSpace::Parameter)
+              continue;
+            const auto found =
+                binding_result.table.lookup(scope, parameter.name.syntax.text);
+            if (!found)
+              throw ResolveException("Bound parameter has no local symbol.");
+            const auto& parameter_symbol =
+                binding_result.table.symbol(found->symbol);
+            resolved_function.parameter_declarations.push_back(
+                resolve_parameter_declaration(
+                    parameter, role, parameter_symbol,
+                    call_argument_properties.at(parameter_symbol.id.value)));
+          }
+        };
+    append_parameters(function->return_parameters,
+                      ParameterDeclarationRole::DeviceReturn);
+    append_parameters(function->parameters,
+                      function->is_entry
+                          ? ParameterDeclarationRole::EntryInput
+                          : ParameterDeclarationRole::DeviceInput);
     resolve_body(function->body, context, binding_result.table, signatures,
                  call_argument_properties, resolved_function, diagnostics);
     check_call_staging_body(*function, function->body, binding_result.table,

--- a/submod/resolved_ir/test/package_consumer/main.cpp
+++ b/submod/resolved_ir/test/package_consumer/main.cpp
@@ -1,11 +1,13 @@
 #include <ptx_frontend/resolved_ir/ptx_storage_declarations.hpp>
 
+#include <cstdint>
 #include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <ptx_frontend/binding/ptx_symbol_table.hpp>
 #include <ptx_frontend/cst/ptx_cst_parser.hpp>
@@ -19,13 +21,19 @@ int check_entry_parameter_metadata() {
   std::optional<ptx_frontend::resolved_ir::ResolvedModule> resolved_module;
   {
     const std::string fixture = R"ptx(
+.version 8.0
+.target sm_80
 .entry declared(.param .u16 scalar,
-                 .param .align 8 .b8 declaration_unsized[]) { }
+                 .param .align 8 .b8 declaration_bytes[4]) { }
 .entry defined(.param .u32 scalar, .param .align 16 .u64 aligned,
                .param .u64 .ptr generic_pointer,
                .param .u64 .ptr .global .align 32 global_pointer,
                .param .align 8 .b8 values[2 * 4]) { }
-.func device_only(.param .u32 ignored) { }
+.func (.param .align 8 .b16 result[2]) device_only(
+    .param .u32 ignored, .param .align 8 .b8 trailing_bytes[]) {
+  .param .u64 staging;
+  { .param .align 4 .u16 staging[2][3]; }
+}
 )ptx";
     ptx_frontend::PtxSyntaxParser parser(fixture);
     const auto ast = parser.parseModule();
@@ -41,44 +49,62 @@ int check_entry_parameter_metadata() {
   if (functions.size() != 3 || !functions[0].is_entry ||
       functions[0].is_prototype || !functions[1].is_entry ||
       functions[1].is_prototype || functions[2].is_entry ||
-      !functions[2].entry_parameters.empty()) {
+      functions[2].is_prototype) {
     return 33;
-  }
-
-  const auto& declared = functions[0].entry_parameters;
-  const auto& defined = functions[1].entry_parameters;
-  if (declared.size() != 2 || defined.size() != 5 ||
-      declared[0].type != ".u16" || declared[0].alignment != 2 ||
-      declared[0].is_array || declared[0].array_extent || declared[0].pointer ||
-      declared[1].type != ".b8" || declared[1].alignment != 8 ||
-      !declared[1].is_array || declared[1].array_extent ||
-      declared[1].pointer || defined[0].type != ".u32" ||
-      defined[0].alignment != 4 || defined[0].is_array ||
-      defined[0].array_extent || defined[0].pointer ||
-      defined[1].type != ".u64" || defined[1].alignment != 16 ||
-      defined[1].is_array || defined[1].array_extent || defined[1].pointer ||
-      defined[2].type != ".u64" || defined[2].alignment != 8 ||
-      !defined[2].pointer || defined[2].pointer->pointed_state_space ||
-      defined[2].pointer->pointed_alignment != 4 || defined[3].type != ".u64" ||
-      defined[3].alignment != 8 || !defined[3].pointer ||
-      defined[3].pointer->pointed_state_space !=
-          ptx_frontend::call_argument_compatibility::PointedStateSpace::
-              Global ||
-      defined[3].pointer->pointed_alignment != 32 || defined[4].type != ".b8" ||
-      defined[4].alignment != 8 || !defined[4].is_array ||
-      defined[4].array_extent != 8 || defined[4].pointer) {
-    return 34;
   }
 
   const auto declared_function_scope =
       resolved_module->symbols.symbol(functions[0].symbol_id).owned_scope;
   const auto defined_function_scope =
       resolved_module->symbols.symbol(functions[1].symbol_id).owned_scope;
+  using ptx_frontend::base::ScalarType;
+  using Role = ptx_frontend::resolved_ir::ParameterDeclarationRole;
+  const auto& declared = functions[0].parameter_declarations;
+  const auto& defined = functions[1].parameter_declarations;
+  if (declared.size() != 2 || defined.size() != 5 ||
+      declared[0].role != Role::EntryInput ||
+      declared[0].scalar_type != ScalarType::U16 ||
+      declared[0].alignment != 2 || declared[0].explicit_alignment ||
+      !declared[0].array_extents.empty() || declared[0].byte_extent != 2 ||
+      declared[0].pointer || declared[1].role != Role::EntryInput ||
+      declared[1].scalar_type != ScalarType::B8 ||
+      declared[1].alignment != 8 || !declared[1].explicit_alignment ||
+      declared[1].array_extents != std::vector<std::optional<uint64_t>>{4} ||
+      declared[1].byte_extent != 4 || declared[1].pointer ||
+      defined[0].role != Role::EntryInput ||
+      defined[0].scalar_type != ScalarType::U32 ||
+      defined[0].alignment != 4 || defined[0].explicit_alignment ||
+      !defined[0].array_extents.empty() || defined[0].byte_extent != 4 ||
+      defined[0].pointer || defined[1].role != Role::EntryInput ||
+      defined[1].scalar_type != ScalarType::U64 ||
+      defined[1].alignment != 16 || !defined[1].explicit_alignment ||
+      !defined[1].array_extents.empty() || defined[1].byte_extent != 8 ||
+      defined[1].pointer || defined[2].role != Role::EntryInput ||
+      defined[2].scalar_type != ScalarType::U64 ||
+      defined[2].alignment != 8 || !defined[2].pointer ||
+      defined[2].pointer->pointed_state_space ||
+      defined[2].pointer->pointed_alignment != 4 ||
+      !defined[2].array_extents.empty() || defined[2].byte_extent != 8 ||
+      defined[3].role != Role::EntryInput ||
+      defined[3].scalar_type != ScalarType::U64 ||
+      defined[3].alignment != 8 || !defined[3].pointer ||
+      defined[3].pointer->pointed_state_space !=
+          ptx_frontend::call_argument_compatibility::PointedStateSpace::
+              Global ||
+      defined[3].pointer->pointed_alignment != 32 ||
+      !defined[3].array_extents.empty() || defined[3].byte_extent != 8 ||
+      defined[4].role != Role::EntryInput ||
+      defined[4].scalar_type != ScalarType::B8 ||
+      defined[4].alignment != 8 || !defined[4].explicit_alignment ||
+      defined[4].array_extents != std::vector<std::optional<uint64_t>>{8} ||
+      defined[4].byte_extent != 8 || defined[4].pointer) {
+    return 34;
+  }
   if (!declared_function_scope || !defined_function_scope ||
       resolved_module->symbols.symbol(declared[0].symbol_id).name !=
           "scalar" ||
       resolved_module->symbols.symbol(declared[1].symbol_id).name !=
-          "declaration_unsized" ||
+          "declaration_bytes" ||
       resolved_module->symbols.symbol(defined[0].symbol_id).name != "scalar" ||
       resolved_module->symbols.symbol(defined[1].symbol_id).name != "aligned" ||
       resolved_module->symbols.symbol(defined[2].symbol_id).name !=
@@ -86,15 +112,114 @@ int check_entry_parameter_metadata() {
       resolved_module->symbols.symbol(defined[3].symbol_id).name !=
           "global_pointer" ||
       resolved_module->symbols.symbol(defined[4].symbol_id).name != "values" ||
-      resolved_module->symbols.symbol(declared[0].symbol_id).scope !=
-          *declared_function_scope ||
-      resolved_module->symbols.symbol(defined[0].symbol_id).scope !=
-          *defined_function_scope ||
-      resolved_module->symbols.symbol(defined[4].symbol_id).scope !=
-          *defined_function_scope ||
+      declared[0].scope_id !=
+          resolved_module->symbols.symbol(declared[0].symbol_id).scope ||
+      declared[1].scope_id !=
+          resolved_module->symbols.symbol(declared[1].symbol_id).scope ||
+      defined[0].scope_id !=
+          resolved_module->symbols.symbol(defined[0].symbol_id).scope ||
+      defined[1].scope_id !=
+          resolved_module->symbols.symbol(defined[1].symbol_id).scope ||
+      defined[2].scope_id !=
+          resolved_module->symbols.symbol(defined[2].symbol_id).scope ||
+      defined[3].scope_id !=
+          resolved_module->symbols.symbol(defined[3].symbol_id).scope ||
+      defined[4].scope_id !=
+          resolved_module->symbols.symbol(defined[4].symbol_id).scope ||
+      declared[0].scope_id != *declared_function_scope ||
+      defined[0].scope_id != *defined_function_scope ||
+      defined[4].scope_id != *defined_function_scope ||
       declared[0].symbol_id == defined[0].symbol_id) {
     return 35;
   }
+  const auto& device_parameters = functions[2].parameter_declarations;
+  if (device_parameters.size() != 5 ||
+      device_parameters[0].role != Role::DeviceReturn ||
+      device_parameters[0].scalar_type != ScalarType::B16 ||
+      device_parameters[0].alignment != 8 ||
+      !device_parameters[0].explicit_alignment ||
+      device_parameters[0].array_extents !=
+          std::vector<std::optional<uint64_t>>{2} ||
+      device_parameters[0].byte_extent != 4 ||
+      device_parameters[1].role != Role::DeviceInput ||
+      device_parameters[1].scalar_type != ScalarType::U32 ||
+      device_parameters[1].alignment != 4 ||
+      device_parameters[1].explicit_alignment ||
+      device_parameters[1].byte_extent != 4 ||
+      device_parameters[2].role != Role::DeviceInput ||
+      device_parameters[2].scalar_type != ScalarType::B8 ||
+      device_parameters[2].alignment != 8 ||
+      !device_parameters[2].explicit_alignment ||
+      device_parameters[2].array_extents !=
+          std::vector<std::optional<uint64_t>>{std::nullopt} ||
+      device_parameters[2].byte_extent ||
+      device_parameters[3].role != Role::BodyLocal ||
+      device_parameters[3].scalar_type != ScalarType::U64 ||
+      device_parameters[3].alignment != 8 ||
+      device_parameters[3].explicit_alignment ||
+      !device_parameters[3].array_extents.empty() ||
+      device_parameters[3].byte_extent != 8 || device_parameters[3].pointer ||
+      device_parameters[4].role != Role::BodyLocal ||
+      device_parameters[4].scalar_type != ScalarType::U16 ||
+      device_parameters[4].alignment != 4 ||
+      !device_parameters[4].explicit_alignment ||
+      device_parameters[4].array_extents !=
+          std::vector<std::optional<uint64_t>>{2, 3} ||
+      device_parameters[4].byte_extent != 12 ||
+      device_parameters[3].symbol_id == device_parameters[4].symbol_id ||
+      device_parameters[3].scope_id == device_parameters[4].scope_id ||
+      device_parameters[0].scope_id !=
+          resolved_module->symbols.symbol(device_parameters[0].symbol_id).scope ||
+      device_parameters[1].scope_id !=
+          resolved_module->symbols.symbol(device_parameters[1].symbol_id).scope ||
+      device_parameters[2].scope_id !=
+          resolved_module->symbols.symbol(device_parameters[2].symbol_id).scope ||
+      device_parameters[3].scope_id !=
+          resolved_module->symbols.symbol(device_parameters[3].symbol_id).scope ||
+      device_parameters[4].scope_id !=
+          resolved_module->symbols.symbol(device_parameters[4].symbol_id).scope) {
+    return 36;
+  }
+  return 0;
+}
+
+/** Confirm installed resolution rejects unsupported parameter boundary forms. */
+int check_parameter_declaration_boundaries() {
+  for (const std::string_view source : {
+           ".version 8.0\n.target sm_80\n"
+           ".entry kernel(.param .pred predicate) { }",
+           ".version 8.0\n.target sm_80\n"
+           ".entry kernel(.param .texref texture) { }",
+           ".version 8.0\n.target sm_80\n"
+           ".entry kernel(.param .unknown unknown) { }",
+           ".version 8.0\n.target sm_80\n"
+           ".entry kernel(.param .b8 bytes[]) { }",
+           ".version 8.0\n.target sm_80\n"
+           ".func device(.param .b8 bytes[], .param .u32 count) { }",
+           ".version 8.0\n.target sm_80\n"
+           ".func device(.param .u16 words[]) { }",
+           ".version 8.1\n.target sm_80\n"
+           ".entry kernel(.param .b8 bytes[32765]) { }",
+       }) {
+    ptx_frontend::PtxSyntaxParser parser(source);
+    const auto ast = parser.parseModule();
+    if (!ast || !ast.diagnostics.empty())
+      return 37;
+    if (ptx_frontend::resolved_ir::resolveModule(*ast))
+      return 38;
+  }
+  ptx_frontend::PtxSyntaxParser boundary_parser(
+      ".version 8.1\n.target sm_80\n"
+      ".entry kernel(.param .b8 bytes[32764]) { }");
+  const auto boundary_ast = boundary_parser.parseModule();
+  if (!boundary_ast || !boundary_ast.diagnostics.empty())
+    return 39;
+  const auto boundary = ptx_frontend::resolved_ir::resolveModule(*boundary_ast);
+  if (!boundary || boundary->functions[0].parameter_declarations[0].byte_extent != 32764 ||
+      ptx_frontend::declaration_semantics::parameterScalarType(".b128") !=
+          ptx_frontend::base::ScalarType::B128 ||
+      ptx_frontend::declaration_semantics::parameterScalarType(".pred"))
+    return 40;
   return 0;
 }
 
@@ -345,6 +470,10 @@ int main() {
   if (const int metadata_result = check_entry_parameter_metadata();
       metadata_result != 0) {
     return metadata_result;
+  }
+  if (const int boundary_result = check_parameter_declaration_boundaries();
+      boundary_result != 0) {
+    return boundary_result;
   }
   if (const int storage_result = check_storage_declaration_metadata();
       storage_result != 0) {

--- a/submod/resolved_ir/test/test_entry_parameter_metadata.cpp
+++ b/submod/resolved_ir/test/test_entry_parameter_metadata.cpp
@@ -1,8 +1,13 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
@@ -23,30 +28,35 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveSource(
   return resolveModule(*ast);
 }
 
-/** Entry metadata remains usable after the source and syntax tree are gone. */
-TEST(ResolvedEntryParameters, RetainsSingleParameterWithoutAst) {
+/** Entry declaration metadata remains usable after its source and AST are gone. */
+TEST(ResolvedParameterDeclarations, RetainsSingleEntryInputWithoutAst) {
   const auto resolved =
       resolveSource(".entry kernel(.param .u32 count) { ret; }");
 
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
-  const auto& parameters = resolved->functions.front().entry_parameters;
-  ASSERT_EQ(parameters.size(), 1u);
-  const auto& parameter = parameters.front();
-  EXPECT_EQ(parameter.type, ".u32");
-  EXPECT_EQ(parameter.alignment, 4u);
-  EXPECT_FALSE(parameter.pointer);
-  EXPECT_FALSE(parameter.is_array);
-  EXPECT_FALSE(parameter.array_extent);
-  const auto& symbol = resolved->symbols.symbol(parameter.symbol_id);
+  const auto& function = resolved->functions.front();
+  const auto& declarations = function.parameter_declarations;
+  ASSERT_EQ(declarations.size(), 1u);
+  const auto& declaration = declarations.front();
+  EXPECT_EQ(declaration.role, ParameterDeclarationRole::EntryInput);
+  EXPECT_EQ(declaration.scalar_type, base::ScalarType::U32);
+  EXPECT_EQ(declaration.alignment, 4u);
+  EXPECT_FALSE(declaration.explicit_alignment);
+  EXPECT_EQ(declaration.vector_width, 1u);
+  EXPECT_TRUE(declaration.array_extents.empty());
+  EXPECT_EQ(declaration.byte_extent, 4u);
+  EXPECT_FALSE(declaration.pointer);
+  const auto& symbol = resolved->symbols.symbol(declaration.symbol_id);
   EXPECT_EQ(symbol.name, "count");
   EXPECT_EQ(symbol.kind, binding::SymbolKind::InputParameter);
   EXPECT_EQ(symbol.state_space, syntax_ast::AstStateSpace::Parameter);
+  EXPECT_EQ(declaration.scope_id, symbol.scope);
   EXPECT_EQ(resolved->symbols.scope(symbol.scope).owner,
             resolved->functions.front().symbol_id);
 }
 
-/** Representative GEMM inputs retain declaration order and separate alignments. */
-TEST(ResolvedEntryParameters, RetainsGemmMetadataInSourceOrder) {
+/** Representative GEMM inputs retain typed source order and alignments. */
+TEST(ResolvedParameterDeclarations, RetainsGemmEntryInputsInSourceOrder) {
   const auto resolved = resolveSource(R"ptx(
 .version 8.0
 .target sm_80
@@ -65,34 +75,38 @@ TEST(ResolvedEntryParameters, RetainsGemmMetadataInSourceOrder) {
 
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
   const auto& function = resolved->functions.front();
-  const auto& parameters = function.entry_parameters;
+  const auto& declarations = function.parameter_declarations;
   constexpr std::array<std::string_view, 9> names{"A", "B",   "C",   "M",  "N",
                                                   "K", "lda", "ldb", "ldc"};
-  ASSERT_EQ(parameters.size(), names.size());
+  ASSERT_EQ(declarations.size(), names.size());
   for (size_t index = 0; index < names.size(); ++index) {
     SCOPED_TRACE(names[index]);
-    const auto& parameter = parameters[index];
-    const auto& symbol = resolved->symbols.symbol(parameter.symbol_id);
+    const auto& declaration = declarations[index];
+    const auto& symbol = resolved->symbols.symbol(declaration.symbol_id);
     EXPECT_EQ(symbol.name, names[index]);
     EXPECT_EQ(symbol.kind, binding::SymbolKind::InputParameter);
+    EXPECT_EQ(declaration.scope_id, symbol.scope);
     EXPECT_EQ(resolved->symbols.scope(symbol.scope).owner, function.symbol_id);
-    EXPECT_EQ(parameter.type, index < 3 ? ".u64" : ".u32");
-    EXPECT_EQ(parameter.alignment, index == 0 ? 16u : index < 3 ? 8u : 4u);
-    EXPECT_FALSE(parameter.is_array);
-    EXPECT_FALSE(parameter.array_extent);
+    EXPECT_EQ(declaration.role, ParameterDeclarationRole::EntryInput);
+    EXPECT_EQ(declaration.scalar_type,
+              index < 3 ? base::ScalarType::U64 : base::ScalarType::U32);
+    EXPECT_EQ(declaration.alignment, index == 0 ? 16u : index < 3 ? 8u : 4u);
+    EXPECT_EQ(declaration.byte_extent, index < 3 ? 8u : 4u);
+    EXPECT_TRUE(declaration.array_extents.empty());
     if (index < 3) {
-      ASSERT_TRUE(parameter.pointer);
-      EXPECT_EQ(parameter.pointer->pointed_state_space,
+      ASSERT_TRUE(declaration.pointer);
+      EXPECT_EQ(declaration.pointer->pointed_state_space,
                 call_argument_compatibility::PointedStateSpace::Global);
-      EXPECT_EQ(parameter.pointer->pointed_alignment, index == 0 ? 32u : 16u);
+      EXPECT_EQ(declaration.pointer->pointed_alignment,
+                index == 0 ? 32u : 16u);
     } else {
-      EXPECT_FALSE(parameter.pointer);
+      EXPECT_FALSE(declaration.pointer);
     }
   }
 }
 
 /** Pointer defaults and all concrete target spaces survive contract lowering. */
-TEST(ResolvedEntryParameters, RetainsPointerTargetSpacesAndDefaults) {
+TEST(ResolvedParameterDeclarations, RetainsEntryPointerTargetSpacesAndDefaults) {
   const auto resolved = resolveSource(R"ptx(
 .entry pointers(
     .param .u64 raw_address,
@@ -103,55 +117,302 @@ TEST(ResolvedEntryParameters, RetainsPointerTargetSpacesAndDefaults) {
 )ptx");
 
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
-  const auto& parameters = resolved->functions.front().entry_parameters;
-  ASSERT_EQ(parameters.size(), 5u);
-  EXPECT_FALSE(parameters[0].pointer);
-  ASSERT_TRUE(parameters[1].pointer);
-  EXPECT_FALSE(parameters[1].pointer->pointed_state_space);
-  EXPECT_EQ(parameters[1].pointer->pointed_alignment, 4u);
+  const auto& function = resolved->functions.front();
+  const auto& declarations = function.parameter_declarations;
+  ASSERT_EQ(declarations.size(), 5u);
+  EXPECT_EQ(declarations[0].role, ParameterDeclarationRole::EntryInput);
+  EXPECT_EQ(declarations[0].scalar_type, base::ScalarType::U64);
+  EXPECT_EQ(declarations[0].alignment, 8u);
+  EXPECT_TRUE(declarations[0].array_extents.empty());
+  EXPECT_EQ(declarations[0].byte_extent, 8u);
+  EXPECT_FALSE(declarations[0].pointer);
+  ASSERT_TRUE(declarations[1].pointer);
+  EXPECT_FALSE(declarations[1].pointer->pointed_state_space);
+  EXPECT_EQ(declarations[1].pointer->pointed_alignment, 4u);
   using call_argument_compatibility::PointedStateSpace;
   constexpr std::array spaces{PointedStateSpace::Local,
                               PointedStateSpace::Shared,
                               PointedStateSpace::Constant};
   for (size_t index = 0; index < spaces.size(); ++index) {
-    ASSERT_TRUE(parameters[index + 2].pointer);
-    EXPECT_EQ(parameters[index + 2].pointer->pointed_state_space,
+    ASSERT_TRUE(declarations[index + 2].pointer);
+    EXPECT_EQ(declarations[index + 2].pointer->pointed_state_space,
               spaces[index]);
-    EXPECT_EQ(parameters[index + 2].pointer->pointed_alignment, 4u << index);
-    EXPECT_EQ(parameters[index + 2].alignment, 8u);
+    EXPECT_EQ(declarations[index + 2].pointer->pointed_alignment,
+              4u << index);
+    EXPECT_EQ(declarations[index + 2].alignment, 8u);
+  }
+  for (size_t index = 1; index < declarations.size(); ++index) {
+    EXPECT_EQ(declarations[index].role, ParameterDeclarationRole::EntryInput);
+    EXPECT_EQ(declarations[index].scalar_type, base::ScalarType::U64);
+    EXPECT_EQ(declarations[index].alignment, 8u);
+    EXPECT_TRUE(declarations[index].array_extents.empty());
+    EXPECT_EQ(declarations[index].byte_extent, 8u);
+    ASSERT_TRUE(declarations[index].pointer);
   }
 }
 
-/** Array extents are element counts; unsized arrays remain distinguishable. */
-TEST(ResolvedEntryParameters, RetainsArrayShapeAndNormalizedExtent) {
+/** Array extents are element counts and byte extents use the element type size. */
+TEST(ResolvedParameterDeclarations, RetainsEntryArrayShapesAndByteExtents) {
   const auto resolved = resolveSource(R"ptx(
 .entry arrays(.param .align 16 .b8 bytes[2 * 8],
               .param .u32 words[2 + 1],
-              .param .align 8 .b8 unsized[],
+              .param .align 8 .b8 padded[4],
               .param .b8 scalar) { ret; }
 )ptx");
 
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
-  const auto& parameters = resolved->functions.front().entry_parameters;
-  ASSERT_EQ(parameters.size(), 4u);
-  EXPECT_EQ(parameters[0].type, ".b8");
-  EXPECT_EQ(parameters[0].alignment, 16u);
-  EXPECT_TRUE(parameters[0].is_array);
-  EXPECT_EQ(parameters[0].array_extent, 16u);
-  EXPECT_EQ(parameters[1].type, ".u32");
-  EXPECT_EQ(parameters[1].alignment, 4u);
-  EXPECT_TRUE(parameters[1].is_array);
-  EXPECT_EQ(parameters[1].array_extent, 3u);
-  EXPECT_EQ(parameters[2].alignment, 8u);
-  EXPECT_TRUE(parameters[2].is_array);
-  EXPECT_FALSE(parameters[2].array_extent);
-  EXPECT_EQ(parameters[3].alignment, 1u);
-  EXPECT_FALSE(parameters[3].is_array);
-  EXPECT_FALSE(parameters[3].array_extent);
+  const auto& declarations =
+      resolved->functions.front().parameter_declarations;
+  ASSERT_EQ(declarations.size(), 4u);
+  for (const auto& declaration : declarations)
+    EXPECT_EQ(declaration.role, ParameterDeclarationRole::EntryInput);
+  EXPECT_EQ(declarations[0].scalar_type, base::ScalarType::B8);
+  EXPECT_EQ(declarations[0].alignment, 16u);
+  EXPECT_EQ(declarations[0].array_extents,
+            (std::vector<std::optional<uint64_t>>{16u}));
+  EXPECT_EQ(declarations[0].byte_extent, 16u);
+  EXPECT_EQ(declarations[1].scalar_type, base::ScalarType::U32);
+  EXPECT_EQ(declarations[1].alignment, 4u);
+  EXPECT_EQ(declarations[1].array_extents,
+            (std::vector<std::optional<uint64_t>>{3u}));
+  EXPECT_EQ(declarations[1].byte_extent, 12u);
+  EXPECT_EQ(declarations[2].scalar_type, base::ScalarType::B8);
+  EXPECT_EQ(declarations[2].alignment, 8u);
+  EXPECT_EQ(declarations[2].array_extents,
+            (std::vector<std::optional<uint64_t>>{4u}));
+  EXPECT_EQ(declarations[2].byte_extent, 4u);
+  EXPECT_EQ(declarations[3].scalar_type, base::ScalarType::B8);
+  EXPECT_EQ(declarations[3].alignment, 1u);
+  EXPECT_TRUE(declarations[3].array_extents.empty());
+  EXPECT_EQ(declarations[3].byte_extent, 1u);
 }
 
-/** Repeated parameter names identify each entry's own inputs, not nested locals. */
-TEST(ResolvedEntryParameters, RetainsParametersPerEntryScope) {
+/** All parameter roles retain typed, scoped metadata after AST destruction. */
+TEST(ResolvedParameterDeclarations, RetainsAllRolesAndDeclarationProperties) {
+  const auto resolved = resolveSource(R"ptx(
+.version 8.0
+.target sm_80
+.entry kernel(.param .align 8 .u16 kernel_input[2]) {
+  .param .align 16 .b8 staging[4];
+  { .param .u32 staging; }
+  ret;
+}
+.func (.param .align 8 .b16 result[2]) device(
+    .param .u32 input, .param .align 8 .b8 bytes[]) {
+  .param .u64 staging;
+  { .param .align 4 .u16 staging[2][3]; }
+  ret;
+}
+)ptx");
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  using base::ScalarType;
+  using Role = ParameterDeclarationRole;
+  const auto& entry = resolved->functions[0];
+  const auto& device = resolved->functions[1];
+  ASSERT_EQ(entry.parameter_declarations.size(), 3u);
+  ASSERT_EQ(device.parameter_declarations.size(), 5u);
+
+  const auto& entry_input = entry.parameter_declarations[0];
+  EXPECT_EQ(entry_input.role, Role::EntryInput);
+  EXPECT_EQ(entry_input.scalar_type, ScalarType::U16);
+  EXPECT_EQ(entry_input.alignment, 8u);
+  EXPECT_TRUE(entry_input.explicit_alignment);
+  EXPECT_EQ(entry_input.vector_width, 1u);
+  EXPECT_EQ(entry_input.array_extents,
+            (std::vector<std::optional<uint64_t>>{2u}));
+  EXPECT_EQ(entry_input.byte_extent, 4u);
+  EXPECT_FALSE(entry_input.pointer);
+
+  const auto& entry_local = entry.parameter_declarations[1];
+  const auto& entry_nested = entry.parameter_declarations[2];
+  EXPECT_EQ(entry_local.role, Role::BodyLocal);
+  EXPECT_EQ(entry_local.scalar_type, ScalarType::B8);
+  EXPECT_EQ(entry_local.alignment, 16u);
+  EXPECT_TRUE(entry_local.explicit_alignment);
+  EXPECT_EQ(entry_local.array_extents,
+            (std::vector<std::optional<uint64_t>>{4u}));
+  EXPECT_EQ(entry_local.byte_extent, 4u);
+  EXPECT_EQ(entry_nested.role, Role::BodyLocal);
+  EXPECT_EQ(entry_nested.scalar_type, ScalarType::U32);
+  EXPECT_EQ(entry_nested.alignment, 4u);
+  EXPECT_FALSE(entry_nested.explicit_alignment);
+  EXPECT_TRUE(entry_nested.array_extents.empty());
+  EXPECT_EQ(entry_nested.byte_extent, 4u);
+  const auto entry_input_count = std::count_if(
+      entry.parameter_declarations.begin(), entry.parameter_declarations.end(),
+      [](const ResolvedParameterDeclaration& declaration) {
+        return declaration.role == Role::EntryInput;
+      });
+  EXPECT_EQ(entry_input_count, 1);
+
+  const auto& result = device.parameter_declarations[0];
+  const auto& input = device.parameter_declarations[1];
+  const auto& bytes = device.parameter_declarations[2];
+  const auto& staging = device.parameter_declarations[3];
+  const auto& nested_staging = device.parameter_declarations[4];
+  EXPECT_EQ(result.role, Role::DeviceReturn);
+  EXPECT_EQ(result.scalar_type, ScalarType::B16);
+  EXPECT_EQ(result.alignment, 8u);
+  EXPECT_TRUE(result.explicit_alignment);
+  EXPECT_EQ(result.array_extents,
+            (std::vector<std::optional<uint64_t>>{2u}));
+  EXPECT_EQ(result.byte_extent, 4u);
+  EXPECT_EQ(input.role, Role::DeviceInput);
+  EXPECT_EQ(input.scalar_type, ScalarType::U32);
+  EXPECT_EQ(input.alignment, 4u);
+  EXPECT_FALSE(input.explicit_alignment);
+  EXPECT_TRUE(input.array_extents.empty());
+  EXPECT_EQ(input.byte_extent, 4u);
+  EXPECT_EQ(bytes.role, Role::DeviceInput);
+  EXPECT_EQ(bytes.scalar_type, ScalarType::B8);
+  EXPECT_EQ(bytes.alignment, 8u);
+  EXPECT_TRUE(bytes.explicit_alignment);
+  EXPECT_EQ(bytes.array_extents,
+            (std::vector<std::optional<uint64_t>>{std::nullopt}));
+  EXPECT_FALSE(bytes.byte_extent);
+  EXPECT_EQ(staging.role, Role::BodyLocal);
+  EXPECT_EQ(staging.scalar_type, ScalarType::U64);
+  EXPECT_EQ(staging.alignment, 8u);
+  EXPECT_FALSE(staging.explicit_alignment);
+  EXPECT_TRUE(staging.array_extents.empty());
+  EXPECT_EQ(staging.byte_extent, 8u);
+  EXPECT_FALSE(staging.pointer);
+  EXPECT_EQ(nested_staging.role, Role::BodyLocal);
+  EXPECT_EQ(nested_staging.scalar_type, ScalarType::U16);
+  EXPECT_EQ(nested_staging.alignment, 4u);
+  EXPECT_TRUE(nested_staging.explicit_alignment);
+  EXPECT_EQ(nested_staging.array_extents,
+            (std::vector<std::optional<uint64_t>>{2u, 3u}));
+  EXPECT_EQ(nested_staging.byte_extent, 12u);
+
+  const auto& symbols = resolved->symbols;
+  const auto& outer_symbol = symbols.symbol(staging.symbol_id);
+  const auto& nested_symbol = symbols.symbol(nested_staging.symbol_id);
+  EXPECT_EQ(outer_symbol.name, "staging");
+  EXPECT_EQ(nested_symbol.name, "staging");
+  EXPECT_NE(staging.symbol_id, nested_staging.symbol_id);
+  EXPECT_NE(staging.scope_id, nested_staging.scope_id);
+  EXPECT_EQ(outer_symbol.scope, staging.scope_id);
+  EXPECT_EQ(nested_symbol.scope, nested_staging.scope_id);
+}
+
+/** Every supported parameter element has a validated enum and natural byte size. */
+TEST(ResolvedParameterDeclarations, ClassifiesEverySupportedElementType) {
+  const std::pair<std::string_view, base::ScalarType> types[] = {
+      {".s8", base::ScalarType::S8}, {".s16", base::ScalarType::S16},
+      {".s32", base::ScalarType::S32}, {".s64", base::ScalarType::S64},
+      {".u8", base::ScalarType::U8}, {".u16", base::ScalarType::U16},
+      {".u32", base::ScalarType::U32}, {".u64", base::ScalarType::U64},
+      {".b8", base::ScalarType::B8}, {".b16", base::ScalarType::B16},
+      {".b32", base::ScalarType::B32}, {".b64", base::ScalarType::B64},
+      {".b128", base::ScalarType::B128}, {".f16", base::ScalarType::F16},
+      {".f32", base::ScalarType::F32}, {".f64", base::ScalarType::F64},
+  };
+  for (const auto& [spelling, type] : types) {
+    SCOPED_TRACE(spelling);
+    const auto resolved = resolveSource(
+        ".version 9.3\n.target sm_80\n.entry k(.param " +
+        std::string(spelling) + " value) {}");
+    ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+    const auto& declaration = resolved->functions[0].parameter_declarations[0];
+    EXPECT_EQ(declaration.scalar_type, type);
+    EXPECT_EQ(declaration.alignment, base::scalar_size_of(type));
+    EXPECT_EQ(declaration.byte_extent, base::scalar_size_of(type));
+    EXPECT_FALSE(declaration.explicit_alignment);
+  }
+}
+
+/** Natural array alignment is consistent across declarations and all call paths. */
+TEST(ResolvedParameterDeclarations, UsesNaturalArrayAlignmentForCalls) {
+  const auto resolved = resolveSource(R"ptx(
+.version 8.0
+.target sm_80
+.func target(.param .u32 values[2]);
+.func target(.param .align 4 .u32 values[2]) { ret; }
+.func alternate(.param .align 4 .u32 values[2]);
+.entry caller() {
+  .reg .u64 address;
+  .param .u32 values[2];
+  prototype: .callprototype _ (.param .u32 input[2]);
+  targets: .calltargets target, alternate;
+  call target, (values);
+  call address, (values), prototype;
+  call address, (values), targets;
+  ret;
+}
+)ptx");
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& declaration = resolved->functions[0].parameter_declarations[0];
+  const auto& definition = resolved->functions[1].parameter_declarations[0];
+  EXPECT_EQ(declaration.alignment, definition.alignment);
+  EXPECT_FALSE(declaration.explicit_alignment);
+  EXPECT_TRUE(definition.explicit_alignment);
+}
+
+/** Entry pointer values can be loaded and passed through ordinary device formals. */
+TEST(ResolvedParameterDeclarations, PassesEntryPointerValuesToDeviceFunctions) {
+  const auto resolved = resolveSource(R"ptx(
+.version 8.0
+.target sm_80
+.func target(.param .u64 address);
+.entry caller(.param .u64 .ptr .global .align 16 pointer) {
+  .reg .u64 function_address, pointer_value;
+  prototype: .callprototype _ (.param .u64 address);
+  ld.param.u64 pointer_value, [pointer];
+  call target, (pointer_value);
+  call function_address, (pointer_value), prototype;
+  ret;
+}
+)ptx");
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  ASSERT_TRUE(resolved->functions[1].parameter_declarations[0].pointer);
+  EXPECT_EQ(resolved->functions[1].parameter_declarations[0]
+                .pointer->pointed_alignment, 16u);
+}
+
+/** Formal .param storage cannot substitute for a local call-argument object. */
+TEST(ResolvedParameterDeclarations, RejectsFormalParameterCallActuals) {
+  for (const std::string_view source : {
+           ".func target(.param .u64 value); "
+           ".entry caller(.param .u64 .ptr .global pointer) { "
+           "call target, (pointer); }",
+           ".func target(.param .u64 value); "
+           ".func caller(.param .u64 input) { call target, (input); }",
+           ".func (.param .u64 output) target(); "
+           ".func (.param .u64 output) caller() { call (output), target, (); }",
+           ".entry caller(.param .u64 input) { .reg .u64 address; "
+           "prototype: .callprototype _ (.param .u64 value); "
+           "call address, (input), prototype; }",
+       }) {
+    SCOPED_TRACE(source);
+    const auto resolved = resolveSource(std::string(source));
+    ASSERT_FALSE(resolved.has_value()) << source;
+    ASSERT_EQ(resolved.error().size(), 1u) << source;
+    EXPECT_NE(resolved.error()[0].message.find("Formal .param parameter"),
+              std::string::npos);
+  }
+}
+
+/** The final unsized device input may have no corresponding actual payload. */
+TEST(ResolvedParameterDeclarations, AllowsOmittedFinalUnsizedInput) {
+  const auto resolved = resolveSource(R"ptx(
+.version 8.0
+.target sm_80
+.func only_bytes(.param .b8 bytes[]);
+.func with_count(.param .u32 count, .param .b8 bytes[]);
+.entry caller() {
+  call only_bytes;
+  call only_bytes, ();
+  call with_count, (0);
+  ret;
+}
+)ptx");
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+}
+
+/** Repeated names retain distinct entry and device declaration identities. */
+TEST(ResolvedParameterDeclarations, RetainsParametersPerFunctionScope) {
   const auto resolved = resolveSource(R"ptx(
 .entry first(.param .u32 input) { ret; }
 .entry second(.param .u32 input) {
@@ -165,25 +426,52 @@ TEST(ResolvedEntryParameters, RetainsParametersPerEntryScope) {
 
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
   ASSERT_EQ(resolved->functions.size(), 5u);
-  ASSERT_EQ(resolved->functions[0].entry_parameters.size(), 1u);
-  ASSERT_EQ(resolved->functions[1].entry_parameters.size(), 1u);
+  const auto& first_declarations =
+      resolved->functions[0].parameter_declarations;
+  const auto& second_declarations =
+      resolved->functions[1].parameter_declarations;
+  const auto& empty_declarations =
+      resolved->functions[2].parameter_declarations;
+  const auto& helper_declaration =
+      resolved->functions[3].parameter_declarations;
+  const auto& helper_definition =
+      resolved->functions[4].parameter_declarations;
+  ASSERT_EQ(first_declarations.size(), 1u);
+  ASSERT_EQ(second_declarations.size(), 1u);
+  ASSERT_TRUE(empty_declarations.empty());
+  ASSERT_EQ(helper_declaration.size(), 2u);
+  ASSERT_EQ(helper_definition.size(), 2u);
+  EXPECT_EQ(first_declarations[0].role, ParameterDeclarationRole::EntryInput);
+  EXPECT_EQ(second_declarations[0].role,
+            ParameterDeclarationRole::EntryInput);
+  EXPECT_EQ(helper_declaration[0].role,
+            ParameterDeclarationRole::DeviceReturn);
+  EXPECT_EQ(helper_declaration[1].role,
+            ParameterDeclarationRole::DeviceInput);
+  EXPECT_EQ(helper_definition[0].role,
+            ParameterDeclarationRole::DeviceReturn);
+  EXPECT_EQ(helper_definition[1].role,
+            ParameterDeclarationRole::DeviceInput);
   const auto& first = resolved->symbols.symbol(
-      resolved->functions[0].entry_parameters[0].symbol_id);
+      first_declarations[0].symbol_id);
   const auto& second = resolved->symbols.symbol(
-      resolved->functions[1].entry_parameters[0].symbol_id);
+      second_declarations[0].symbol_id);
   EXPECT_NE(first.id, second.id);
   EXPECT_NE(first.scope, second.scope);
   EXPECT_EQ(first.name, "input");
   EXPECT_EQ(second.name, "input");
   EXPECT_EQ(first.kind, binding::SymbolKind::InputParameter);
   EXPECT_EQ(second.kind, binding::SymbolKind::InputParameter);
+  EXPECT_EQ(first_declarations[0].scope_id, first.scope);
+  EXPECT_EQ(second_declarations[0].scope_id, second.scope);
   EXPECT_EQ(resolved->symbols.scope(first.scope).owner,
             resolved->functions[0].symbol_id);
   EXPECT_EQ(resolved->symbols.scope(second.scope).owner,
             resolved->functions[1].symbol_id);
-  EXPECT_TRUE(resolved->functions[2].entry_parameters.empty());
-  EXPECT_TRUE(resolved->functions[3].entry_parameters.empty());
-  EXPECT_TRUE(resolved->functions[4].entry_parameters.empty());
+  EXPECT_NE(helper_declaration[0].symbol_id, helper_definition[0].symbol_id);
+  EXPECT_NE(helper_declaration[1].symbol_id, helper_definition[1].symbol_id);
+  EXPECT_NE(helper_declaration[0].scope_id, helper_definition[0].scope_id);
+  EXPECT_NE(helper_declaration[1].scope_id, helper_definition[1].scope_id);
 }
 
 }  // namespace

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -8855,10 +8855,8 @@ TEST(ResolvedModule, ReportsDirectCallAbiPropertyAndLiteralMismatches) {
   const auto resolved = resolveModule(parseModule(R"ptx(
 .func scalar(.param .u32 input);
 .func bytes(.param .align 16 .b8 input[8]);
-.func pointer(.param .u64 .ptr .global .align 16 input);
 .func literal(.param .u16 input);
-.entry caller(.param .u64 .ptr .shared .align 32 wrong_space,
-              .param .u64 .ptr .global .align 8 weak_alignment) {
+.entry caller() {
   .reg .v2 .u32 vector_argument;
   .reg .b8 register_byte;
   .param .align 16 .b8 wrong_size[4];
@@ -8867,17 +8865,14 @@ TEST(ResolvedModule, ReportsDirectCallAbiPropertyAndLiteralMismatches) {
   call bytes, (register_byte);
   call bytes, (wrong_size);
   call bytes, (weak_array_alignment);
-  call pointer, (wrong_space);
-  call pointer, (weak_alignment);
   call literal, (1.5);
   call literal, (65536);
   call bytes, (1);
-  call pointer, (1);
 }
 )ptx"));
 
   ASSERT_FALSE(resolved.has_value());
-  ASSERT_EQ(resolved.error().size(), 10u);
+  ASSERT_EQ(resolved.error().size(), 7u);
   EXPECT_EQ(resolved.error()[0].message,
             "Direct call input argument 1 for 'scalar' has type or vector "
             "shape mismatch.");
@@ -8891,34 +8886,25 @@ TEST(ResolvedModule, ReportsDirectCallAbiPropertyAndLiteralMismatches) {
             "Direct call input argument 1 for 'bytes' has array alignment "
             "mismatch.");
   EXPECT_EQ(resolved.error()[4].message,
-            "Direct call input argument 1 for 'pointer' has pointed "
-            "state-space mismatch.");
-  EXPECT_EQ(resolved.error()[5].message,
-            "Direct call input argument 1 for 'pointer' has pointed alignment "
-            "mismatch.");
-  EXPECT_EQ(resolved.error()[6].message,
             "Decimal floating literal '1.5' is incompatible with scalar type "
             "'U16'.");
-  EXPECT_EQ(resolved.error()[7].message,
+  EXPECT_EQ(resolved.error()[5].message,
             "Integer literal '65536' is out of range for scalar type 'U16'.");
-  EXPECT_EQ(resolved.error()[8].message,
+  EXPECT_EQ(resolved.error()[6].message,
             "Direct call input argument 1 for 'bytes' has call argument "
             "state-space mismatch.");
-  EXPECT_EQ(resolved.error()[9].message,
-            "Direct call input argument 1 for 'pointer' has pointer "
-            "qualification mismatch.");
 }
 
 TEST(ResolvedModule, AcceptsDirectCallsAcrossFunctionLifecycles) {
   const auto resolved = resolveModule(parseModule(R"ptx(
+.version 8.0
+.target sm_80
 .func prototype_only(.reg .u32 input);
 .extern .func external(.reg .u32 input);
 .func defined_before(.reg .u32 input) { }
 .func bytes(.param .align 8 .b8 input[]);
-.func generic_pointer(.param .u64 .ptr .align 8 input);
-.func global_pointer(.param .u64 .ptr .global .align 16 input);
 .func immediate(.reg .u8 high, .reg .s8 low, .reg .f32 float);
-.entry caller(.param .u64 .ptr .global .align 16 global_actual) {
+.entry caller() {
   .reg .u32 %r;
   .param .align 8 .b8 blob[8];
   call prototype_only, (%r);
@@ -8927,8 +8913,6 @@ TEST(ResolvedModule, AcceptsDirectCallsAcrossFunctionLifecycles) {
   call defined_after, (%r);
   call renamed, (%r);
   call bytes, (blob);
-  call generic_pointer, (global_actual);
-  call global_pointer, (global_actual);
   call immediate, (255, -128, 0f3f800000);
 }
 .func defined_after(.reg .u32 input) { }
@@ -9262,24 +9246,22 @@ TEST(ResolvedModule, ReportsIndirectCallAbiMismatches) {
   const auto resolved = resolveModule(parseModule(R"ptx(
 .func target(.reg .u32 input);
 .func another_target(.reg .u32 value);
-.entry caller(.param .u64 .ptr .shared .align 32 wrong_space) {
+.entry caller() {
   .reg .u64 %fptr, %wide;
   .reg .b8 %byte;
 arity: .callprototype (.reg .u32 result) _;
 targets: .calltargets target, another_target;
 bytes: .callprototype _ (.param .align 16 .b8 expected[8]);
-pointer: .callprototype _ (.param .u64 .ptr .global .align 16 expected);
 literal: .callprototype _ (.param .u16 expected);
   call %fptr, arity;
   call %fptr, (%wide), targets;
   call %fptr, (%byte), bytes;
-  call %fptr, (wrong_space), pointer;
   call %fptr, (65536), literal;
 }
 )ptx"));
 
   ASSERT_FALSE(resolved.has_value());
-  ASSERT_EQ(resolved.error().size(), 5u);
+  ASSERT_EQ(resolved.error().size(), 4u);
   EXPECT_EQ(resolved.error()[0].message,
             "Indirect call via metadata 'arity' has 0 return arguments but "
             "callee requires 1.");
@@ -9290,9 +9272,6 @@ literal: .callprototype _ (.param .u16 expected);
             "Indirect call via metadata 'bytes' input argument 1 has call "
             "argument state-space mismatch.");
   EXPECT_EQ(resolved.error()[3].message,
-            "Indirect call via metadata 'pointer' input argument 1 has "
-            "pointed state-space mismatch.");
-  EXPECT_EQ(resolved.error()[4].message,
             "Integer literal '65536' is out of range for scalar type 'U16'.");
 }
 

--- a/submod/semantic/include/ptx_declaration_semantics.hpp
+++ b/submod/semantic/include/ptx_declaration_semantics.hpp
@@ -3,8 +3,10 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
+#include <ptx_frontend/base/base.hpp>
 #include <ptx_frontend/binding/ptx_symbol_table.hpp>
 #include <ptx_frontend/common/source_loc.hpp>
 #include <ptx_frontend/syntax/ptx_syntax_ast.hpp>
@@ -14,10 +16,12 @@ namespace ptx_frontend::declaration_semantics {
 /** ABI-relevant, source-location-independent function parameter data. */
 struct FunctionParameterContract {
   syntax_ast::AstStateSpace state_space{};
+  /** Effective byte alignment as a decimal key, or retained invalid source text. */
   std::optional<std::string> alignment;
   std::string type;
   bool is_pointer{};
   std::optional<std::string> pointer_space;
+  /** Effective pointee alignment (default four bytes); absent for non-pointers. */
   std::optional<std::string> pointer_alignment;
   bool is_array{};
   /** A normalized constant extent, or a structural key for an invalid one. */
@@ -63,6 +67,15 @@ struct IntegerConstantValue {
 [[nodiscard]] std::optional<IntegerConstantValue> constantIntegerValue(
     const syntax_ast::AstConstantExpression& expression);
 
+/**
+ * Classify a supported non-predicate fundamental scalar parameter spelling.
+ *
+ * Opaque parameter identities and unsupported or instruction-only spellings
+ * deliberately have no scalar classification.
+ */
+[[nodiscard]] std::optional<base::ScalarType> parameterScalarType(
+    std::string_view spelling) noexcept;
+
 enum class DeclarationDiagnosticKind : uint8_t {
   InvalidArrayDimension,
   UnsizedArrayDimension,
@@ -88,6 +101,7 @@ enum class DeclarationDiagnosticKind : uint8_t {
   StorageExtentOverflow,
   UnsupportedStorageDeclaration,
   UnsupportedStorageInitializer,
+  UnsupportedParameterDeclaration,
 };
 
 struct DeclarationDiagnostic {

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -1,5 +1,7 @@
 #include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
 
+#include <ptx_frontend/base/ptx_target.hpp>
+
 #include <algorithm>
 #include <array>
 #include <bit>
@@ -534,19 +536,39 @@ bool compactTargetsOverlap(std::string_view existing_prefix,
          (existing_in_candidate && *existing_in_candidate < candidate_count);
 }
 
+/** Normalize known effective alignment while retaining invalid source for diagnostics. */
+std::optional<std::string> parameterAlignmentContract(
+    const std::optional<syntax_ast::AstSyntax>& explicit_alignment,
+    std::optional<uint64_t> default_alignment) {
+  if (explicit_alignment) {
+    const auto value = positiveCount(explicit_alignment->text);
+    return value ? std::to_string(*value) : explicit_alignment->text;
+  }
+  return default_alignment ? std::optional{std::to_string(*default_alignment)}
+                           : std::nullopt;
+}
+
 FunctionParameterContract parameterContract(
     const syntax_ast::AstFunctionParameter& parameter) {
   const auto syntax_text =
       [](const auto& syntax) -> std::optional<std::string> {
     return syntax ? std::optional<std::string>{syntax->text} : std::nullopt;
   };
+  const auto scalar = parameterScalarType(parameter.type.text);
+  const std::optional<uint64_t> natural_alignment =
+      scalar ? std::optional<uint64_t>{base::scalar_size_of(*scalar)}
+      : parameter.type.text == ".pred" ? std::optional<uint64_t>{1}
+      : parameter.type.text == ".f16x2" ? std::optional<uint64_t>{4}
+                                        : std::nullopt;
   return {
       .state_space = parameter.state_space,
-      .alignment = syntax_text(parameter.alignment),
+      .alignment = parameterAlignmentContract(parameter.alignment, natural_alignment),
       .type = parameter.type.text,
       .is_pointer = parameter.is_pointer,
       .pointer_space = syntax_text(parameter.pointer_space),
-      .pointer_alignment = syntax_text(parameter.pointer_alignment),
+      .pointer_alignment = parameterAlignmentContract(
+          parameter.pointer_alignment,
+          parameter.is_pointer ? std::optional<uint64_t>{4} : std::nullopt),
       .is_array = parameter.is_array,
       .array_extent = parameter.array_size
                           ? std::optional{dimensionKey(*parameter.array_size)}
@@ -572,6 +594,11 @@ std::string variableSignature(
 
 bool isUnsupportedInitializerType(std::string_view type) {
   return type == ".f16" || type == ".f16x2" || type == ".pred";
+}
+
+/** Return whether a spelling denotes an opaque parameter identity. */
+bool isOpaqueParameterType(std::string_view type) {
+  return type == ".texref" || type == ".samplerref" || type == ".surfref";
 }
 
 bool initializerTypeAccepts(std::string_view type,
@@ -605,8 +632,10 @@ class Checker {
   explicit Checker(const binding::SymbolTable& symbols) : symbols_(symbols) {}
 
   std::vector<DeclarationDiagnostic> run(const syntax_ast::AstModule& module) {
+    const auto module_version = modulePtxVersion(module);
+    const auto module_sm = moduleSmVersion(module);
     checkRedeclarations(module);
-    checkControlFlowMetadata(module);
+    checkControlFlowMetadata(module, module_version, module_sm);
     checkKernelResources(module);
     checkM11Directives(module);
     for (const auto& item : module.items) {
@@ -615,15 +644,16 @@ class Checker {
         checkAlignment(declaration->alignment);
         checkVariableDeclaration(*declaration);
         if (declaration->state_space == syntax_ast::AstStateSpace::Parameter) {
-          diagnose(DeclarationDiagnosticKind::ModuleScopeParameter,
-                   declaration->range,
-                   "A .param variable declaration must be local to a function.");
+          diagnose(
+              DeclarationDiagnosticKind::ModuleScopeParameter,
+              declaration->range,
+              "A .param variable declaration must be local to a function.");
         }
       } else if (const auto* function =
                      std::get_if<syntax_ast::AstFunction>(&item)) {
-        checkFunctionAlignments(*function);
-        checkFunctionArrays(*function);
-        checkFunctionBodyDeclarations(function->body);
+        checkFunctionParameters(*function, module_version, module_sm);
+        checkFunctionBodyDeclarations(function->body, module_version,
+                                      module_sm);
       }
     }
     return std::move(diagnostics_);
@@ -651,6 +681,15 @@ class Checker {
     uint16_t major{};
     uint16_t minor{};
     constexpr auto operator<=>(const PtxVersion&) const = default;
+  };
+
+  /** Lexical role that determines the declaration rules for a parameter. */
+  enum class ParameterContext : uint8_t {
+    EntryInput,
+    DeviceInput,
+    DeviceReturn,
+    CallPrototypeInput,
+    CallPrototypeReturn,
   };
 
   const binding::SymbolTable& symbols_;
@@ -934,9 +973,23 @@ class Checker {
     return std::nullopt;
   }
 
-  void requirePtx(std::optional<PtxVersion> module_version,
-                  PtxVersion required, SourceRange range,
-                  std::string_view spelling) {
+  /** Return the architecture number from the first recognized module target. */
+  std::optional<uint32_t> moduleSmVersion(
+      const syntax_ast::AstModule& module) const {
+    for (const auto& item : module.items) {
+      const auto* target = std::get_if<syntax_ast::AstTargetDirective>(&item);
+      if (target == nullptr || target->targets.empty())
+        continue;
+      const auto identity =
+          base::parse_target_identity(target->targets.front().text);
+      if (identity)
+        return identity->architecture.number;
+    }
+    return std::nullopt;
+  }
+
+  void requirePtx(std::optional<PtxVersion> module_version, PtxVersion required,
+                  SourceRange range, std::string_view spelling) {
     if (!module_version || *module_version >= required)
       return;
     diagnose(DeclarationDiagnosticKind::UnsupportedDirectivePtxVersion, range,
@@ -1299,33 +1352,296 @@ class Checker {
     }
   }
 
-  void checkCallPrototype(const syntax_ast::AstCallPrototype& prototype) {
+  /** Report a parameter construct whose PTX or SM availability is too old. */
+  void requireParameterAvailability(std::optional<PtxVersion> module_version,
+                                    std::optional<uint32_t> module_sm,
+                                    PtxVersion required_version,
+                                    uint32_t required_sm, SourceRange range,
+                                    std::string_view spelling) {
+    if (module_version && *module_version < required_version) {
+      diagnose(
+          DeclarationDiagnosticKind::UnsupportedParameterDeclaration, range,
+          fmt::format("{} requires PTX ISA >= {}.{}, but module PTX ISA "
+                      "is {}.{}.",
+                      spelling, required_version.major, required_version.minor,
+                      module_version->major, module_version->minor));
+    }
+    if (module_sm && *module_sm < required_sm) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               range,
+               fmt::format("{} requires sm_{} or later, but module "
+                           "target is sm_{}.",
+                           spelling, required_sm, *module_sm));
+    }
+  }
+
+  /** Return whether a header role permits a register formal parameter. */
+  static bool permitsRegisterParameter(ParameterContext context) {
+    return context == ParameterContext::DeviceInput ||
+           context == ParameterContext::DeviceReturn ||
+           context == ParameterContext::CallPrototypeInput ||
+           context == ParameterContext::CallPrototypeReturn;
+  }
+
+  /** Return whether an input role can carry the documented unsized byte array. */
+  static bool permitsUnsizedInput(ParameterContext context) {
+    return context == ParameterContext::DeviceInput ||
+           context == ParameterContext::CallPrototypeInput;
+  }
+
+  /** Return a static scalar or one-dimensional array byte count when known. */
+  static std::optional<uint64_t> parameterByteExtent(
+      base::ScalarType type, bool is_array,
+      const std::optional<AstConstantExpression>& array_size) {
+    const uint64_t scalar_bytes = base::scalar_size_of(type);
+    if (scalar_bytes == 0 || (is_array && !array_size))
+      return std::nullopt;
+    if (!is_array)
+      return scalar_bytes;
+    const auto extent = constantArrayExtent(*array_size);
+    if (!extent || *extent == 0 ||
+        scalar_bytes > std::numeric_limits<uint64_t>::max() / *extent) {
+      return std::nullopt;
+    }
+    return scalar_bytes * *extent;
+  }
+
+  /** Validate type, state space, shape, availability, and pointer attributes. */
+  void checkHeaderParameter(const syntax_ast::AstFunctionParameter& parameter,
+                            ParameterContext context, bool is_final,
+                            std::optional<PtxVersion> module_version,
+                            std::optional<uint32_t> module_sm) {
+    checkAlignment(parameter.alignment);
+    checkAlignment(parameter.pointer_alignment);
+    if (parameter.array_size)
+      checkDimension(*parameter.array_size);
+
+    const bool is_parameter =
+        parameter.state_space == syntax_ast::AstStateSpace::Parameter;
+    const bool is_register =
+        parameter.state_space == syntax_ast::AstStateSpace::Register;
+    if ((!is_parameter &&
+         !(is_register && permitsRegisterParameter(context))) ||
+        (context == ParameterContext::EntryInput && !is_parameter)) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               parameter.range,
+               "This parameter role does not permit the declared state space.");
+      return;
+    }
+
+    if (isOpaqueParameterType(parameter.type.text)) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               parameter.type.range,
+               "Opaque .texref/.samplerref/.surfref parameters are not "
+               "modeled by this frontend.");
+      return;
+    }
+    const bool predicate = parameter.type.text == ".pred";
+    const bool packed_half_register =
+        parameter.type.text == ".f16x2" && is_register;
+    const auto scalar = parameterScalarType(parameter.type.text);
+    if (!scalar && !(predicate && is_register) && !packed_half_register) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               parameter.type.range,
+               predicate ? ".pred parameters must use .reg state space."
+               : parameter.type.text == ".f16x2"
+                   ? "Fundamental .f16x2 parameter storage is not "
+                     "modeled by this frontend."
+                   : fmt::format("Parameter type '{}' is not a supported "
+                                 "fundamental scalar type.",
+                                 parameter.type.text));
+      return;
+    }
+
+    if (parameter.is_array && !is_parameter) {
+      const bool is_call_prototype =
+          context == ParameterContext::CallPrototypeInput ||
+          context == ParameterContext::CallPrototypeReturn;
+      diagnose(is_call_prototype ? DeclarationDiagnosticKind::InvalidCallPrototype
+                                 : DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               parameter.range,
+               is_call_prototype
+                   ? "A .callprototype array parameter must use .param state space."
+                   : "Array parameters must use .param state space.");
+      return;
+    }
+    if (parameter.is_array && !parameter.array_size) {
+      if (!permitsUnsizedInput(context) || !is_final || !scalar ||
+          *scalar != base::ScalarType::B8) {
+        diagnose(DeclarationDiagnosticKind::UnsizedArrayDimension,
+                 parameter.range,
+                 "Only a final device or call-prototype .param .b8 input may "
+                 "be unsized.");
+        return;
+      }
+      requireParameterAvailability(module_version, module_sm, {6, 0}, 30,
+                                   parameter.range, "Unsized .param input");
+    }
+    if (is_parameter && (context == ParameterContext::DeviceInput ||
+                         context == ParameterContext::DeviceReturn)) {
+      requireParameterAvailability(module_version, module_sm, {2, 0}, 20,
+                                   parameter.range, "Device .param formal");
+    }
+    if (parameter.is_pointer) {
+      if (context != ParameterContext::EntryInput || !is_parameter || !scalar ||
+          parameter.is_array ||
+          (*scalar != base::ScalarType::U32 &&
+           *scalar != base::ScalarType::U64)) {
+        diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+                 parameter.range,
+                 ".ptr is supported only on scalar .entry .param .u32/.u64 "
+                 "inputs.");
+      } else {
+        requireParameterAvailability(module_version, module_sm, {2, 2}, 0,
+                                     parameter.range, ".ptr entry parameter");
+      }
+    }
+    if (scalar && parameter.array_size) {
+      const auto extent = constantArrayExtent(*parameter.array_size);
+      if (extent && *extent != 0 &&
+          !parameterByteExtent(*scalar, true, parameter.array_size)) {
+        diagnose(DeclarationDiagnosticKind::StorageExtentOverflow,
+                 parameter.array_size->range,
+                 "Parameter byte extent overflows uint64_t.");
+      }
+    }
+  }
+
+  /** Validate the role-specific formal parameters of one function header. */
+  void checkFunctionParameters(const syntax_ast::AstFunction& function,
+                               std::optional<PtxVersion> module_version,
+                               std::optional<uint32_t> module_sm) {
+    if (function.is_entry) {
+      if (!function.return_parameters.empty()) {
+        diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+                 function.return_parameters.front().range,
+                 ".entry declarations cannot have return parameters.");
+      }
+      for (size_t index = 0; index < function.parameters.size(); ++index) {
+        checkHeaderParameter(
+            function.parameters[index], ParameterContext::EntryInput,
+            index + 1 == function.parameters.size(), module_version, module_sm);
+      }
+      if (!function.parameters.empty()) {
+        requireParameterAvailability(module_version, module_sm, {1, 4}, 0,
+                                     function.parameters.front().range,
+                                     ".entry parameter list");
+        checkEntryParameterSize(function.parameters, module_version);
+      }
+      return;
+    }
+    if (function.return_parameters.size() > 1 && module_version && module_sm &&
+        *module_version >= PtxVersion{2, 0} && *module_sm >= 20) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               function.return_parameters[1].range,
+               "Modern device-function declarations support at most one return "
+               "parameter.",
+               function.return_parameters.front().range);
+    }
+    for (size_t index = 0; index < function.return_parameters.size(); ++index) {
+      checkHeaderParameter(function.return_parameters[index],
+                           ParameterContext::DeviceReturn,
+                           index + 1 == function.return_parameters.size(),
+                           module_version, module_sm);
+    }
+    for (size_t index = 0; index < function.parameters.size(); ++index) {
+      checkHeaderParameter(
+          function.parameters[index], ParameterContext::DeviceInput,
+          index + 1 == function.parameters.size(), module_version, module_sm);
+    }
+  }
+
+  /** Check the version-dependent static byte limit for one entry header. */
+  void checkEntryParameterSize(
+      const std::vector<syntax_ast::AstFunctionParameter>& parameters,
+      std::optional<PtxVersion> module_version) {
+    if (!module_version)
+      return;
+    const uint64_t limit = *module_version < PtxVersion{1, 5}   ? 256
+                           : *module_version < PtxVersion{8, 1} ? 4352
+                                                                : 32764;
+    uint64_t total = 0;
+    for (const auto& parameter : parameters) {
+      if (parameter.state_space != syntax_ast::AstStateSpace::Parameter)
+        return;
+      const auto scalar = parameterScalarType(parameter.type.text);
+      const auto bytes = scalar
+                             ? parameterByteExtent(*scalar, parameter.is_array,
+                                                   parameter.array_size)
+                             : std::nullopt;
+      if (!bytes)
+        return;
+      if (parameter.alignment && !isValidAlignment(parameter.alignment->text))
+        return;
+      const uint64_t alignment =
+          parameter.alignment
+              ? positiveCount(parameter.alignment->text).value_or(0)
+              : base::scalar_size_of(*scalar);
+      if (alignment == 0)
+        return;
+      if (total > std::numeric_limits<uint64_t>::max() - (alignment - 1)) {
+        diagnose(DeclarationDiagnosticKind::StorageExtentOverflow,
+                 parameter.range,
+                 "Aligned entry parameter byte size overflows uint64_t.");
+        return;
+      }
+      total = ((total + alignment - 1) / alignment) * alignment;
+      if (total > std::numeric_limits<uint64_t>::max() - *bytes) {
+        diagnose(DeclarationDiagnosticKind::StorageExtentOverflow,
+                 parameter.range,
+                 "Aligned entry parameter byte size overflows uint64_t.");
+        return;
+      }
+      total += *bytes;
+    }
+    if (total > limit) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               parameters.front().range,
+               fmt::format("Static entry parameter bytes ({}) exceed the PTX "
+                           "ISA {}.{} limit of {} bytes.",
+                           total, module_version->major, module_version->minor,
+                           limit));
+    }
+  }
+
+  /** Validate PTX-versioned local call-prototype parameter declarations. */
+  void checkCallPrototype(const syntax_ast::AstCallPrototype& prototype,
+                          std::optional<PtxVersion> module_version,
+                          std::optional<uint32_t> module_sm) {
+    requireParameterAvailability(module_version, module_sm, {2, 1}, 20,
+                                 prototype.range, ".callprototype");
     if (prototype.noreturn_directive && !prototype.return_parameters.empty()) {
       diagnose(DeclarationDiagnosticKind::InvalidCallPrototype,
                prototype.noreturn_directive->range,
                "A .callprototype with return parameters cannot specify "
-               ".noreturn.", prototype.return_parameters.front().range);
+               ".noreturn.",
+               prototype.return_parameters.front().range);
     }
-    const auto check_parameters = [this](const auto& parameters) {
-      for (const auto& parameter : parameters) {
-        checkAlignment(parameter.alignment);
-        checkAlignment(parameter.pointer_alignment);
-        if (parameter.array_size)
-          checkDimension(*parameter.array_size);
-        if (parameter.is_array &&
-            parameter.state_space != syntax_ast::AstStateSpace::Parameter) {
-          diagnose(DeclarationDiagnosticKind::InvalidCallPrototype,
-                   parameter.range,
-                   "A .callprototype array parameter must use .param state "
-                   "space.");
-        }
-      }
-    };
-    check_parameters(prototype.return_parameters);
-    check_parameters(prototype.parameters);
+    if (prototype.return_parameters.size() > 1 && module_version && module_sm &&
+        *module_version >= PtxVersion{2, 0} && *module_sm >= 20) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               prototype.return_parameters[1].range,
+               "Modern call-prototype declarations support at most one return "
+               "parameter.",
+               prototype.return_parameters.front().range);
+    }
+    for (size_t index = 0; index < prototype.return_parameters.size();
+         ++index) {
+      checkHeaderParameter(prototype.return_parameters[index],
+                           ParameterContext::CallPrototypeReturn,
+                           index + 1 == prototype.return_parameters.size(),
+                           module_version, module_sm);
+    }
+    for (size_t index = 0; index < prototype.parameters.size(); ++index) {
+      checkHeaderParameter(
+          prototype.parameters[index], ParameterContext::CallPrototypeInput,
+          index + 1 == prototype.parameters.size(), module_version, module_sm);
+    }
   }
 
-  void checkControlFlowMetadata(const syntax_ast::AstModule& module) {
+  void checkControlFlowMetadata(const syntax_ast::AstModule& module,
+                                std::optional<PtxVersion> module_version,
+                                std::optional<uint32_t> module_sm) {
     std::unordered_map<std::string, SeenFunction> seen_functions;
     std::vector<binding::ScopeId> function_scopes;
     for (const auto& scope : symbols_.scopes()) {
@@ -1344,18 +1660,21 @@ class Checker {
                              : std::nullopt;
       ++function_index;
       if (scope)
-        checkControlFlowMetadataBody(function->body, *scope, seen_functions);
+        checkControlFlowMetadataBody(function->body, *scope, seen_functions,
+                                     module_version, module_sm);
     }
   }
 
   void checkControlFlowMetadataBody(
       const std::vector<syntax_ast::AstFunctionBodyItem>& body,
       binding::ScopeId function_scope,
-      const std::unordered_map<std::string, SeenFunction>& seen_functions) {
+      const std::unordered_map<std::string, SeenFunction>& seen_functions,
+      std::optional<PtxVersion> module_version,
+      std::optional<uint32_t> module_sm) {
     for (const auto& body_item : body) {
       if (const auto* prototype =
               std::get_if<syntax_ast::AstCallPrototype>(&body_item)) {
-        checkCallPrototype(*prototype);
+        checkCallPrototype(*prototype, module_version, module_sm);
       } else if (const auto* targets =
                      std::get_if<syntax_ast::AstCallTargets>(&body_item)) {
         checkCallTargets(*targets, seen_functions);
@@ -1367,23 +1686,103 @@ class Checker {
                          &body_item);
                  block != nullptr && *block) {
         checkControlFlowMetadataBody((*block)->body, function_scope,
-                                     seen_functions);
+                                     seen_functions, module_version, module_sm);
       }
     }
   }
 
   void checkFunctionBodyDeclarations(
-      const std::vector<syntax_ast::AstFunctionBodyItem>& body) {
+      const std::vector<syntax_ast::AstFunctionBodyItem>& body,
+      std::optional<PtxVersion> module_version,
+      std::optional<uint32_t> module_sm) {
     for (const auto& body_item : body) {
       if (const auto* declaration =
               std::get_if<syntax_ast::AstVariableDeclaration>(&body_item)) {
         checkAlignment(declaration->alignment);
         checkVariableDeclaration(*declaration);
+        if (declaration->state_space == syntax_ast::AstStateSpace::Parameter) {
+          checkBodyParameterDeclaration(*declaration, module_version,
+                                        module_sm);
+        }
       } else if (const auto* block =
                      std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(
                          &body_item);
                  block != nullptr && *block) {
-        checkFunctionBodyDeclarations((*block)->body);
+        checkFunctionBodyDeclarations((*block)->body, module_version,
+                                      module_sm);
+      }
+    }
+  }
+
+  /** Validate body-local .param objects without assigning call ABI allocation. */
+  void checkBodyParameterDeclaration(
+      const syntax_ast::AstVariableDeclaration& declaration,
+      std::optional<PtxVersion> module_version,
+      std::optional<uint32_t> module_sm) {
+    requireParameterAvailability(module_version, module_sm, {2, 0}, 20,
+                                 declaration.range, "Body-local call .param");
+    if (declaration.vector_type) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               declaration.vector_type->range,
+               "Vector body-local .param declarations are not modeled by this "
+               "frontend.");
+      return;
+    }
+    if (isOpaqueParameterType(declaration.type.text)) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               declaration.type.range,
+               "Opaque .texref/.samplerref/.surfref parameters are not "
+               "modeled by this frontend.");
+      return;
+    }
+    const auto scalar = parameterScalarType(declaration.type.text);
+    if (!scalar) {
+      diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+               declaration.type.range,
+               declaration.type.text == ".pred"
+                   ? ".pred parameters must use .reg state space."
+               : declaration.type.text == ".f16x2"
+                   ? "Fundamental .f16x2 parameter storage is not "
+                     "modeled by this frontend."
+                   : fmt::format("Parameter type '{}' is not a supported "
+                                 "fundamental scalar type.",
+                                 declaration.type.text));
+      return;
+    }
+    for (const auto& declarator : declaration.declarators) {
+      if (declarator.initializer) {
+        diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+                 declarator.initializer->range,
+                 "Body-local .param declarations cannot have initializers.");
+      }
+      if (declarator.parameterized_count) {
+        diagnose(DeclarationDiagnosticKind::UnsupportedParameterDeclaration,
+                 declarator.parameterized_count->range,
+                 "Parameterized body-local .param declaration groups are not "
+                 "modeled by this frontend.");
+        continue;
+      }
+      uint64_t bytes = base::scalar_size_of(*scalar);
+      for (const auto& dimension : declarator.array_dimensions) {
+        if (!dimension.size) {
+          if (declarator.initializer) {
+            diagnose(DeclarationDiagnosticKind::UnsizedArrayDimension,
+                     dimension.range,
+                     "Body-local .param array dimensions must be sized.");
+          }
+          break;
+        }
+        const auto extent = constantArrayExtent(*dimension.size);
+        if (!extent || *extent == 0) {
+          break;
+        }
+        if (bytes > std::numeric_limits<uint64_t>::max() / *extent) {
+          diagnose(DeclarationDiagnosticKind::StorageExtentOverflow,
+                   dimension.range,
+                   "Body-local parameter byte extent overflows uint64_t.");
+          break;
+        }
+        bytes *= *extent;
       }
     }
   }
@@ -1398,33 +1797,11 @@ class Checker {
     }
   }
 
-  void checkFunctionArrays(const syntax_ast::AstFunction& function) {
-    const auto check_parameters = [this](const auto& parameters) {
-      for (const auto& parameter : parameters) {
-        if (parameter.array_size)
-          checkDimension(*parameter.array_size);
-      }
-    };
-    check_parameters(function.return_parameters);
-    check_parameters(function.parameters);
-  }
-
   void checkAlignment(const std::optional<syntax_ast::AstSyntax>& alignment) {
     if (alignment && !isValidAlignment(alignment->text)) {
       diagnose(DeclarationDiagnosticKind::InvalidAlignment, alignment->range,
                "Declaration alignment must be a positive power of two.");
     }
-  }
-
-  void checkFunctionAlignments(const syntax_ast::AstFunction& function) {
-    const auto check_parameters = [this](const auto& parameters) {
-      for (const auto& parameter : parameters) {
-        checkAlignment(parameter.alignment);
-        checkAlignment(parameter.pointer_alignment);
-      }
-    };
-    check_parameters(function.return_parameters);
-    check_parameters(function.parameters);
   }
 
   void checkVariableDeclaration(
@@ -1657,6 +2034,44 @@ std::optional<IntegerConstantValue> constantIntegerValue(
       .is_unsigned =
           info.integer_value->type == ExpressionInfo::IntegerType::Unsigned,
   };
+}
+
+std::optional<base::ScalarType> parameterScalarType(
+    std::string_view spelling) noexcept {
+  using base::ScalarType;
+  if (spelling == ".u8")
+    return ScalarType::U8;
+  if (spelling == ".u16")
+    return ScalarType::U16;
+  if (spelling == ".u32")
+    return ScalarType::U32;
+  if (spelling == ".u64")
+    return ScalarType::U64;
+  if (spelling == ".s8")
+    return ScalarType::S8;
+  if (spelling == ".s16")
+    return ScalarType::S16;
+  if (spelling == ".s32")
+    return ScalarType::S32;
+  if (spelling == ".s64")
+    return ScalarType::S64;
+  if (spelling == ".b8")
+    return ScalarType::B8;
+  if (spelling == ".b16")
+    return ScalarType::B16;
+  if (spelling == ".b32")
+    return ScalarType::B32;
+  if (spelling == ".b64")
+    return ScalarType::B64;
+  if (spelling == ".b128")
+    return ScalarType::B128;
+  if (spelling == ".f16")
+    return ScalarType::F16;
+  if (spelling == ".f32")
+    return ScalarType::F32;
+  if (spelling == ".f64")
+    return ScalarType::F64;
+  return std::nullopt;
 }
 
 std::vector<DeclarationDiagnostic> checkDeclarations(

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -21,6 +21,7 @@ CheckedModule check(std::string_view source) {
   PtxSyntaxParser parser(source);
   auto module = parser.parseModule();
   EXPECT_TRUE(module.has_value()) << module.diagnostics.front().message;
+  EXPECT_TRUE(module.diagnostics.empty());
   auto binding = binding::bindSymbols(*module);
   auto diagnostics = checkDeclarations(*module, binding.table);
   return {std::move(binding), std::move(diagnostics)};
@@ -198,6 +199,236 @@ TEST(PtxDeclarationSemantics, ValidatesInitializerExpressionTypes) {
       2u);
 }
 
+/** Parameter declarations reject unsupported types, shapes, and ABI contexts. */
+TEST(PtxDeclarationSemantics, ValidatesParameterDeclarationBoundaries) {
+  /** One source declaration expected to produce the named diagnostic kind. */
+  struct Case {
+    std::string_view source;
+    DeclarationDiagnosticKind kind;
+  };
+  constexpr std::array cases = {
+      Case{R"ptx(.version 9.3
+.target sm_80
+.entry k(.param .pred predicate) {})ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{R"ptx(.version 9.3
+.target sm_80
+.entry k(.param .mystery value) {})ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{R"ptx(.version 9.3
+.target sm_80
+.entry k(.param .texref texture) {})ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{R"ptx(.version 9.3
+.target sm_80
+.entry k(.param .b8 bytes[]) {})ptx",
+           DeclarationDiagnosticKind::UnsizedArrayDimension},
+      Case{R"ptx(.version 5.0
+.target sm_30
+.func f(.param .b8 bytes[]);)ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{R"ptx(.version 9.3
+.target sm_80
+.func f(.param .u64 .ptr .global pointer);)ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{R"ptx(.version 8.1
+.target sm_80
+.entry k(.param .b8 payload[32765]) {})ptx",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+  };
+  for (const auto& test : cases) {
+    const CheckedModule result = check(test.source);
+    EXPECT_GT(diagnosticCount(result, test.kind), 0u) << test.source;
+  }
+}
+
+/** Supported parameter forms preserve body-local array coverage and predicates. */
+TEST(PtxDeclarationSemantics, AcceptsSupportedParameterDeclarationForms) {
+  const CheckedModule result = check(R"ptx(
+.version 8.0
+.target sm_80
+.entry k(.param .u64 .ptr .global pointer) {
+  .param .u32 matrix[2][3];
+}
+.func device(.reg .pred predicate, .param .b8 bytes[]);
+)ptx");
+
+  EXPECT_TRUE(result.binding.diagnostics.empty());
+  EXPECT_TRUE(result.diagnostics.empty());
+}
+
+/** Parameter availability and incomplete-array rules honor PTX and SM bounds. */
+TEST(PtxDeclarationSemantics, ValidatesParameterAvailabilityBoundaries) {
+  /** One versioned source declaration expected to produce the named diagnostic. */
+  struct Case {
+    std::string_view source;
+    DeclarationDiagnosticKind kind;
+  };
+  constexpr std::array rejected = {
+      Case{".version 1.3\n.entry k(.param .u32 value) {}",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 1.5\n.target sm_20\n.func f(.param .u32 value);",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 2.0\n.target sm_13\n.func f(.param .u32 value);",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 2.1\n.target sm_30\n.entry k(.param .u64 .ptr p) {}",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 2.0\n.target sm_20\n.entry k() {\n"
+           "p: .callprototype _ (.param .u32 value);\n}",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 5.0\n.target sm_30\n.func f(.param .b8 bytes[]);",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 6.0\n.target sm_20\n.func f(.param .b8 bytes[]);",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".version 6.0\n.target sm_30\n.func f(.param .u32 bytes[]);",
+           DeclarationDiagnosticKind::UnsizedArrayDimension},
+      Case{".version 6.0\n.target sm_30\n.func f(\n"
+           ".param .b8 bytes[], .param .u32 trailing);",
+           DeclarationDiagnosticKind::UnsizedArrayDimension},
+      Case{".version 8.0\n.target sm_80\n.func (.param .b8 result[]) f();",
+           DeclarationDiagnosticKind::UnsizedArrayDimension},
+  };
+  for (const auto& test : rejected) {
+    const CheckedModule result = check(test.source);
+    EXPECT_GT(diagnosticCount(result, test.kind), 0u) << test.source;
+  }
+
+  constexpr std::array accepted = {
+      ".version 1.4\n.target sm_20\n.entry k(.param .u32 value) {}",
+      ".version 2.0\n.target sm_20\n.func f(.param .u32 value);",
+      ".version 2.2\n.target sm_20\n.entry k(.param .u64 .ptr p) {}",
+      ".version 2.1\n.target sm_20\n.entry k() {\n"
+      "p: .callprototype _ (.param .u32 value);\n}",
+      ".version 6.0\n.target sm_30\n.func f(.param .b8 bytes[]);",
+  };
+  for (const auto source : accepted) {
+    const CheckedModule result = check(source);
+    EXPECT_TRUE(result.binding.diagnostics.empty()) << source;
+    EXPECT_TRUE(result.diagnostics.empty()) << source;
+  }
+}
+
+/** Entry parameter byte limits account for alignment and checked arithmetic. */
+TEST(PtxDeclarationSemantics, ValidatesEntryParameterByteBoundaries) {
+  const auto entry = [](std::string_view version, uint64_t bytes) {
+    return ".version " + std::string{version} +
+           "\n.target sm_80\n.entry k(.param .b8 payload[" +
+           std::to_string(bytes) + "]) {}";
+  };
+  constexpr std::array<std::pair<std::string_view, uint64_t>, 4> limits{{
+      {"1.4", 256},
+      {"1.5", 4352},
+      {"8.0", 4352},
+      {"8.1", 32764},
+  }};
+  for (const auto& [version, limit] : limits) {
+    const CheckedModule exact = check(entry(version, limit));
+    EXPECT_TRUE(exact.diagnostics.empty()) << version;
+    const CheckedModule excess = check(entry(version, limit + 1));
+    EXPECT_GT(
+        diagnosticCount(
+            excess, DeclarationDiagnosticKind::UnsupportedParameterDeclaration),
+        0u)
+        << version;
+  }
+
+  const CheckedModule aligned_fit = check(
+      ".version 1.4\n.target sm_20\n.entry k("
+      ".param .b8 first[1], .param .align 16 .b8 second[240]) {}");
+  EXPECT_TRUE(aligned_fit.diagnostics.empty());
+  const CheckedModule aligned_excess = check(
+      ".version 1.4\n.target sm_20\n.entry k("
+      ".param .b8 first[1], .param .align 16 .b8 second[241]) {}");
+  EXPECT_GT(diagnosticCount(
+                aligned_excess,
+                DeclarationDiagnosticKind::UnsupportedParameterDeclaration),
+            0u);
+
+  const CheckedModule multiply_overflow = check(
+      ".version 8.1\n.target sm_80\n.entry k("
+      ".param .u64 values[18446744073709551615U]) {}");
+  EXPECT_GT(diagnosticCount(multiply_overflow,
+                            DeclarationDiagnosticKind::StorageExtentOverflow),
+            0u);
+  const CheckedModule sum_overflow = check(
+      ".version 8.1\n.target sm_80\n.entry k("
+      ".param .b8 first[18446744073709551608U], .param .b8 second[16]) {}");
+  EXPECT_GT(diagnosticCount(sum_overflow,
+                            DeclarationDiagnosticKind::StorageExtentOverflow),
+            0u);
+}
+
+/** Parameter scalar classification accepts only the modeled storage subset. */
+TEST(PtxDeclarationSemantics, ClassifiesSupportedParameterScalarTypes) {
+  constexpr std::array supported = {
+      ".u8", ".u16", ".u32", ".u64", ".s8",   ".s16", ".s32", ".s64",
+      ".b8", ".b16", ".b32", ".b64", ".b128", ".f16", ".f32", ".f64",
+  };
+  std::string source = ".version 9.3\n.target sm_80\n.entry k(";
+  for (size_t index = 0; index < supported.size(); ++index) {
+    if (index != 0)
+      source += ", ";
+    source += ".param ";
+    source += supported[index];
+    source += " value" + std::to_string(index);
+  }
+  source += ") {}";
+  const CheckedModule accepted = check(source);
+  EXPECT_TRUE(accepted.binding.diagnostics.empty());
+  EXPECT_TRUE(accepted.diagnostics.empty());
+  for (const auto type : supported)
+    EXPECT_TRUE(parameterScalarType(type).has_value()) << type;
+
+  constexpr std::array unsupported = {
+      ".pred", ".f16x2", ".bf16", ".tf32", ".mystery",
+  };
+  for (const auto type : unsupported) {
+    const CheckedModule result = check(
+        ".version 9.3\n.target sm_80\n.entry "
+        "k(.param " +
+        std::string{type} + " value) {}");
+    EXPECT_GT(
+        diagnosticCount(
+            result, DeclarationDiagnosticKind::UnsupportedParameterDeclaration),
+        0u)
+        << type;
+    EXPECT_FALSE(parameterScalarType(type).has_value()) << type;
+  }
+  const CheckedModule register_packed_half =
+      check(".version 9.3\n.target sm_80\n.func f(.reg .f16x2 value);");
+  EXPECT_TRUE(register_packed_half.diagnostics.empty());
+}
+
+/** Body-local parameters reject unmodeled forms but retain sized multidimensional arrays. */
+TEST(PtxDeclarationSemantics, ValidatesBodyLocalParameterForms) {
+  /** One body-local declaration expected to produce the named diagnostic. */
+  struct Case {
+    std::string_view declaration;
+    DeclarationDiagnosticKind kind;
+  };
+  constexpr std::array rejected = {
+      Case{".param .b8 bytes[];",
+           DeclarationDiagnosticKind::UnsizedArrayDimension},
+      Case{".param .v2 .u32 vector;",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".param .texref texture;",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+      Case{".param .u32 values<2>;",
+           DeclarationDiagnosticKind::UnsupportedParameterDeclaration},
+  };
+  for (const auto& test : rejected) {
+    const CheckedModule result =
+        check(".version 8.0\n.target sm_80\n.entry k() {\n" +
+              std::string{test.declaration} + "\n}");
+    EXPECT_GT(diagnosticCount(result, test.kind), 0u) << test.declaration;
+  }
+  const CheckedModule accepted = check(
+      ".version 8.0\n.target sm_80\n.entry k() {\n"
+      ".param .u32 matrix[2][3];\n}");
+  EXPECT_TRUE(accepted.binding.diagnostics.empty());
+  EXPECT_TRUE(accepted.diagnostics.empty());
+}
+
 TEST(PtxDeclarationSemantics,
      AcceptsCompatibleExternalAndFunctionDeclarations) {
   const CheckedModule result = check(R"ptx(
@@ -222,16 +453,16 @@ TEST(PtxDeclarationSemantics,
 TEST(PtxDeclarationSemantics, BuildsReusableCanonicalFunctionSignatures) {
   PtxSyntaxParser parser(R"ptx(
 .func (.param .align 16 .u32 result) helper(
-    .param .u64 .ptr .global .align 16 pointer,
+    .param .u64 address,
     .param .u32 values[2 * 2]);
 .func (.param .align 16 .u32 output) helper(
-    .param .u64 .ptr .global .align 16 address,
+    .param .u64 address,
     .param .u32 data[4]) { ret; }
 .entry kernel() { }
 .func noreturn_function() .noreturn { }
 .func indirect() {
   prototype: .callprototype (.param .align 16 .u32 output) _
-      (.param .u64 .ptr .global .align 16 address, .param .u32 data[4]);
+      (.param .u64 address, .param .u32 data[4]);
   noreturn_prototype: .callprototype _ .noreturn;
 }
 )ptx");
@@ -247,10 +478,9 @@ TEST(PtxDeclarationSemantics, BuildsReusableCanonicalFunctionSignatures) {
   EXPECT_EQ(result.state_space, syntax_ast::AstStateSpace::Parameter);
   EXPECT_EQ(result.alignment, "16");
   EXPECT_EQ(result.type, ".u32");
-  const auto& pointer = prototype_signature.parameters[0];
-  EXPECT_TRUE(pointer.is_pointer);
-  EXPECT_EQ(pointer.pointer_space, ".global");
-  EXPECT_EQ(pointer.pointer_alignment, "16");
+  const auto& address = prototype_signature.parameters[0];
+  EXPECT_FALSE(address.is_pointer);
+  EXPECT_EQ(address.type, ".u64");
   ASSERT_EQ(prototype_signature.parameters.size(), 2u);
   const auto& values = prototype_signature.parameters[1];
   EXPECT_TRUE(values.is_array);


### PR DESCRIPTION
## Summary

Closes #55.

- Validate supported PTX .param declarations across entry inputs, device inputs/returns and body-local call parameters, including scalar types, extents, alignment, pointer attributes, version/target availability and statically decidable size limits.
- Publish one owned ResolvedFunction::parameter_declarations table containing role, scalar type, lexical/symbol identity, shape, byte extent, effective alignment, explicit-alignment provenance and pointee properties. Preserve return/input/body ordering and inspection after source/AST destruction.
- Reject invalid formal-parameter call actuals, normalize effective signature/array alignment and support omission of a validated final unsized byte input when no payload is supplied.
- Add parser, semantic, resolved-IR and installed-package consumer regressions, plus aligned English/Chinese coverage and migration documentation.

## Breaking API change

Remove ResolvedFunction::entry_parameters and ResolvedEntryParameter instead of retaining duplicate entry metadata. Consumers must migrate to parameter_declarations and select ParameterDeclarationRole::EntryInput in source order. DeviceInput, DeviceReturn and BodyLocal are not launch slots. Use scalar_type, non-optional effective alignment, array_extents and byte_extent in place of the old string/shape fields.

Downstream ptxsim adaptation is tracked separately in https://github.com/endingly/ptxsim/issues/35. This PR does not modify ptxsim or its ExecIR/runtime layout and packing APIs.

## Explicit boundaries

Opaque parameter objects, .f16x2 parameters, header vectors/multidimensional arrays and body-local vectors/parameterized groups remain explicitly unsupported with documented diagnostics and follow-up scope. Unsupported is distinguished from ISA-illegal. No opaque physical layout, launch allocation, driver policy or simulator execution is introduced.

## Verification

All checks below passed on the final local file contents before commit; this publication step made no source changes:

- Debug build and C++ preset: 652/652 tests passed.
- Release build and C++ preset: 652/652 tests passed.
- Python and installed-package consumer preset: 2/2 tests passed.
- git diff --check and staged diff check passed.

The installed consumer exercises the unified public metadata, AST-independent lifetime, typed shape/alignment and declaration identity. Hosted CI results are separate from this local verification.