### PR TITLE
fix(ci): save missing vcpkg caches from Release jobs

### DIFF
--- a/.github/scripts/test_ci_helpers.py
+++ b/.github/scripts/test_ci_helpers.py
@@ -249,27 +249,42 @@ class WorkflowContractTests(unittest.TestCase):
             consumer,
         )
 
-    def test_dependency_archives_have_debug_only_configure_time_writers(self) -> None:
-        """Only Debug matrix entries may save shared dependencies after configuration."""
-        linux = (WORKFLOWS / "linux-ci.yml").read_text(encoding="utf-8")
-        smoke = (WORKFLOWS / "integration-smoke.yml").read_text(encoding="utf-8")
+    def test_binary_cache_writers_are_independent_of_shared_download_ownership(self) -> None:
+        """Every matrix job saves its missing binary key; shared downloads stay Debug-owned."""
+        for filename in ("linux-ci.yml", "integration-smoke.yml"):
+            with self.subTest(workflow=filename):
+                workflow = (WORKFLOWS / filename).read_text(encoding="utf-8")
+                self.assertIn(
+                    "name: Debug\n            preset: ci-linux-gcc-debug\n            writes_shared_caches: true",
+                    workflow,
+                )
+                self.assertIn(
+                    "name: Release\n            preset: ci-linux-gcc-release\n            writes_shared_caches: false",
+                    workflow,
+                )
+                for name, condition in (
+                    (
+                        "Save vcpkg binary archive cache",
+                        "success() && steps.setup.outputs.binary-cache-hit != 'true'",
+                    ),
+                    (
+                        "Save vcpkg source-download cache",
+                        "success() && matrix.writes_shared_caches && steps.setup.outputs.downloads-cache-hit != 'true'",
+                    ),
+                ):
+                    start = workflow.index(f"- name: {name}")
+                    end = workflow.index("\n      - name:", start)
+                    step = workflow[start:end]
+                    self.assertIn(f"if: {condition}\n", step)
+                    self.assertIn("uses: actions/cache/save@", step)
+                    self.assertGreater(start, workflow.index("- name: Configure"))
+                    self.assertLess(start, workflow.index("- name: Build"))
+                archive = workflow.split("- name: Save vcpkg binary archive cache", 1)[1]
+                archive = archive.split("\n      - name:", 1)[0]
+                self.assertIn("path: .cache/vcpkg/archives", archive)
+                self.assertIn("key: ${{ steps.setup.outputs.binary-cache-key }}", archive)
+                self.assertNotIn("matrix.", archive)
         action = (SCRIPTS.parent / "actions/setup-linux/action.yml").read_text(encoding="utf-8")
-        self.assertIn("name: Debug\n            preset: ci-linux-gcc-debug\n            writes_shared_caches: true", linux)
-        self.assertIn("name: Release\n            preset: ci-linux-gcc-release\n            writes_shared_caches: false", linux)
-        self.assertGreater(linux.index("- name: Save vcpkg binary archive cache"), linux.index("- name: Configure"))
-        self.assertLess(linux.index("- name: Save vcpkg binary archive cache"), linux.index("- name: Build"))
-        self.assertIn(
-            "writes-shared-caches: ${{ matrix.writes_shared_caches }}",
-            smoke,
-        )
-        source_save = smoke.index("- name: Save vcpkg source-download cache")
-        archive_save = smoke.index("- name: Save vcpkg binary archive cache")
-        self.assertIn("if: success() && matrix.writes_shared_caches", smoke[source_save:])
-        self.assertIn("if: success() && matrix.writes_shared_caches", smoke[archive_save:])
-        self.assertGreater(source_save, smoke.index("- name: Configure"))
-        self.assertLess(source_save, smoke.index("- name: Build"))
-        self.assertGreater(archive_save, smoke.index("- name: Configure"))
-        self.assertLess(archive_save, smoke.index("- name: Build"))
         self.assertIn("vcpkg-binaries-v3-", action)
         self.assertNotIn("github.run_id", action)
 

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -71,8 +71,9 @@ jobs:
           path: .cache/vcpkg/downloads
           key: ${{ steps.setup.outputs.downloads-cache-key }}
 
+      # Runner images can differ within the matrix, producing distinct binary keys.
       - name: Save vcpkg binary archive cache
