### PR TITLE
fix(resolved-ir): preserve structured module diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ and the explicit lowering functions when retained tokens and source text are
 required. `resolved_ir::resolveModule` runs binding and declaration checks as
 part of module resolution and returns their diagnostics together with
 instruction-resolution diagnostics.
+Imported binding, declaration, and checker diagnostics retain their typed
+categories and source locations through `ResolveDiagnostic`; `stage()` identifies
+their origin, and `previous_range` preserves related declaration locations.
 
 ## Requirements
 

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -51,6 +51,18 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics>
 resolveModule(const syntax_ast::AstModule& ast);
 ```
 
+`ResolveDiagnostic` owns its message and source ranges. Module resolution
+preserves the originating `binding_kind`, `declaration_kind`, or `checker_kind`,
+as well as the primary `range` and any `previous_range` supplied by binding or
+declaration semantics. `stage()` derives `Binding`, `DeclarationSemantics`, or
+`Checking` from that typed category. Exactly one category is populated for an
+imported diagnostic; native resolver errors keep all three empty and report
+`Resolution`. Native resolver errors do not yet have a finer-grained code.
+Consumers can inspect imported error categories and related locations without
+parsing the human-readable message, even after source text and AST destruction.
+Diagnostic ordering and existing early-return boundaries are unchanged. The
+existing aggregate fields remain in order, with new optional categories appended.
+
 `resolveInstruction` is generated from the instruction database and dispatches
 to the existing `resolve<T>` specialization. This keeps opcode dispatch out of
 callers while retaining the strongly typed per-opcode structures.

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -44,6 +44,15 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics>
 resolveModule(const syntax_ast::AstModule& ast);
 ```
 
+`ResolveDiagnostic` 拥有 message 和 source range 的值。模块解析保留原阶段的
+`binding_kind`、`declaration_kind` 或 `checker_kind`，以及主位置 `range` 和 binding
+或 declaration semantics 提供的 `previous_range`。`stage()` 由类型化类别推导出
+`Binding`、`DeclarationSemantics` 或 `Checking`。转换而来的诊断恰有一个类别字段；
+resolver 原生错误的三个类别字段均为空，阶段为 `Resolution`，目前没有更细的错误码。
+调用者无需解析 message，即可检查转换诊断的原始类别与关联位置；源码和 AST 销毁后
+这些信息仍然有效。诊断顺序和原有提前返回边界不变。既有 aggregate 字段保持原顺序，
+新增可选类别字段追加在末尾。
+
 `resolveInstruction` 根据指令数据库生成，并分发到现有的 `resolve<T>` 特化。调用者不再
 需要手写 opcode 分派，同时每个 opcode 仍保留强类型结构。`resolveModule` 先建立
 `SymbolTable`，再为每个 function scope 构造显式 `ResolveContext`；返回的

--- a/submod/resolved_ir/include/ptx_resolved_ir.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir.hpp
@@ -273,13 +273,46 @@ struct ResolvedInstructionDescriptor {
 
 };  // namespace check_end
 
