### PR TITLE
fix(semantic): preserve repeated branch target destinations

### DIFF
--- a/docs/us-en/control_flow_syntax_design.md
+++ b/docs/us-en/control_flow_syntax_design.md
@@ -129,7 +129,9 @@ canonical signatures.
 ordered list preserves ordinary labels and compact entries such as `N<5>`;
 the latter retain name, count, angle punctuation, and one entry range without
 expanding into synthetic labels. Declaration semantics checks local-label
-membership, compact overlap, and count validity without adding symbols.
+membership and count validity without adding symbols. Repeated destinations,
+including overlapping compact entries, retain their order and multiplicity;
+each expanded occurrence denotes a separate index slot.
 `brx.idx` consumes the declaration by stable local identity without expanding
 its entries.
 

--- a/docs/us-en/declaration_semantics_design.md
+++ b/docs/us-en/declaration_semantics_design.md
@@ -79,7 +79,9 @@ members are rejected with both member ranges, and every valid member must have
 the same canonical `FunctionSignature`. `.branchtargets` members must be labels
 in the owning function; forward labels are valid. Compact entries such as
 `N<5>` are checked against the existing local labels without creating synthetic
-symbols, and report the compact-entry range for missing or overlapping labels.
+symbols, and report the compact-entry range for missing labels. The branch
+table is an ordered index sequence: repeated explicit destinations and overlaps
+with or between compact entries are valid and are not deduplicated.
 
 `.callprototype` rejects `.noreturn` with return parameters, applies existing
 alignment/array-extent checks to its formals, and requires an array formal to

--- a/docs/zh-han/control_flow_syntax_design.md
+++ b/docs/zh-han/control_flow_syntax_design.md
@@ -94,7 +94,8 @@ canonical signature 相同。
 `.branchtargets` 现在有自己的 function-body CST/AST node。其非空且有序的 list 会保留
 普通 label 与 `N<5>` 这样的 compact entry；后者保留 name、count、angle punctuation 和单项
 range，不会展开为 synthetic label。declaration semantics 在不增加 symbol 的前提下检查 local label
-membership、compact overlap 与 count validity。`brx.idx` 以 stable local identity 使用该
+membership 与 count validity。重复目标（包括交叠的 compact entry）保留原有顺序及重复次数；
+展开后的每次出现均占据独立索引槽。`brx.idx` 以 stable local identity 使用该
 declaration，但不会展开其中 entry。
 
 对于 module 中的 direct named call，resolution 会查找 callee 的 canonical

--- a/docs/zh-han/declaration_semantics_design.md
+++ b/docs/zh-han/declaration_semantics_design.md
@@ -66,7 +66,8 @@ function prototype 与 definition 各自仍拥有 lexical scope。function symbo
 此前已声明的 device `.func`；重复 member 会以两个 member range 诊断，所有有效 member 必须有
 相同的 canonical `FunctionSignature`。`.branchtargets` member 必须是所属 function 中的 label，
 允许 forward label。`N<5>` 这样的 compact entry 会基于已有 local label 检查，不创建 synthetic
-symbol；缺失或 overlap label 使用 compact-entry range 诊断。
+symbol；缺失 label 使用 compact-entry range 诊断。分支表是有序的索引序列：允许显式目标
+重复、compact 与显式目标交叠，以及 compact entry 之间交叠，不对这些目标去重。
 
 `.callprototype` 拒绝同时出现 return parameter 与 `.noreturn`，对 formal 使用既有
 alignment/array-extent 检查，并要求 array formal 使用 `.param`。duplicate declaration label 仍由