-        if: success() && matrix.writes_shared_caches && steps.setup.outputs.binary-cache-hit != 'true'
+        if: success() && steps.setup.outputs.binary-cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .cache/vcpkg/archives

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -74,8 +74,9 @@ jobs:
           path: .cache/vcpkg/downloads
           key: ${{ steps.setup.outputs.downloads-cache-key }}
 
+      # Runner images can differ within the matrix, producing distinct binary keys.
       - name: Save vcpkg binary archive cache
-        if: success() && matrix.writes_shared_caches && steps.setup.outputs.binary-cache-hit != 'true'
+        if: success() && steps.setup.outputs.binary-cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .cache/vcpkg/archives

--- a/docs/us-en/ci_workflows.md
+++ b/docs/us-en/ci_workflows.md
@@ -81,8 +81,13 @@ acceptance. Release uses its own build directory.
 The workflows share `.github/actions/setup-linux` for system packages, Python
 dependencies, and vcpkg setup. Cache identity includes the installed toolchain
 and runner image; vcpkg uses the manifest's exact builtin baseline. Dependency
-archives are separate from source downloads. Designated jobs write shared
-dependency/download caches; other jobs restore and use them.
+archives are separate from source downloads. In both matrix workflows, every
+Debug/Release job saves a missing exact vcpkg binary-cache key after successful
+configuration. Runner images can differ within one matrix, so a fixed Debug
+writer cannot populate every Release key. Jobs sharing a key may race to save;
+the cache action handles duplicate saves without failing the job.
+Only Debug writes shared APT, pip, and vcpkg source-download caches. The separate
+Python/package job remains restore-only for dependency caches.
 
 Integration and PR Debug jobs share a compiler-cache namespace; Release has its
 own shared namespace. The Python/package job restores Debug caches but does not

--- a/docs/zh-han/ci_workflows.md
+++ b/docs/zh-han/ci_workflows.md
@@ -69,8 +69,12 @@ smoke 注册。Release 使用独立 build 目录。
 
 工作流共用 `.github/actions/setup-linux` 完成系统包、Python 依赖及 vcpkg setup。
 缓存身份包含实际安装的工具链与 runner image；vcpkg 使用 manifest 的精确 builtin
-baseline。依赖二进制 archive 与源文件下载分别缓存，由指定 job 写入共享依赖/下载
-缓存；其他 job 只恢复并使用。
+baseline。依赖二进制 archive 与源文件下载分别缓存。两个矩阵工作流中的每个
+Debug/Release job 都在 configure 成功且精确 vcpkg 二进制缓存 key 未命中时保存缓存。
+同一矩阵可能使用不同 runner image，因此固定由 Debug 写入无法覆盖所有 Release key。
+相同 key 的 job 可能竞争保存；cache action 会处理重复保存，不使 job 失败。
+APT、pip 和 vcpkg 源文件下载缓存仍仅由 Debug 写入；独立 Python/package job
+对依赖缓存仍只恢复、不保存。
 
 Integration 与 PR 的 Debug job 共用编译缓存命名空间，Release 另有共用命名空间。
 Python/package job 恢复 Debug 缓存，但不上传较小的 library/consumer-only 快照，


### PR DESCRIPTION
## Summary

- Allow both Debug and Release matrix jobs in Linux CI and integration prewarming to save a missing exact vcpkg binary-cache key after successful configuration.
- Keep cache identities, ccache behavior, and Debug-only APT/pip/source-download ownership unchanged; the separate Python/package lane remains restore-only.
- Update workflow contract regressions and matching English/Chinese documentation, including duplicate-save behavior.

## Evidence

The Release prewarm following #64 used a different runner image and compiler-cache identity, missed its vcpkg binary cache, and skipped saving it because only Debug was allowed to write. This is the same write-policy gap addressed by endingly/ptxsim#41. The separate ccache misses were explained by cache scope and image identity; ccache is not changed here.

## Validation

- CI helper tests: 15 passed.
- actionlint passed for both changed workflows with ubuntu-26.04 recognized.
- Action-pin check and git diff --check passed.
- No C++ build/test rerun: only cache-save conditions, regression assertions, and documentation changed.
- Actual save/reuse on cache-miss hosted runs remains to be verified.

Based on main at a98ab6fc4935e65edc6d2a39e912a0cd77a47ff4.