+/** Origin of a diagnostic returned through the resolution API. */
+enum class ResolveDiagnosticStage : uint8_t {
+  Resolution,
+  Binding,
+  DeclarationSemantics,
+  Checking,
+};
+
+/**
+ * Owned diagnostic returned by standalone or module resolution.
+ *
+ * Imported diagnostics retain their original typed category. At most one of
+ * the category fields is populated by the frontend; native resolution errors
+ * have none. Source ranges are values and the message owns its text, so this
+ * record remains valid after the source, AST, and intermediate results die.
+ */
 struct ResolveDiagnostic {
+  /** Primary source location supplied by the originating stage. */
   SourceRange range;
+  /** Owned human-readable explanation; not a machine-readable error code. */
   std::string message;
   /** Preserved declaration-stage category; absent for other diagnostic stages. */
   std::optional<declaration_semantics::DeclarationDiagnosticKind> declaration_kind{};
-  /** Related declaration location when provided by declaration semantics. */
+  /** Related declaration location supplied by binding or declaration semantics. */
   std::optional<SourceRange> previous_range{};
+  /** Original binding category; absent for other diagnostic stages. */
+  std::optional<binding::BindDiagnosticKind> binding_kind{};
+  /** Original checker category; absent for other diagnostic stages. */
+  std::optional<checker::CheckDiagnosticKind> checker_kind{};
+
+  /** Derive the origin from the typed category without duplicating stage state. */
+  [[nodiscard]] constexpr ResolveDiagnosticStage stage() const noexcept {
+    if (binding_kind)
+      return ResolveDiagnosticStage::Binding;
+    if (declaration_kind)
+      return ResolveDiagnosticStage::DeclarationSemantics;
+    if (checker_kind)
+      return ResolveDiagnosticStage::Checking;
+    return ResolveDiagnosticStage::Resolution;
+  }
 };
 
 class ResolveException : public std::runtime_error {

--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -823,6 +823,8 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
     diagnostics.push_back(ResolveDiagnostic{
         .range = diagnostic.range,
         .message = diagnostic.message,
+        .previous_range = diagnostic.previous_range,
+        .binding_kind = diagnostic.kind,
     });
   }
   for (const auto& diagnostic :
@@ -970,7 +972,9 @@ std::expected<ResolvedModule, ModuleResolveDiagnostics> resolveModule(
     availability_diagnostics.reserve(availability.error().size());
     for (const checker::CheckDiagnostic& diagnostic : availability.error()) {
       availability_diagnostics.push_back(
-          {.range = diagnostic.range, .message = diagnostic.message});
+          {.range = diagnostic.range,
+           .message = diagnostic.message,
+           .checker_kind = diagnostic.kind});
     }
     return std::unexpected(std::move(availability_diagnostics));
   }

--- a/submod/resolved_ir/test/package_consumer/main.cpp
+++ b/submod/resolved_ir/test/package_consumer/main.cpp
@@ -380,6 +380,43 @@ int check_fma_contract() {
   return 0;
 }
 