--- a/submod/resolved_ir/test/test_branch_target_repetition.cpp
+++ b/submod/resolved_ir/test/test_branch_target_repetition.cpp
@@ -1,0 +1,119 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Repeated destinations retain their index slots and the bound table identity. */
+TEST(BranchTargetRepetition, PreservesExplicitAndCompactSequences) {
+  const std::vector<std::pair<std::string, std::vector<std::string>>> cases{
+      {"L0, L0, L1", {"L0", "L0", "L1"}},
+      {"L<2>, L0", {"L0", "L1", "L0"}},
+      {"L1, L<2>", {"L1", "L0", "L1"}},
+      {"L<2>, L<2>", {"L0", "L1", "L0", "L1"}},
+  };
+  for (const auto& [entries, expected] : cases) {
+    SCOPED_TRACE(entries);
+    const std::string source =
+        ".version 6.0\n.target sm_30\n.entry k() {\n.reg .u32 %idx;\n"
+        "targets: .branchtargets " + entries +
+        ";\nmov.u32 %idx, 1;\nbrx.idx %idx, targets;\nL0: ret;\nL1: ret;\n}";
+    PtxSyntaxParser parser(source);
+    const auto ast = parser.parseModule();
+    ASSERT_TRUE(ast);
+    ASSERT_TRUE(ast.diagnostics.empty());
+    const auto resolved = resolveModule(*ast);
+    ASSERT_TRUE(resolved) << resolved.error().front().message;
+    const auto& function = resolved->functions.front();
+    const auto scope = resolved->symbols.symbol(function.symbol_id).owned_scope;
+    ASSERT_TRUE(scope);
+    const auto table_symbol = resolved->symbols.lookup(*scope, "targets");
+    ASSERT_TRUE(table_symbol);
+    ASSERT_EQ(function.body.size(), 4u);
+    const auto& branch = std::get<Brx::Idx>(std::get<Brx>(function.body[1]).variant);
+    EXPECT_EQ(branch.tlist.value.symbol_id, table_symbol->symbol);
+    EXPECT_EQ(resolved->symbols.symbol(table_symbol->symbol).kind,
+              binding::SymbolKind::BranchTargetSet);
+
+    const auto& syntax_function = std::get<syntax_ast::AstFunction>(ast->items.back());
+    const auto& table = std::get<syntax_ast::AstBranchTargets>(syntax_function.body[1]);
+    // Expand only in this assertion: the public AST retains compact entries.
+    std::vector<std::string> expanded;
+    std::string retained_entries;
+    for (const auto& entry : table.targets) {
+      if (!retained_entries.empty())
+        retained_entries += ", ";
+      retained_entries += entry.name.syntax.text;
+      if (entry.count) {
+        retained_entries += "<" + entry.count->text + ">";
+        for (unsigned index = 0; index < std::stoul(entry.count->text); ++index)
+          expanded.push_back(entry.name.syntax.text + std::to_string(index));
+      } else {
+        expanded.push_back(entry.name.syntax.text);
+      }
+    }
+    EXPECT_EQ(retained_entries, entries);
+    EXPECT_EQ(expanded, expected);
+    for (const auto& name : expanded) {
+      const auto label = resolved->symbols.lookup(*scope, name);
+      ASSERT_TRUE(label);
+      EXPECT_EQ(resolved->symbols.symbol(label->symbol).kind, binding::SymbolKind::Label);
+    }
+  }
+}
+
+/** Repetition does not make missing or cross-function destinations valid. */
+TEST(BranchTargetRepetition, RejectsMissingAndForeignLabels) {
+  for (const std::string suffix : {"", ".func other() { Missing: ret; }"}) {
+    SCOPED_TRACE(suffix);
+    const std::string source =
+        ".entry k() {\n.reg .u32 %idx;\n"
+        "targets: .branchtargets Missing, Missing;\n"
+        "brx.idx %idx, targets;\n}\n" + suffix;
+    PtxSyntaxParser parser(source);
+    const auto ast = parser.parseModule();
+    ASSERT_TRUE(ast);
+    ASSERT_TRUE(ast.diagnostics.empty());
+    const auto& function = std::get<syntax_ast::AstFunction>(ast->items.front());
+    const auto& table = std::get<syntax_ast::AstBranchTargets>(function.body[1]);
+    const auto resolved = resolveModule(*ast);
+    ASSERT_FALSE(resolved);
+    ASSERT_EQ(resolved.error().size(), 2u);
+    for (size_t index = 0; index < 2; ++index) {
+      EXPECT_EQ(resolved.error()[index].declaration_kind,
+                declaration_semantics::DeclarationDiagnosticKind::UnresolvedMetadataTarget);
+      EXPECT_EQ(resolved.error()[index].range, table.targets[index].range);
+    }
+  }
+}
+
+/** Repeated table members remain distinct from duplicate label definitions. */
+TEST(BranchTargetRepetition, RejectsDuplicateLabelDefinitions) {
+  PtxSyntaxParser parser(R"ptx(
+.entry k() {
+  targets: .branchtargets L0, L0;
+L0: ret;
+L0: ret;
+}
+)ptx");
+  const auto ast = parser.parseModule();
+  ASSERT_TRUE(ast);
+  ASSERT_TRUE(ast.diagnostics.empty());
+  const auto resolved = resolveModule(*ast);
+  ASSERT_FALSE(resolved);
+  ASSERT_EQ(resolved.error().size(), 1u);
+  EXPECT_EQ(resolved.error().front().binding_kind,
+            binding::BindDiagnosticKind::DuplicateSymbol);
+  EXPECT_EQ(resolved.error().front().range.start.line, 5);
+  ASSERT_TRUE(resolved.error().front().previous_range);
+  EXPECT_EQ(resolved.error().front().previous_range->start.line, 4);
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -542,20 +542,6 @@ std::optional<uint64_t> positiveCount(std::string_view text) {
   return count;
 }
 
-bool compactTargetsOverlap(std::string_view existing_prefix,
-                           uint64_t existing_count,
-                           std::string_view candidate_prefix,
-                           uint64_t candidate_count) {
-  const std::string existing_first = std::string{existing_prefix} + "0";
-  const std::string candidate_first = std::string{candidate_prefix} + "0";
-  const auto candidate_in_existing =
-      compactLabelIndex(existing_prefix, candidate_first);
-  const auto existing_in_candidate =
-      compactLabelIndex(candidate_prefix, existing_first);
-  return (candidate_in_existing && *candidate_in_existing < existing_count) ||
-         (existing_in_candidate && *existing_in_candidate < candidate_count);
-}
-
 /** Normalize known effective alignment while retaining invalid source for diagnostics. */
 std::optional<std::string> parameterAlignmentContract(
     const std::optional<syntax_ast::AstSyntax>& explicit_alignment,
@@ -1247,6 +1233,12 @@ class Checker {
     }
   }
 
+  /**
+   * Validate every .branchtargets slot against labels in its enclosing function.
+   *
+   * Repeated explicit and compact destinations are legal and retain their AST
+   * ordering; this check only validates each destination independently.
+   */
   void checkBranchTargets(
       binding::ScopeId function_scope,
       const syntax_ast::AstBranchTargets& targets) {
@@ -1258,35 +1250,8 @@ class Checker {
       }
     }
 
-    struct CompactTarget {
-      std::string_view prefix;
-      uint64_t count;
-      SourceRange range;
-    };
-    std::unordered_map<std::string, SourceRange> seen_labels;
-    std::vector<CompactTarget> seen_compact_targets;
-    const auto check_label = [this, function_scope, &labels, &seen_labels,
-                              &seen_compact_targets](std::string_view name,
-                                                     SourceRange range) {
-      const auto [previous, inserted] =
-          seen_labels.emplace(std::string{name}, range);
-      if (!inserted) {
-        diagnose(DeclarationDiagnosticKind::DuplicateMetadataTarget, range,
-                 fmt::format("Duplicate .branchtargets member '{}'.", name),
-                 previous->second);
-      } else {
-        for (const auto& compact : seen_compact_targets) {
-          const auto index = compactLabelIndex(compact.prefix, name);
-          if (index && *index < compact.count) {
-            diagnose(DeclarationDiagnosticKind::DuplicateMetadataTarget,
-                     range,
-                     fmt::format("Duplicate .branchtargets member '{}'.",
-                                 name),
-                     compact.range);
-            break;
-          }
-        }
-      }
+    const auto check_label = [this, function_scope, &labels](
+                                 std::string_view name, SourceRange range) {
       const auto label = labels.find(name);
       if (label == labels.end()) {
         const auto bound = symbols_.lookup(function_scope, name);
@@ -1320,32 +1285,6 @@ class Checker {
         continue;
       }
 
-      std::optional<SourceRange> duplicate_range;
-      for (const auto& compact : seen_compact_targets) {
-        if (compactTargetsOverlap(compact.prefix, compact.count,
-                                  target.name.syntax.text, *count)) {
-          duplicate_range = compact.range;
-          break;
-        }
-      }
-      if (!duplicate_range) {
-        for (const auto& [label, range] : seen_labels) {
-          const auto index =
-              compactLabelIndex(target.name.syntax.text, label);
-          if (index && *index < *count) {
-            duplicate_range = range;
-            break;
-          }
-        }
-      }
-      if (duplicate_range) {
-        diagnose(DeclarationDiagnosticKind::DuplicateMetadataTarget,
-                 target.range,
-                 fmt::format("Duplicate .branchtargets member '{}<{}>'.",
-                             target.name.syntax.text, target.count->text),
-                 *duplicate_range);
-      }
-
       uint64_t matched = 0;
       for (const auto& entry : labels) {
         const auto index =
@@ -1361,8 +1300,6 @@ class Checker {
                              "not declared in the current function.",
                              target.name.syntax.text, target.count->text));
       }
-      seen_compact_targets.push_back(
-          CompactTarget{target.name.syntax.text, *count, target.range});
     }
   }
 

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -664,7 +664,7 @@ N1:
   EXPECT_TRUE(result.binding.diagnostics.empty());
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::DuplicateMetadataTarget),
-            3u);
+            1u);
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::UnresolvedMetadataTarget),
             3u);