+/** Verify imported binding diagnostics survive through the installed module API. */
+int check_module_diagnostics() {
+  using namespace ptx_frontend;
+  std::vector<binding::BindDiagnostic> original;
+  resolved_ir::ModuleResolveDiagnostics diagnostics;
+  {
+    const std::string source =
+        ".entry k() { .reg .u32 %r; .reg .u32 %r; }";
+    PtxSyntaxParser parser(source);
+    const auto ast = parser.parseModule();
+    if (!ast || !ast.diagnostics.empty())
+      return 100;
+    original = binding::bindSymbols(*ast).diagnostics;
+    auto result = resolved_ir::resolveModule(*ast);
+    if (result || original.empty())
+      return 101;
+    diagnostics = std::move(result.error());
+  }
+  if (diagnostics.size() < original.size())
+    return 102;
+  for (size_t index = 0; index < original.size(); ++index) {
+    const auto& diagnostic = diagnostics[index];
+    const auto& expected = original[index];
+    if (diagnostic.stage() != resolved_ir::ResolveDiagnosticStage::Binding ||
+        diagnostic.binding_kind != expected.kind ||
+        diagnostic.declaration_kind || diagnostic.checker_kind ||
+        diagnostic.range != expected.range ||
+        diagnostic.previous_range != expected.previous_range ||
+        diagnostic.message != expected.message)
+      return 103;
+  }
+  if (original.front().kind != binding::BindDiagnosticKind::DuplicateSymbol ||
+      !diagnostics.front().previous_range)
+    return 104;
+  return 0;
+}
+
 int main() {
   constexpr std::string_view source = "add.u32 %r0, %r1, 1;";
   ptx_frontend::PtxCstParser cst_parser(source);
@@ -481,6 +518,9 @@ int main() {
   }
   if (const int fma_result = check_fma_contract(); fma_result != 0)
     return fma_result;
+  if (const int diagnostic_result = check_module_diagnostics();
+      diagnostic_result != 0)
+    return diagnostic_result;
 
   ptx_frontend::PtxSyntaxParser call_parser(
       "call (%result), callee, (%argument, 1);");

--- a/submod/resolved_ir/test/test_module_diagnostics.cpp
+++ b/submod/resolved_ir/test/test_module_diagnostics.cpp
@@ -1,0 +1,262 @@
+#include <gtest/gtest.h>
+
+#include <expected>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/semantic/ptx_declaration_semantics.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+#include <ptx_frontend/binding/ptx_symbol_table.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Parse a module, retaining failure diagnostics without dereferencing invalid input. */
+std::optional<syntax_ast::AstModule> parseModule(std::string_view source) {
+  PtxSyntaxParser parser(source);
+  auto module = parser.parseModule();
+  if (!module || !module.diagnostics.empty()) {
+    ADD_FAILURE() << (module.diagnostics.empty()
+                          ? "PTX source did not parse."
+                          : module.diagnostics.front().message);
+    return std::nullopt;
+  }
+  return std::move(*module);
+}
+
+/** Verify the lossless projection of one binding diagnostic into resolution. */
+void expectBindingProjection(const ResolveDiagnostic& actual,
+                             const binding::BindDiagnostic& expected) {
+  EXPECT_EQ(actual.stage(), ResolveDiagnosticStage::Binding);
+  EXPECT_EQ(actual.binding_kind, expected.kind);
+  EXPECT_EQ(actual.range, expected.range);
+  EXPECT_EQ(actual.previous_range, expected.previous_range);
+  EXPECT_EQ(actual.message, expected.message);
+  EXPECT_FALSE(actual.declaration_kind);
+  EXPECT_FALSE(actual.checker_kind);
+}
+
+/** Verify the lossless projection of one declaration diagnostic into resolution. */
+void expectDeclarationProjection(
+    const ResolveDiagnostic& actual,
+    const declaration_semantics::DeclarationDiagnostic& expected) {
+  EXPECT_EQ(actual.stage(), ResolveDiagnosticStage::DeclarationSemantics);
+  EXPECT_EQ(actual.declaration_kind, expected.kind);
+  EXPECT_EQ(actual.range, expected.range);
+  EXPECT_EQ(actual.previous_range, expected.previous_range);
+  EXPECT_EQ(actual.message, expected.message);
+  EXPECT_FALSE(actual.binding_kind);
+  EXPECT_FALSE(actual.checker_kind);
+}
+
+/** Verify the lossless projection of one checker diagnostic into resolution. */
+void expectCheckerProjection(const ResolveDiagnostic& actual,
+                             const checker::CheckDiagnostic& expected) {
+  EXPECT_EQ(actual.stage(), ResolveDiagnosticStage::Checking);
+  EXPECT_EQ(actual.checker_kind, expected.kind);
+  EXPECT_EQ(actual.range, expected.range);
+  EXPECT_EQ(actual.message, expected.message);
+  EXPECT_FALSE(actual.previous_range);
+  EXPECT_FALSE(actual.binding_kind);
+  EXPECT_FALSE(actual.declaration_kind);
+}
+
+/** Resolve invalid input in a nested scope so all parser-owned data dies first. */
+ModuleResolveDiagnostics diagnosticsAfterInputDies() {
+  std::string source = R"ptx(
+.entry kernel() {
+  .reg .u32 %dst;
+  mov.u32 %dst, %missing;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  if (!ast || !ast.diagnostics.empty()) {
+    ADD_FAILURE() << (ast.diagnostics.empty()
+                          ? "PTX source did not parse."
+                          : ast.diagnostics.front().message);
+    return {};
+  }
+  auto resolved = resolveModule(*ast);
+  if (resolved) {
+    ADD_FAILURE() << "PTX source unexpectedly resolved.";
+    return {};
+  }
+  return std::move(resolved.error());
+}
+
+/** Binding categories, messages, primary ranges, and related ranges survive. */
+TEST(ModuleDiagnostics, ProjectsBindingDiagnosticsWithoutClassification) {
+  const auto ast = parseModule(R"ptx(
+.entry kernel() {
+again:
+again:
+  .reg .u32 %dst;
+  mov.u32 %dst, %missing;
+}
+)ptx");
+  ASSERT_TRUE(ast);
+  const auto binding = binding::bindSymbols(*ast);
+  ASSERT_EQ(binding.diagnostics.size(), 2u);
+
+  const auto resolved = resolveModule(*ast);
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), binding.diagnostics.size());
+  for (size_t index = 0; index < binding.diagnostics.size(); ++index)
+    expectBindingProjection(resolved.error()[index], binding.diagnostics[index]);
+
+  EXPECT_EQ(resolved.error()[0].binding_kind,
+            binding::BindDiagnosticKind::DuplicateSymbol);
+  EXPECT_TRUE(resolved.error()[0].previous_range);
+  EXPECT_EQ(resolved.error()[1].binding_kind,
+            binding::BindDiagnosticKind::UnresolvedReference);
+  EXPECT_FALSE(resolved.error()[1].previous_range);
+}
+
+/** Binding diagnostics precede declaration diagnostics while preserving each order. */
+TEST(ModuleDiagnostics, OrdersBindingThenDeclarationSemanticsDiagnostics) {
+  const auto ast = parseModule(R"ptx(
+.extern .global .u32 conflicting[2];
+.extern .global .u64 conflicting[2];
+.entry kernel() {
+  .reg .u32 %dst;
+  mov.u32 %dst, %missing;
+}
+)ptx");
+  ASSERT_TRUE(ast);
+  const auto binding = binding::bindSymbols(*ast);
+  const auto declarations =
+      declaration_semantics::checkDeclarations(*ast, binding.table);
+  ASSERT_EQ(binding.diagnostics.size(), 1u);
+  ASSERT_EQ(declarations.size(), 1u);
+
+  const auto resolved = resolveModule(*ast);
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(),
+            binding.diagnostics.size() + declarations.size());
+  expectBindingProjection(resolved.error().front(), binding.diagnostics.front());
+  expectDeclarationProjection(resolved.error().back(), declarations.front());
+  EXPECT_EQ(resolved.error().back().declaration_kind,
+            declaration_semantics::DeclarationDiagnosticKind::
+                IncompatibleRedeclaration);
+  EXPECT_TRUE(resolved.error().back().previous_range);
+}
+
+/** Storage lowering keeps its declaration category even without a public lowerer. */
+TEST(ModuleDiagnostics, ProjectsStorageOnlyDeclarationDiagnostic) {
+  const auto ast = parseModule(".global .bf16 unsupported_storage;");
+  ASSERT_TRUE(ast);
+  const auto resolved = resolveModule(*ast);
+
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), 1u);
+  const ResolveDiagnostic& diagnostic = resolved.error().front();
+  EXPECT_EQ(diagnostic.stage(), ResolveDiagnosticStage::DeclarationSemantics);
+  EXPECT_EQ(diagnostic.declaration_kind,
+            declaration_semantics::DeclarationDiagnosticKind::
+                UnsupportedStorageDeclaration);
+  EXPECT_EQ(diagnostic.range,
+            std::get<syntax_ast::AstVariableDeclaration>(ast->items.front())
+                .type.range);
+  EXPECT_FALSE(diagnostic.previous_range);
+  EXPECT_FALSE(diagnostic.binding_kind);
+  EXPECT_FALSE(diagnostic.checker_kind);
+}
+
+/** Availability checker categories and locations survive module resolution. */
+TEST(ModuleDiagnostics, ProjectsCheckerDiagnosticForRecognizedTargetAndVersion) {
+  constexpr std::string_view unchecked_source = R"ptx(
+.version 0.9
+.entry kernel() {
+  .reg .u32 %r<3>;
+  add.u32 %r0, %r1, %r2;
+}
+)ptx";
+  constexpr std::string_view checked_source = R"ptx(
+.version 0.9
+.target sm_80
+.entry kernel() {
+  .reg .u32 %r<3>;
+  add.u32 %r0, %r1, %r2;
+}
+)ptx";
+  const auto unchecked_ast = parseModule(unchecked_source);
+  const auto checked_ast = parseModule(checked_source);
+  ASSERT_TRUE(unchecked_ast);
+  ASSERT_TRUE(checked_ast);
+  const auto unchecked_module = resolveModule(*unchecked_ast);
+  ASSERT_TRUE(unchecked_module.has_value())
+      << unchecked_module.error().front().message;
+  const auto expected =
+      checkModuleAvailability(*checked_ast, *unchecked_module);
+  ASSERT_FALSE(expected.has_value());
+  ASSERT_EQ(expected.error().size(), 1u);
+
+  const auto resolved = resolveModule(*checked_ast);
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), expected.error().size());
+  expectCheckerProjection(resolved.error().front(), expected.error().front());
+  EXPECT_EQ(resolved.error().front().checker_kind,
+            checker::CheckDiagnosticKind::UnsupportedPtxVersion);
+}
+
+/** Native instruction-resolution errors retain no imported category or stage. */
+TEST(ModuleDiagnostics, NativeResolutionFailureDefaultsToResolutionStage) {
+  const auto ast = parseModule(R"ptx(
+.entry kernel() {
+  .reg .b32 %b<2>;
+  match.all.sync.b32 _|_, %b1, 0xffffffff;
+}
+)ptx");
+  ASSERT_TRUE(ast);
+  const auto& function =
+      std::get<syntax_ast::AstFunction>(ast->items.front());
+  const auto& instruction =
+      std::get<syntax_ast::AstInstruction>(function.body.back());
+  const auto resolved = resolveModule(*ast);
+
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_FALSE(resolved.error().empty());
+  const ResolveDiagnostic& diagnostic = resolved.error().front();
+  EXPECT_EQ(diagnostic.stage(), ResolveDiagnosticStage::Resolution);
+  EXPECT_EQ(diagnostic.range, sourceRange(instruction.operands.front()));
+  EXPECT_FALSE(diagnostic.binding_kind);
+  EXPECT_FALSE(diagnostic.declaration_kind);
+  EXPECT_FALSE(diagnostic.checker_kind);
+  EXPECT_FALSE(diagnostic.previous_range);
+}
+
+/** Module diagnostics own all data needed after parser, source, and AST destruction. */
+TEST(ModuleDiagnostics, OwnsDiagnosticDataAfterAstAndSourceDestruction) {
+  const ModuleResolveDiagnostics diagnostics = diagnosticsAfterInputDies();
+
+  ASSERT_EQ(diagnostics.size(), 1u);
+  EXPECT_EQ(diagnostics.front().stage(), ResolveDiagnosticStage::Binding);
+  EXPECT_EQ(diagnostics.front().binding_kind,
+            binding::BindDiagnosticKind::UnresolvedReference);
+  EXPECT_EQ(diagnostics.front().message,
+            "Unresolved instruction operand '%missing'.");
+  EXPECT_EQ(diagnostics.front().range, (SourceRange{{4, 17}, {4, 25}}));
+  EXPECT_FALSE(diagnostics.front().previous_range);
+}
+
+/** Existing positional two- and four-field diagnostic initializers remain valid. */
+TEST(ModuleDiagnostics, PreservesLegacyAggregateInitialization) {
+  static_assert(std::is_aggregate_v<ResolveDiagnostic>);
+  const ResolveDiagnostic native{SourceRange{{1, 1}, {1, 2}}, "native"};
+  const ResolveDiagnostic semantic{
+      SourceRange{{2, 1}, {2, 2}}, "semantic",
+      declaration_semantics::DeclarationDiagnosticKind::InvalidAlignment,
+      SourceRange{{1, 1}, {1, 2}}};
+
+  EXPECT_EQ(native.stage(), ResolveDiagnosticStage::Resolution);
+  EXPECT_EQ(semantic.stage(), ResolveDiagnosticStage::DeclarationSemantics);
+  EXPECT_EQ(semantic.previous_range, (SourceRange{{1, 1}, {1, 2}}));
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir


### PR DESCRIPTION
`resolveModule()` discarded binding/checker diagnostic categories and binding-related declaration locations, leaving consumers to interpret message text. Preserve the original typed categories and all available source locations through the unified resolution result.

- Append `binding_kind` and `checker_kind` to `ResolveDiagnostic`, retaining the existing `range`, `message`, `declaration_kind`, and `previous_range` fields in order.
- Add `ResolveDiagnosticStage` and `stage()` to identify the originating stage from its typed category. Existing native resolver errors remain uncoded and report `Resolution`.
- Preserve diagnostic ordering, early-return behavior, and existing declaration/storage diagnostics.
- Add seven regressions for exact projection, related locations, mixed-stage ordering, storage errors, checker errors, native errors, source lifetime, and aggregate initialization; exercise the public API in the installed consumer.
- Align the README and English/Chinese design documentation.

Validation:

- Debug builds of `test_resolved_ir` and `test_modern_operand_codegen` passed.
- All 490 resolved-IR tests and 9 generated-code integration tests passed.
- Installed-package API smoke passed, including the new diagnostic/lifetime check.
- `git diff --check` passed; independent static review found no blocking issues.

The public aggregate grows, so downstream binaries must be rebuilt; existing two-/four-field aggregate initialization remains source-compatible. Release, full package acceptance, sanitizer, and hosted CI results are not claimed by this validation.

Fixes #72