@@ -682,16 +682,16 @@ N1:
                             DeclarationDiagnosticKind::InvalidArrayDimension),
             1u);
 
-  const auto compact_duplicate = std::ranges::find_if(
+  const auto duplicate_call_target = std::ranges::find_if(
       result.diagnostics, [](const auto& diagnostic) {
         return diagnostic.kind ==
                    DeclarationDiagnosticKind::DuplicateMetadataTarget &&
-               diagnostic.message.find("N<2>") != std::string::npos;
+               diagnostic.message.find(".calltargets") != std::string::npos;
       });
-  ASSERT_NE(compact_duplicate, result.diagnostics.end());
-  ASSERT_TRUE(compact_duplicate->previous_range.has_value());
-  EXPECT_EQ(compact_duplicate->previous_range->start.line, 10);
-  EXPECT_EQ(compact_duplicate->range.start.line, 10);
+  ASSERT_NE(duplicate_call_target, result.diagnostics.end());
+  ASSERT_TRUE(duplicate_call_target->previous_range.has_value());
+  EXPECT_EQ(duplicate_call_target->previous_range->start.line, 9);
+  EXPECT_EQ(duplicate_call_target->range.start.line, 9);
 
   const auto incompatible = std::ranges::find_if(
       result.diagnostics, [](const auto& diagnostic) {
@@ -705,7 +705,7 @@ N1:
 }
 
 TEST(PtxDeclarationSemantics,
-     DiagnosesSymbolicDuplicateBranchTargetsBeforeResolution) {
+     AllowsRepeatedSymbolicBranchTargetsWhileCheckingEachDestination) {
   const CheckedModule result = check(R"ptx(
 .func dispatch() {
   branches: .branchtargets Missing, Missing, N<3>, N<2>;
@@ -715,13 +715,31 @@ TEST(PtxDeclarationSemantics,
   EXPECT_TRUE(result.binding.diagnostics.empty());
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::DuplicateMetadataTarget),
-            2u);
+            0u);
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::UnresolvedMetadataTarget),
             4u);
 }
 
-TEST(PtxDeclarationSemantics, DiagnosesOverlappingCompactBranchTargetPrefixes) {
+TEST(PtxDeclarationSemantics, AllowsOverlappingBranchTargetDestinations) {
+  const CheckedModule result = check(R"ptx(
+.func dispatch() {
+N0:
+N1:
+N2:
+N3:
+N10:
+N11:
+  branches: .branchtargets N0, N0, N<4>, N<2>, N1<2>;
+}
+)ptx");
+
+  EXPECT_TRUE(result.binding.diagnostics.empty());
+  EXPECT_TRUE(result.diagnostics.empty());
+}
+
+TEST(PtxDeclarationSemantics,
+     ReportsMissingLabelsForDistinctCompactBranchTargetPrefixes) {
   const CheckedModule result = check(R"ptx(
 .func dispatch() {
   branches: .branchtargets N<20>, N1<2>;
@@ -731,7 +749,7 @@ TEST(PtxDeclarationSemantics, DiagnosesOverlappingCompactBranchTargetPrefixes) {
   EXPECT_TRUE(result.binding.diagnostics.empty());
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::DuplicateMetadataTarget),
-            1u);
+            0u);
   EXPECT_EQ(diagnosticCount(result,
                             DeclarationDiagnosticKind::UnresolvedMetadataTarget),
             2u);


### PR DESCRIPTION
## Summary

- Allow repeated explicit destinations and compact-entry overlaps in .branchtargets without deduplicating or reordering the AST.
- Preserve missing-label, current-function, compact-count, and duplicate label definition checks; leave .calltargets duplicate checks unchanged.
- Add real frontend regression tests for ordered slots, compact entries, bound table identity, and diagnostic ranges; update bilingual documentation.
- This fixes input validation only; downstream owned metadata payload remains outside this change.

## Stack

Depends on #108 (fix/93), which depends on #107. Merge the parent PRs first, then retarget this PR to main.

Fixes #95 (when merged into the default branch).

## Validation

- Reproduced the rejection through the real frontend before the fix.
- 40 semantic tests passed.
- 497 resolved IR tests passed.
- 9 modern operand code-generation tests passed.
- git diff --check passed.