### PR TITLE
fix(spec): accept compatible same-width register declarations

### DIFF
--- a/docs/register_type_policy_ptxas.json
+++ b/docs/register_type_policy_ptxas.json
@@ -1,0 +1,210 @@
+{
+  "description": "Reconstructed issue #106 modules, not the unavailable round-seven attachment.",
+  "ptxas_version": "CUDA 13.1, V13.1.115; Build cuda_13.1.r13.1/compiler.37061995_0",
+  "ptxas_command": "/usr/local/cuda/bin/ptxas -arch=sm_80 -O0 CASE.ptx -o CASE.cubin",
+  "fixture_ptx_version": "8.0",
+  "fixture_target": "sm_80",
+  "project_specification": "PTX ISA 9.3 (CUDA 13.3.0 archive)",
+  "frontend_revision": "fix/issue_106 working tree based on c6e5e2d5503b6f8a7d01dca7e7cb43e33f78719a, including uncommitted policy fix",
+  "frontend_exit_codes": {
+    "0": "accepted",
+    "1": "explicit generated checking rejected",
+    "2": "parse failure",
+    "3": "module resolution (including target-aware checking) rejected",
+    "4": "driver input error"
+  },
+  "driver_source": "#include <fstream>\n#include <iostream>\n#include <iterator>\n#include <string>\n#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>\n#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>\n\n/** Check one PTX 8.0/sm_80 module; distinct exits expose parse/resolve failures. */\nint main(int argc, char** argv) {\n  using namespace ptx_frontend;\n  using namespace ptx_frontend::resolved_ir;\n  if (argc != 2) return 4;\n  std::ifstream input(argv[1]);\n  if (!input) return 4;\n  const std::string source{std::istreambuf_iterator<char>{input}, {}};\n  PtxSyntaxParser parser(source);\n  const auto ast = parser.parseModule();\n  if (!ast || !ast.diagnostics.empty()) return 2;\n  const auto module = resolveModule(*ast);\n  if (!module) {\n    for (const auto& diagnostic : module.error())\n      std::cout << (diagnostic.checker_kind ? \"checker: \" : \"resolution: \")\n                << diagnostic.message << '\\n';\n    return 3;\n  }\n  const checker::Context context{.target = {.ptx_version = {8, 0}, .sm_version = 80}};\n  bool valid = true;\n  for (const auto& function : module->functions) {\n    for (const auto& instruction : function.body) {\n      const auto checked = std::visit(\n          [&context](const auto& value) { return checker::check(value, context); },\n          instruction);\n      if (!checked) {\n        valid = false;\n        for (const auto& diagnostic : checked.error())\n          std::cout << diagnostic.message << '\\n';\n      }\n    }\n  }\n  return valid ? 0 : 1;\n}\n",
+  "summary": {
+    "cases": 23,
+    "accepted": 15,
+    "rejected": 8,
+    "accept_reject_agreement": 23,
+    "ptxas_warnings": 0
+  },
+  "cases": [
+    {
+      "name": "mul_u",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .u32 a,b;\n.reg .u64 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "mul_b",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 a,b;\n.reg .b64 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "mul_s",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .s32 a,b;\n.reg .s64 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "mul_bad_width",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b64 a,b;\n.reg .b64 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'src1' has declared type 'B64' but instruction type source 'fixed scalar type' is 'U32'.\nchecker: Register operand 'src2' has declared type 'B64' but instruction type source 'fixed scalar type' is 'U32'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas mul_bad_width.ptx, line 7; error   : Arguments mismatch for instruction 'mul.wide'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "mul_bad_float",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .f32 a,b;\n.reg .u64 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'src1' has declared type 'F32' but instruction type source 'fixed scalar type' is 'U32'.\nchecker: Register operand 'src2' has declared type 'F32' but instruction type source 'fixed scalar type' is 'U32'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas mul_bad_float.ptx, line 7; error   : Arguments mismatch for instruction 'mul.wide'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "mul_bad_result",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .u32 a,b;\n.reg .u32 d;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'dst' has declared type 'U32' but instruction type source 'fixed scalar type' is 'U64'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas mul_bad_result.ptx, line 7; error   : Arguments mismatch for instruction 'mul.wide'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "bit_counts",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 d,a;\n.reg .b64 b;\npopc.b32 d,a;\nclz.b32 d,a;\nclz.b64 d,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "mad_wide_b",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 a,b;\n.reg .b64 d,c;\nmad.wide.u32 d,a,b,c;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "mad_float_b",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 d,a,b,c;\nmad.rn.f32 d,a,b,c;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "bfind_bfe_s",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .s32 d,a;\nbfind.shiftamt.u32 d,a;\nbfe.u32 d,a,0,8;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "float_ops_b",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 d,a,b;\n.reg .b64 x,y,z;\ndiv.rn.f32 d,a,b;\ndiv.rn.f64 x,y,z;\nmin.NaN.f32 d,a,b;\nmax.NaN.f32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "neg_b32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 d,a;\nneg.f16x2 d,a;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "cvt_b32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 d;\n.reg .b32 a,b;\ncvt.rn.f16x2.f32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "neg_f16x2",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .f16x2 d,a;\nneg.f16x2 d,a;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "cvt_f16x2",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .f16x2 d;\n.reg .b32 a,b;\ncvt.rn.f16x2.f32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "neg_u32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .u32 d,a;\nneg.f16x2 d,a;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'dst' has declared type 'U32' but instruction type source 'fixed scalar type' is 'F16x2'.\nchecker: Register operand 'src' has declared type 'U32' but instruction type source 'fixed scalar type' is 'F16x2'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas neg_u32.ptx, line 6; error   : Arguments mismatch for instruction 'neg'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "cvt_u32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .u32 d;\n.reg .b32 a,b;\ncvt.rn.f16x2.f32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'dst' has declared type 'U32' but instruction type source 'fixed scalar type' is 'F16x2'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas cvt_u32.ptx, line 7; error   : Arguments mismatch for instruction 'cvt'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "neg_f32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .f32 d,a;\nneg.f16x2 d,a;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'dst' has declared type 'F32' but instruction type source 'fixed scalar type' is 'F16x2'.\nchecker: Register operand 'src' has declared type 'F32' but instruction type source 'fixed scalar type' is 'F16x2'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas neg_f32.ptx, line 6; error   : Arguments mismatch for instruction 'neg'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "cvt_f32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .f32 d;\n.reg .b32 a,b;\ncvt.rn.f16x2.f32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'dst' has declared type 'F32' but instruction type source 'fixed scalar type' is 'F16x2'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas cvt_f32.ptx, line 7; error   : Arguments mismatch for instruction 'cvt'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "bf16_b16",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b16 d,a,b,c;\nfma.rn.bf16 d,a,b,c;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "bf16_bad_f16",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b16 d,b,c;\n.reg .f16 a;\nfma.rn.bf16 d,a,b,c;\nret;\n}\n",
+      "frontend_exit": 3,
+      "frontend_diagnostics": "checker: Register operand 'src1' has declared type 'F16' but instruction type source 'fixed scalar type' is 'B16'.",
+      "ptxas_exit": 255,
+      "ptxas_diagnostics": "ptxas bf16_bad_f16.ptx, line 7; error   : Arguments mismatch for instruction 'fma'\nptxas fatal   : Ptx assembly aborted due to errors"
+    },
+    {
+      "name": "mask_u32",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .u32 d,m;\n.reg .pred p;\nactivemask.b32 d;\nvote.sync.ballot.b32 d,p,m;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    },
+    {
+      "name": "kernel_original",
+      "source": ".version 8.0\n.target sm_80\n.address_size 64\n.visible .entry k() {\n.reg .b32 a,b;\n.reg .b64 d;\nmov.b32 a,2;\nmov.b32 b,3;\nmul.wide.u32 d,a,b;\nret;\n}\n",
+      "frontend_exit": 0,
+      "frontend_diagnostics": "",
+      "ptxas_exit": 0,
+      "ptxas_diagnostics": ""
+    }
+  ]
+}

--- a/docs/us-en/register_type_policy.md
+++ b/docs/us-en/register_type_policy.md
@@ -1,0 +1,86 @@
+# Register declaration compatibility
+
+## Contract
+
+`register_width: same_width` checks both width and fundamental-type
+compatibility. It is not enum identity: bit-size registers can carry compatible
+same-width integer or floating operands, and signed/unsigned integer declarations
+can be interchanged at the same width. Integer/float substitutions remain errors.
+`mul.wide.u32` and `mad.wide.u32` still require 32-bit multiplicands and a 64-bit
+result (and 64-bit addend for `mad`). No wider-register relaxation is introduced.
+
+`exact` retains its existing enum-identity meaning. It is appropriate for
+explicit declaration-format requirements, not ordinary arithmetic merely because
+its width is fixed. `equal_or_wider` and immediate conversion are unchanged.
+Resolution still builds the same IR; generated checking applies the descriptor
+policy to bound register declarations. Resolving a module alone is not a claim
+that its instructions pass checking.
+
+## Normative source ledger
+
+The project specification is PTX ISA 9.3. This correction uses the
+[CUDA 13.3.0 archived PTX ISA 9.3 manual](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html),
+retrieved 2026-09-10: sections 5.2.1 and 9.4/Table 26 for fundamental
+compatibility; 9.7.1.3/9.7.1.4 for wide integer operands; 5.2.3/5.2.5 for
+alternate and packed declaration formats. The moving unversioned manual is not
+used as a frozen edition.
+
+## Verification boundary
+
+The audit starts from `c6e5e2d5503b6f8a7d01dca7e7cb43e33f78719a`:
+106 explicit `exact` declarations across three specification files. The scoped
+decisions are:
+
+| Consumers | Policy decision |
+| --- | --- |
+| `mul/mad.wide.u32`, `popc/clz`, `bfind/bfe`, ordinary `mad/div/min/max` float forms | Same-width fundamental compatibility; keep each operand's original width |
+| `neg.f16x2`, packed `cvt` destination | Require expected `f16x2` with `same_width`, accepting `.f16x2`/`.b32`, not arbitrary 32-bit storage |
+| `cvt` ordinary f32 operands, `mapa/getctarank`, `isspacep` | Same-width compatibility; address shape/state-space checks remain independent |
+| `vote/match/redux/elect/activemask`, mbarrier counts/parity/hints, decoded cluster CTA IDs | Same-width compatibility; masks, ranges, and target checks remain independent |
+| Alternate-format FMA (`bf16`, `bf16x2`, `f32x2`, mixed bf16 sources) | Retain exact bit-container requirements |
+| Opaque mbarrier state and cluster cancellation response | Retain exact token/response storage and shape requirements |
+| Mbarrier opaque report value | Retain existing exact `.b8` model; the audited manual does not independently establish that declaration width |
+
+This is not a full audit of wider-register `cvt` behavior. The affected f32
+operands now accept compatible **same-width** declarations; further widening
+under PTX section 9.4.1 and the `cvt` instruction rules is outside this correction.
+
+The regression suite links the real parser, resolver, compatibility helper, and
+generated checker. An independent type matrix and declaration-substitution tests
+do not obtain their expected answers from the instruction YAML. Negative cases
+check diagnostic kinds and operand ranges; descriptor assertions verify policy
+propagation without changing public IR fields.
+
+The original round-seven evidence bundle is not a prerequisite for these new
+regressions: reconstructed cases must not be reported as execution of an
+unavailable attachment. The bounded workspace search found no original bundle.
+The initial non-interactive PATH lookup did not locate `ptxas`. A subsequent
+interactive-shell check found `/usr/local/cuda/bin/ptxas`, supplied through
+`.bashrc`: CUDA 13.1, V13.1.115, build
+`cuda_13.1.r13.1/compiler.37061995_0`.
+
+The assembler and the current linked frontend were run on the **same 23
+reconstructed modules**, using `.version 8.0`, `.target sm_80` and
+`ptxas -arch=sm_80 -O0`: both accepted 15 and rejected 8, with complete
+accept/reject agreement. The assembler produced no warnings; rejected modules
+reported argument-mismatch errors and exit 255. Frontend rejections were
+generated-checker diagnostics propagated by module resolution, not parse failures.
+[Full sources, driver, exit codes, and diagnostics](../register_type_policy_ptxas.json)
+record wide mul/mad, bit counts, ordinary floating and bit operations, masks,
+packed f16x2/bf16 controls, and the issue's example kernel.
+
+This is a CUDA 13.1 comparison of those PTX 8.0 fixtures, **not** a CUDA 13.3 /
+PTX 9.3 toolchain validation or a complete exact-consumer conformance audit.
+
+Validation on 2026-09-10 used GCC 15.2.0 and Python 3.14.4. Before changing
+the specifications, the initial six linked regression groups produced five
+failures and one passing exact-bf16 control. After the correction, all 506
+resolved-IR tests (including nine register-policy groups), nine modern-operand
+code-generation tests, and 199 Python model/generator tests passed. Commands:
+
+```sh
+cmake --build out/build/ci-linux-gcc-debug --target test_resolved_ir test_modern_operand_codegen -j 4
+out/build/ci-linux-gcc-debug/submod/resolved_ir/test_resolved_ir --gtest_brief=1
+out/build/ci-linux-gcc-debug/submod/resolved_ir/test_modern_operand_codegen --gtest_brief=1
+PYTHONPATH=python .venv/bin/python -m unittest discover -s python/tests -t python -p 'test_*.py' -q
+```

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -324,7 +324,11 @@ A register operand may also select an explicit width policy:
   register_width: equal_or_wider
 ```
 
-`register_width` defaults to `same_width`. The normalizer rejects the non-default
+`register_width` defaults to `same_width`, which permits compatible fundamental
+types at the same width. `exact` instead requires identical declaration-type
+enums; reserve it for explicit format restrictions, not ordinary operands with
+a fixed width. See [register declaration compatibility](register_type_policy.md)
+for the normative source and regression boundary. The normalizer rejects the non-default
 `equal_or_wider` value on a non-register operand or an operand without a type
 expression, preventing a silent no-op. `reg_vector` operands may also use this
 policy, applying it to each vector element. The resolved operand descriptor

--- a/docs/zh-han/register_type_policy.md
+++ b/docs/zh-han/register_type_policy.md
@@ -1,0 +1,71 @@
+# 寄存器声明兼容性
+
+## Contract
+
+`register_width: same_width` 同时检查位宽和基础类型兼容性，而非枚举 identity：
+bit-size 寄存器可承载同宽兼容的整数或浮点 operand，同宽有符号与无符号整数声明可互换。
+整数与浮点之间的替换仍然非法。`mul.wide.u32` 和 `mad.wide.u32` 仍要求 32 位乘数、
+64 位结果；`mad` 的加数也必须为 64 位。本次不引入更宽寄存器放宽。
+
+`exact` 保留枚举 identity 语义，适用于显式声明格式要求，不能仅因为普通算术 operand
+位宽固定就使用它。`equal_or_wider` 和立即数转换不变。resolution 仍构造相同 IR，
+generated checker 按 descriptor policy 检查已绑定寄存器声明；仅 resolve 成功不表示
+整个模块的指令均通过 checking。
+
+## 规范来源记录
+
+工程规范版本为 PTX ISA 9.3。本次依据
+[CUDA 13.3.0 归档的 PTX ISA 9.3 手册](https://docs.nvidia.com/cuda/archive/13.3.0/parallel-thread-execution/index.html)，
+查阅日期为 2026-09-10：5.2.1 与 9.4/Table 26 规定基础类型兼容性，9.7.1.3/9.7.1.4
+规定 wide 整数 operand，5.2.3/5.2.5 规定 alternate/packed 声明格式。
+不把持续更新的无版本手册 URL 当作冻结规范版本。
+
+## 验证边界
+
+审查基线为 `c6e5e2d5503b6f8a7d01dca7e7cb43e33f78719a`，三个规格文件中共有
+106 处显式 `exact` 声明。本次决策如下：
+
+| Consumer | Policy 决策 |
+| --- | --- |
+| `mul/mad.wide.u32`、`popc/clz`、`bfind/bfe`、普通 `mad/div/min/max` 浮点形式 | 同宽基础类型兼容，保留各 operand 原有位宽 |
+| `neg.f16x2`、packed `cvt` 的 destination | expected type 使用 `f16x2` 加 `same_width`，接受 `.f16x2`/`.b32`，不接受任意 32 位存储 |
+| `cvt` 普通 f32 operand、`mapa/getctarank`、`isspacep` | 同宽兼容；address shape/state-space 检查独立保留 |
+| `vote/match/redux/elect/activemask`、mbarrier count/parity/hint、解码后的 cluster CTA ID | 同宽兼容；mask、数值范围与 target 检查独立保留 |
+| alternate-format FMA（`bf16`、`bf16x2`、`f32x2`、mixed bf16 source） | 保留 exact bit-container 要求 |
+| opaque mbarrier state 与 cluster cancellation response | 保留 exact token/response 存储及 shape 要求 |
+| mbarrier opaque report value | 保留既有 exact `.b8` 模型；本次查阅手册未独立证实其声明位宽 |
+
+本次不是更宽寄存器 `cvt` 行为的完整审查。受影响的 f32 operand 现在接受兼容的**同宽**
+声明；PTX 9.4.1 节与 `cvt` 指令规则中的进一步 widening 不属于此次修正。
+
+回归测试链接真实 parser、resolver、兼容性 helper 和 generated checker。
+独立类型矩阵与声明替换测试不从指令 YAML 推导预期结果；负向用例检查 diagnostic kind
+和 operand range，descriptor 断言检查 policy 传递，不改变公共 IR 字段。
+
+原始 round-seven evidence bundle 不是新增回归测试的前置依赖；重建用例不能被报告为
+执行了不可用附件。有界工作区搜索未找到原始 bundle。最初的非交互式 PATH 查询未定位到
+`ptxas`；随后检查交互式 shell，确认 `.bashrc` 提供了 `/usr/local/cuda/bin/ptxas`，
+版本为 CUDA 13.1、V13.1.115，build 为 `cuda_13.1.r13.1/compiler.37061995_0`。
+
+assembler 与当前链接的 frontend 读取了**同一批 23 个重建模块**，均使用
+`.version 8.0`、`.target sm_80`，assembler 命令为 `ptxas -arch=sm_80 -O0`。
+双方均接受 15 个、拒绝 8 个，接受/拒绝结果全部一致。assembler 无 warning；非法模块
+报告 argument-mismatch error，退出码为 255。frontend 的拒绝来自 module resolution
+传递的 generated-checker 诊断，而非 parse failure。
+[完整源码、driver、退出码及诊断](../register_type_policy_ptxas.json)记录了 wide mul/mad、
+位计数、普通浮点与位运算、mask、packed f16x2/bf16 控制以及 issue 的示例 kernel。
+
+这只是 CUDA 13.1 对上述 PTX 8.0 fixture 的对照，**不是** CUDA 13.3 / PTX 9.3
+工具链验证，也不代表所有 exact consumer 均已完成 conformance audit。
+
+2026-09-10 验证环境为 GCC 15.2.0、Python 3.14.4。修改规格前，首批六组 linked
+回归中五组失败，exact-bf16 对照通过。修正后，506 项 resolved-IR 测试（含九组
+register-policy 测试）、九项 modern-operand code-generation 测试及 199 项 Python
+model/generator 测试全部通过。执行命令：
+
+```sh
+cmake --build out/build/ci-linux-gcc-debug --target test_resolved_ir test_modern_operand_codegen -j 4
+out/build/ci-linux-gcc-debug/submod/resolved_ir/test_resolved_ir --gtest_brief=1
+out/build/ci-linux-gcc-debug/submod/resolved_ir/test_modern_operand_codegen --gtest_brief=1
+PYTHONPATH=python .venv/bin/python -m unittest discover -s python/tests -t python -p 'test_*.py' -q
+```

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -286,7 +286,9 @@ legacy memory-vector payload 最多 128 bit：`.v2` 到 64-bit type，`.v4` 到
   register_width: equal_or_wider
 ```
 
-`register_width` 默认为 `same_width`。normalizer 会拒绝在非 register operand 或没有 type
+`register_width` 默认为 `same_width`，允许同宽兼容基础类型。`exact` 则要求声明类型枚举
+相同，应保留给显式格式限制，而非仅位宽固定的普通 operand。规范来源及回归边界见
+[寄存器声明兼容性](register_type_policy.md)。normalizer 会拒绝在非 register operand 或没有 type
 expression 的 operand 上使用非默认 `equal_or_wider`，避免 constraint 静默失效；`reg_vector`
 operand 也可使用该 policy，并逐元素检查。resolved operand descriptor 保存该 policy，不生成
 runtime Resolved IR field。当前 scalar `ld` destination、scalar `st` source，以及 legacy

--- a/python/code_gen/resources/ptx_spec/arithmetic.yaml
+++ b/python/code_gen/resources/ptx_spec/arithmetic.yaml
@@ -40,29 +40,29 @@ operand_patterns:
     - {name: dst, kind: reg, role: dst, access: write, type: {expr: "modifier(type)"}}
     - {name: src, kind: reg, role: src, access: read, type: {expr: "modifier(type)"}}
 
-  unary_packed_b32_register_exact:
-    - {name: dst, kind: reg, role: dst, access: write, type: b32, register_width: exact}
-    - {name: src, kind: reg, role: src, access: read, type: b32, register_width: exact}
+  unary_f16x2_register:
+    - {name: dst, kind: reg, role: dst, access: write, type: f16x2, register_width: same_width}
+    - {name: src, kind: reg, role: src, access: read, type: f16x2, register_width: same_width}
 
   popc_b32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
     - {name: src, kind: reg, role: src, access: read, type: b32, register_width: same_width}
 
   clz_b32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
     - {name: src, kind: reg, role: src, access: read, type: b32, register_width: same_width}
 
   clz_b64:
-    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
     - {name: src, kind: reg, role: src, access: read, type: b64, register_width: same_width}
 
   bfind_shiftamt_u32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: exact}
-    - {name: src, kind: reg, role: src, access: read, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
+    - {name: src, kind: reg, role: src, access: read, type: u32, register_width: same_width}
 
   bfe_u32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: exact}
-    - {name: src, kind: reg, role: src1, access: read, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
+    - {name: src, kind: reg, role: src1, access: read, type: u32, register_width: same_width}
     - {name: offset, kind: imm, role: src2, access: read, type: u32}
     - {name: width, kind: imm, role: src3, access: read, type: u32}
 
@@ -78,9 +78,9 @@ operand_patterns:
     - {name: src, kind: reg, role: src, access: read, type: b32, register_width: same_width}
 
   binary_wide_u32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u64, register_width: exact}
-    - {name: src1, kind: reg_or_imm, role: src1, access: read, type: u32, register_width: exact}
-    - {name: src2, kind: reg_or_imm, role: src2, access: read, type: u32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u64, register_width: same_width}
+    - {name: src1, kind: reg_or_imm, role: src1, access: read, type: u32, register_width: same_width}
+    - {name: src2, kind: reg_or_imm, role: src2, access: read, type: u32, register_width: same_width}
 
   binary_wide_s32:
     - {name: dst, kind: reg, role: dst, access: write, type: s64}
@@ -124,10 +124,10 @@ operand_patterns:
     - {name: src3, kind: reg_or_imm, role: src3, access: read, type: {expr: "modifier(result_type)"}}
 
   ternary_wide_u32:
-    - {name: dst, kind: reg, role: dst, access: write, type: u64, register_width: exact}
-    - {name: src1, kind: reg_or_imm, role: src1, access: read, type: u32, register_width: exact}
-    - {name: src2, kind: reg_or_imm, role: src2, access: read, type: u32, register_width: exact}
-    - {name: src3, kind: reg_or_imm, role: src3, access: read, type: u64, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: u64, register_width: same_width}
+    - {name: src1, kind: reg_or_imm, role: src1, access: read, type: u32, register_width: same_width}
+    - {name: src2, kind: reg_or_imm, role: src2, access: read, type: u32, register_width: same_width}
+    - {name: src3, kind: reg_or_imm, role: src3, access: read, type: u64, register_width: same_width}
 
   binary_float_scalar:
     - name: dst
@@ -173,11 +173,6 @@ operand_patterns:
       type:
         expr: modifier(type)
 
-  binary_float_register_exact:
-    - {name: dst, kind: reg, role: dst, access: write, type: {expr: "modifier(type)"}, register_width: exact}
-    - {name: src1, kind: reg, role: src1, access: read, type: {expr: "modifier(type)"}, register_width: exact}
-    - {name: src2, kind: reg, role: src2, access: read, type: {expr: "modifier(type)"}, register_width: exact}
-
   ternary_float_register:
     - name: dst
       kind: reg
@@ -206,12 +201,6 @@ operand_patterns:
       access: read
       type:
         expr: modifier(type)
-
-  ternary_float_register_exact:
-    - {name: dst, kind: reg, role: dst, access: write, type: {expr: "modifier(type)"}, register_width: exact}
-    - {name: src1, kind: reg, role: src1, access: read, type: {expr: "modifier(type)"}, register_width: exact}
-    - {name: src2, kind: reg, role: src2, access: read, type: {expr: "modifier(type)"}, register_width: exact}
-    - {name: src3, kind: reg, role: src3, access: read, type: {expr: "modifier(type)"}, register_width: exact}
 
   binary_mixed_float_register:
     - name: dst
@@ -998,7 +987,7 @@ instructions:
     section: "9.7.3.7"
     doc: "Frozen round-to-nearest single-precision multiply-add."
     syntax: "mad.rn.f32 dst, src1, src2, src3"
-    operands: $ternary_float_register_exact
+    operands: $ternary_float_register
     variants:
       - name: mad_rn_f32
         availability: {ptx: "2.0", sm: 20}
@@ -1012,7 +1001,7 @@ instructions:
     section: "9.7.3.8"
     doc: "Frozen round-to-nearest single- and double-precision division."
     syntax: "div.rn.f32 | div.rn.f64 dst, src1, src2"
-    operands: $binary_float_register_exact
+    operands: $binary_float_register
     variants:
       - name: div_rn_f32
         availability: {ptx: "1.4", sm: 20}
@@ -1248,7 +1237,7 @@ instructions:
     section: "9.7.3.11"
     doc: "Frozen NaN-propagating single-precision minimum."
     syntax: "min.NaN.f32 dst, src1, src2"
-    operands: $binary_float_register_exact
+    operands: $binary_float_register
     variants:
       - name: min_nan_f32
         availability: {ptx: "7.0", sm: 80}
@@ -1275,7 +1264,7 @@ instructions:
     section: "9.7.3.12"
     doc: "Frozen NaN-propagating single-precision maximum."
     syntax: "max.NaN.f32 dst, src1, src2"
-    operands: $binary_float_register_exact
+    operands: $binary_float_register
     variants:
       - name: max_nan_f32
         availability: {ptx: "7.0", sm: 80}
@@ -1341,7 +1330,7 @@ instructions:
     section: "9.7.4.5"
     doc: "Frozen packed half-precision negation using b32 register containers."
     syntax: "neg.f16x2 dst, src"
-    operands: $unary_packed_b32_register_exact
+    operands: $unary_f16x2_register
     variants:
       - name: neg_f16x2
         availability: {ptx: "6.0", sm: 53}

--- a/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
+++ b/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
@@ -49,21 +49,21 @@ operand_patterns:
       access: write
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: src
       kind: cluster_address
       role: src
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
       state_space: [shared]
     - name: rank
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mapa_generic:
     - name: dst
@@ -72,20 +72,20 @@ operand_patterns:
       access: write
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: src
       kind: reg
       role: src
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: rank
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   getctarank_shared_cluster:
     - name: dst
@@ -100,7 +100,7 @@ operand_patterns:
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
       state_space: [shared]
 
   getctarank_generic:
@@ -116,7 +116,7 @@ operand_patterns:
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
 
   mov_pred:
     - name: dst
@@ -171,13 +171,13 @@ operand_patterns:
       register_width: equal_or_wider
 
   cvt_rn_f32_s32:
-    - {name: dst, kind: reg, role: dst, access: write, type: f32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: f32, register_width: same_width}
     - {name: src, kind: reg, role: src, access: read, type: s32, register_width: equal_or_wider}
 
   cvt_rn_f16x2_f32:
-    - {name: dst, kind: reg, role: dst, access: write, type: b32, register_width: exact}
-    - {name: src1, kind: reg, role: src1, access: read, type: f32, register_width: exact}
-    - {name: src2, kind: reg, role: src2, access: read, type: f32, register_width: exact}
+    - {name: dst, kind: reg, role: dst, access: write, type: f16x2, register_width: same_width}
+    - {name: src1, kind: reg, role: src1, access: read, type: f32, register_width: same_width}
+    - {name: src2, kind: reg, role: src2, access: read, type: f32, register_width: same_width}
 
   cvt_pack_sat_u8_s32_b32:
     - {name: dst, kind: reg, role: dst, access: write, type: b32, register_width: same_width}
@@ -386,7 +386,7 @@ operand_patterns:
 
   isspacep_global_u64:
     - {name: dst, kind: pred, role: dst, access: write, type: pred}
-    - {name: src, kind: reg, role: src, access: read, type: u64, register_width: exact}
+    - {name: src, kind: reg, role: src, access: read, type: u64, register_width: same_width}
 
   shfl_sync_idx:
     - name: dst

--- a/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
+++ b/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
@@ -150,7 +150,7 @@ operand_patterns:
       role: dst
       access: write
       type: b32
-      register_width: exact
+      register_width: same_width
     - name: predicate
       kind: pred
       role: predicate
@@ -168,20 +168,20 @@ operand_patterns:
       role: dst
       access: write
       type: b32
-      register_width: exact
+      register_width: same_width
     - name: src
       kind: reg
       role: src
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: membermask
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   match_all_sync_without_predicate:
     - name: dst
@@ -189,20 +189,20 @@ operand_patterns:
       role: dst
       access: write
       type: b32
-      register_width: exact
+      register_width: same_width
     - name: src
       kind: reg
       role: src
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: membermask
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   match_sync_with_predicate:
     - name: dst
@@ -210,7 +210,7 @@ operand_patterns:
       role: dst
       access: write
       type: b32
-      register_width: exact
+      register_width: same_width
       allow_destination_sink: true
       allow_predicate_sink: true
     - name: src
@@ -219,13 +219,13 @@ operand_patterns:
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: membermask
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   redux_sync:
     - name: dst
@@ -234,20 +234,20 @@ operand_patterns:
       access: write
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: src
       kind: reg
       role: src
       access: read
       type:
         expr: modifier(type)
-      register_width: exact
+      register_width: same_width
     - name: membermask
       kind: reg_or_imm
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_init:
     - name: address
@@ -260,7 +260,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_inval:
     - name: address
@@ -280,7 +280,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_arrive_cta:
     - name: state
@@ -316,7 +316,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_arrive_cluster:
     - name: state
@@ -352,7 +352,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_arrive_expect_tx_cta:
     - name: state
@@ -373,7 +373,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_arrive_expect_tx_cluster:
     - name: state
@@ -394,7 +394,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_test_wait_token:
     - {name: wait_complete, kind: pred, role: dst, access: write, type: pred}
@@ -415,7 +415,7 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
+      register_width: same_width
 
   mbarrier_try_wait_token_hint:
     - {name: wait_complete, kind: pred, role: dst, access: write, type: pred}
@@ -427,7 +427,7 @@ operand_patterns:
       type: b64
       register_width: exact
       mbarrier_state_token_form: register
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
 
   mbarrier_try_wait_parity_hint:
     - {name: wait_complete, kind: pred, role: dst, access: write, type: pred}
@@ -437,8 +437,8 @@ operand_patterns:
       role: src
       access: read
       type: u32
-      register_width: exact
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+      register_width: same_width
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
 
   mbarrier_wait_token_report_predicate:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
@@ -452,34 +452,34 @@ operand_patterns:
   mbarrier_wait_parity_report_predicate:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
-    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   mbarrier_wait_parity_report_predicate_value:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: report_value, kind: reg, role: dst, access: write, type: b8, register_width: exact}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
-    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   mbarrier_try_wait_token_report_predicate_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: state, kind: mbarrier_state_token, role: src, access: read, type: b64, register_width: exact, mbarrier_state_token_form: register}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   mbarrier_try_wait_token_report_predicate_value_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: report_value, kind: reg, role: dst, access: write, type: b8, register_width: exact}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: state, kind: mbarrier_state_token, role: src, access: read, type: b64, register_width: exact, mbarrier_state_token_form: register}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   mbarrier_try_wait_parity_report_predicate_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
-    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   mbarrier_try_wait_parity_report_predicate_value_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: report_value, kind: reg, role: dst, access: write, type: b8, register_width: exact}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
-    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: exact}
+    - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
   fence_proxy_acquire:
     - {name: address, kind: addr, role: addr, access: read, state_space: [global]}
     - {name: size, kind: imm, role: src, access: read, type: u32}
@@ -495,11 +495,11 @@ operand_patterns:
       role: dst
       access: write
       type: b32
-      register_width: exact
+      register_width: same_width
       vector: {kind: vector, arity: [4], type_policy: element, allow_sink: true}
     - {name: response, kind: reg, role: src, access: read, type: b128, register_width: exact}
   clusterlaunchcontrol_query_cancel_scalar:
-    - {name: ctaid, kind: reg, role: dst, access: write, type: b32, register_width: exact}
+    - {name: ctaid, kind: reg, role: dst, access: write, type: b32, register_width: same_width}
     - {name: response, kind: reg, role: src, access: read, type: b128, register_width: exact}
 instructions:
   - opcode: bar
@@ -1231,7 +1231,7 @@ instructions:
             role: dst
             access: write
             type: b32
-            register_width: exact
+            register_width: same_width
         rule: parallel_sync_and_communication.activemask
 
         examples:
@@ -1457,7 +1457,7 @@ instructions:
             role: src
             access: read
             type: u32
-            register_width: exact
+            register_width: same_width
 
   - opcode: mbarrier
     section: "9.7.14.16.12"
@@ -2394,7 +2394,7 @@ instructions:
           - {name: layout, kind: mbarrier_layout, domain: mbarrier_layouts, presence: optional, values: [{value: layout::v0, availability: {ptx: "9.3", sm: 90}}], default: layout::v0}
           - {name: type, kind: type, domain: scalar_types, presence: fixed, value: b64}
         operands:
-          - {name: count, kind: reg, role: dst, access: write, type: u32, register_width: exact}
+          - {name: count, kind: reg, role: dst, access: write, type: u32, register_width: same_width}
           - {name: state, kind: mbarrier_state_token, role: src, access: read, type: b64, register_width: exact, mbarrier_state_token_form: register}
       - name: mbarrier_check_layout_generic_v0
         section: "9.7.14.16.21"

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -412,7 +412,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 binding.register_width_policy
                 for binding in self.mul_instruction.variants[3].operand_layouts[0].bindings
             ],
-            [ResolvedRegisterWidthPolicy.EXACT] * 3,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
         )
         self.assertEqual(
             [
@@ -440,14 +440,14 @@ class ResolvedIrBuildTest(unittest.TestCase):
                 binding.register_width_policy
                 for binding in self.mad_instruction.variants[3].operand_layouts[0].bindings
             ],
-            [ResolvedRegisterWidthPolicy.EXACT] * 4,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 4,
         )
         self.assertEqual(
             [
                 binding.register_width_policy
                 for binding in self.mad_instruction.variants[0].operand_layouts[0].bindings
             ],
-            [ResolvedRegisterWidthPolicy.EXACT] * 4,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 4,
         )
 
     def test_fma_models_all_ptx_93_ternary_layouts(self) -> None:
@@ -516,7 +516,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         for variant in self.div_instruction.variants[:2]:
             self.assertEqual(
                 [binding.register_width_policy for binding in variant.operand_layouts[0].bindings],
-                [ResolvedRegisterWidthPolicy.EXACT] * 3,
+                [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
             )
 
     def test_rem_has_frozen_signed_and_unsigned_binary_variants(self) -> None:
@@ -551,7 +551,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(nan_f32.fields[1].constant_value, "f32")
         self.assertEqual(
             [binding.register_width_policy for binding in nan_f32.operand_layouts[0].bindings],
-            [ResolvedRegisterWidthPolicy.EXACT] * 3,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
         )
 
     def test_max_has_frozen_signed_and_nan_binary_variants(self) -> None:
@@ -572,7 +572,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(nan_f32.fields[1].constant_value, "f32")
         self.assertEqual(
             [binding.register_width_policy for binding in nan_f32.operand_layouts[0].bindings],
-            [ResolvedRegisterWidthPolicy.EXACT] * 3,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
         )
 
     def test_abs_has_frozen_signed_and_float_unary_variants(self) -> None:
@@ -603,7 +603,12 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             [binding.register_width_policy
              for binding in self.neg_instruction.variants[2].operand_layouts[0].bindings],
-            [ResolvedRegisterWidthPolicy.EXACT] * 2,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 2,
+        )
+        self.assertEqual(
+            [binding.type_expression.scalar_type
+             for binding in self.neg_instruction.variants[2].operand_layouts[0].bindings],
+            ["f16x2"] * 2,
         )
 
     def test_lop3_has_fixed_b32_variant_and_lut_range(self) -> None:
@@ -635,7 +640,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             [binding.register_width_policy
              for binding in variant.operand_layouts[0].bindings[:2]],
-            [ResolvedRegisterWidthPolicy.EXACT] * 2,
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 2,
         )
 
     def test_shf_has_frozen_direction_and_mode_variants(self) -> None:
@@ -1027,9 +1032,10 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
             source = output_path.read_text(encoding="utf-8")
         self.assertIn(".is_sink = !payload.dst.value.register_ref,", source)
-        for binding in (*plain, *paired):
+        for binding in (*variants["AnySync"].operand_layouts[0].bindings,
+                        *plain, *paired):
             self.assertEqual(
-                binding.register_width_policy, ResolvedRegisterWidthPolicy.EXACT
+                binding.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH
             )
 
     def test_redux_sync_model_variants_and_availability(self) -> None:
@@ -1078,7 +1084,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             self.assertEqual(len(variant.operand_layouts), 1)
             self.assertEqual(
                 [binding.register_width_policy for binding in variant.operand_layouts[0].bindings],
-                [ResolvedRegisterWidthPolicy.EXACT] * 3,
+                [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
             )
 
     def test_griddepcontrol_model_has_two_zero_operand_actions(self) -> None:
@@ -1132,7 +1138,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(result.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
         self.assertTrue(result.allow_destination_sink)
         self.assertFalse(result.allow_predicate_sink)
-        self.assertEqual(membermask.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
+        self.assertEqual(membermask.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
         self.assertFalse(membermask.allow_destination_sink)
         self.assertFalse(membermask.allow_predicate_sink)
         with tempfile.TemporaryDirectory() as directory:
@@ -1525,9 +1531,17 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ["shared"],
         )
         self.assertEqual(
+            [binding.register_width_policy for binding in shared.operand_layouts[0].bindings],
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
+        )
+        self.assertEqual(
             [binding.type_expression.scalar_type
              for binding in generic.operand_layouts[0].bindings],
             [None, None, "u32"],
+        )
+        self.assertEqual(
+            [binding.register_width_policy for binding in generic.operand_layouts[0].bindings],
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
         )
 
     def test_getctarank_uses_cluster_address_and_u32_rank_destination(self) -> None:
@@ -1576,6 +1590,10 @@ class ResolvedIrBuildTest(unittest.TestCase):
             [value.value for value in shared_source.allowed_address_state_spaces],
             ["shared"],
         )
+        self.assertEqual(
+            shared_source.register_width_policy,
+            ResolvedRegisterWidthPolicy.SAME_WIDTH,
+        )
         generic_dst, generic_source = generic.operand_layouts[0].bindings
         self.assertEqual(generic_dst.type_expression.scalar_type, "u32")
         self.assertEqual(
@@ -1583,7 +1601,54 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ResolvedRegisterWidthPolicy.SAME_WIDTH,
         )
         self.assertEqual(
+            generic_source.register_width_policy,
+            ResolvedRegisterWidthPolicy.SAME_WIDTH,
+        )
+        self.assertEqual(
             generic_source.type_expression.modifier_field_id, "type"
+        )
+
+    def test_cvt_and_isspacep_register_width_policies(self) -> None:
+        cvt = from_instruction_spec(next(
+            instruction
+            for instruction in self.database.instructions
+            if instruction.opcode == "cvt"
+        ))
+        rn_f32_s32 = next(
+            variant for variant in cvt.variants if variant.cpp_name == "RnF32S32"
+        )
+        self.assertEqual(
+            [binding.register_width_policy
+             for binding in rn_f32_s32.operand_layouts[0].bindings],
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH,
+             ResolvedRegisterWidthPolicy.EQUAL_OR_WIDER],
+        )
+        rn_f16x2_f32 = next(
+            variant for variant in cvt.variants if variant.cpp_name == "RnF16x2F32"
+        )
+        self.assertEqual(
+            [binding.type_expression.scalar_type
+             for binding in rn_f16x2_f32.operand_layouts[0].bindings],
+            ["f16x2", "f32", "f32"],
+        )
+        self.assertEqual(
+            [binding.register_width_policy
+             for binding in rn_f16x2_f32.operand_layouts[0].bindings],
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 3,
+        )
+
+        isspacep = from_instruction_spec(next(
+            instruction
+            for instruction in self.database.instructions
+            if instruction.opcode == "isspacep"
+        ))
+        global_u64 = next(
+            variant for variant in isspacep.variants if variant.cpp_name == "GlobalU64"
+        )
+        self.assertEqual(
+            [binding.register_width_policy
+             for binding in global_u64.operand_layouts[0].bindings],
+            [ResolvedRegisterWidthPolicy.SAME_WIDTH] * 2,
         )
 
     def test_mbarrier_init_models_layout_space_and_count_ranges(self) -> None:
@@ -1753,7 +1818,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(check_layout_shared_cta_v1.modifier_fields[1].constant_value, "layout::v1")
         self.assertEqual(state.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
         self.assertEqual(parity.type_expression.scalar_type, "u32")
-        self.assertEqual(parity.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
+        self.assertEqual(parity.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
         self.assertEqual(
             [(constraint.minimum, constraint.maximum)
              for constraint in test_wait_parity.immediate_ranges],
@@ -1818,7 +1883,8 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         count, state = pending_count.operand_layouts[0].bindings
         self.assertEqual(count.type_expression.scalar_type, "u32")
-        self.assertEqual(count.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
+        self.assertEqual(count.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
+        self.assertEqual(state.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
         self.assertEqual(state.mbarrier_state_token_form.value, "register")
         self.assertEqual(
             [layout.layout_id for layout in arrive_drop_generic.operand_layouts],
@@ -1842,7 +1908,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertEqual(
             arrive_generic.operand_layouts[1].bindings[-1].register_width_policy,
-            ResolvedRegisterWidthPolicy.EXACT,
+            ResolvedRegisterWidthPolicy.SAME_WIDTH,
         )
         self.assertEqual(
             [(field.name, field.cpp_type) for field in generic_v0.fields],
@@ -1879,7 +1945,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             [value.value for value in address.allowed_address_state_spaces], ["shared"]
         )
         self.assertEqual(count.type_expression.scalar_type, "u32")
-        self.assertEqual(count.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
+        self.assertEqual(count.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
         self.assertEqual(
             [(field.name, field.cpp_type) for field in inval_generic.fields],
             [
@@ -1929,7 +1995,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         complete_tx_address, complete_tx_count = complete_tx_generic.operand_layouts[0].bindings
         self.assertEqual(complete_tx_address.allowed_shapes, (ResolvedOperandShape.ADDRESS,))
         self.assertEqual(complete_tx_count.type_expression.scalar_type, "u32")
-        self.assertEqual(complete_tx_count.register_width_policy, ResolvedRegisterWidthPolicy.EXACT)
+        self.assertEqual(complete_tx_count.register_width_policy, ResolvedRegisterWidthPolicy.SAME_WIDTH)
 
     def test_mbarrier_operand_domains_are_uniform_across_variants(self) -> None:
         mbarrier = from_instruction_spec(next(
@@ -1976,7 +2042,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
             )
             self.assertEqual(binding.type_expression.scalar_type, "u32")
             self.assertEqual(binding.register_width_policy,
-                             ResolvedRegisterWidthPolicy.EXACT)
+                             ResolvedRegisterWidthPolicy.SAME_WIDTH)
 
     def test_ld_and_st_scalar_model_constraints(self) -> None:
         database = self.database
@@ -3241,7 +3307,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertEqual(
             variant.operand_layouts[0].bindings[0].register_width_policy,
-            ResolvedRegisterWidthPolicy.EXACT,
+            ResolvedRegisterWidthPolicy.SAME_WIDTH,
         )
 
     def test_vote_sync_ballot_b32_model(self) -> None:
@@ -3272,7 +3338,7 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertEqual(
             variant.operand_layouts[0].bindings[0].register_width_policy,
-            ResolvedRegisterWidthPolicy.EXACT,
+            ResolvedRegisterWidthPolicy.SAME_WIDTH,
         )
 
     def test_shfl_sync_idx_b32_model(self) -> None:

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -2205,6 +2205,8 @@ TEST(ResolvedModule, ResolvesAndChecksClusterlaunchcontrolQueryCancelSlices) {
 .entry kernel() {
   .reg .pred %p0;
   .reg .b32 %r<8>;
+  .reg .u32 %u0;
+  .reg .s32 %s0;
   .reg .b128 %q0;
   clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 %p0, %q0;
   clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 {%r0, %r1, %r2, %r3}, %q0;
@@ -2212,12 +2214,14 @@ TEST(ResolvedModule, ResolvesAndChecksClusterlaunchcontrolQueryCancelSlices) {
   clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128 %r5, %q0;
   clusterlaunchcontrol.query_cancel.get_first_ctaid::y.b32.b128 %r6, %q0;
   clusterlaunchcontrol.query_cancel.get_first_ctaid::z.b32.b128 %r7, %q0;
+  clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128 %u0, %q0;
+  clusterlaunchcontrol.query_cancel.get_first_ctaid::y.b32.b128 %s0, %q0;
 }
 )ptx");
   const auto resolved = resolveModule(ast);
   ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
   const auto& body = resolved->functions.front().body;
-  ASSERT_EQ(body.size(), 6u);
+  ASSERT_EQ(body.size(), 8u);
   EXPECT_TRUE(std::holds_alternative<Clusterlaunchcontrol::QueryCancelIsCanceledPred>(
       std::get<Clusterlaunchcontrol>(body[0]).variant));
   EXPECT_TRUE(std::holds_alternative<Clusterlaunchcontrol::QueryCancelGetFirstCtaidV4>(
@@ -2230,6 +2234,10 @@ TEST(ResolvedModule, ResolvesAndChecksClusterlaunchcontrolQueryCancelSlices) {
       std::get<Clusterlaunchcontrol>(body[4]).variant));
   EXPECT_TRUE(std::holds_alternative<Clusterlaunchcontrol::QueryCancelGetFirstCtaidZ>(
       std::get<Clusterlaunchcontrol>(body[5]).variant));
+  EXPECT_TRUE(std::holds_alternative<Clusterlaunchcontrol::QueryCancelGetFirstCtaidX>(
+      std::get<Clusterlaunchcontrol>(body[6]).variant));
+  EXPECT_TRUE(std::holds_alternative<Clusterlaunchcontrol::QueryCancelGetFirstCtaidY>(
+      std::get<Clusterlaunchcontrol>(body[7]).variant));
 
   const auto context_for = [&ast](std::string_view target,
                                   checker::PtxVersion ptx_version) {
@@ -2576,11 +2584,22 @@ TEST(ResolvedModule, ResolvesAndChecksActivemaskB32Slice) {
   EXPECT_EQ(too_old_sm.error().front().kind,
             checker::CheckDiagnosticKind::UnsupportedSmVersion);
 
-  const auto mismatched_dsts = resolveModule(parseModule(R"ptx(
+  const auto compatible_dst = resolveModule(parseModule(R"ptx(
 .entry kernel() {
   .reg .u32 %u0;
-  .reg .b64 %wide0;
   activemask.b32 %u0;
+}
+)ptx"));
+  ASSERT_TRUE(compatible_dst.has_value())
+      << compatible_dst.error().front().message;
+  EXPECT_TRUE(checker::check(
+                  std::get<Activemask>(compatible_dst->functions.front().body.front()),
+                  checker::Context{.target = {.ptx_version = {6, 2}, .sm_version = 30}})
+                  .has_value());
+
+  const auto mismatched_dsts = resolveModule(parseModule(R"ptx(
+.entry kernel() {
+  .reg .b64 %wide0;
   activemask.b32 %wide0;
 }
 )ptx"));
@@ -2657,7 +2676,6 @@ TEST(ResolvedModule, ResolvesAndChecksVoteSyncBallotB32Slice) {
   .reg .b64 %wide0;
   .reg .pred %p0;
   .reg .b64 %bad_mask;
-  vote.sync.ballot.b32 %u0, %p0, 0;
   vote.sync.ballot.b32 %wide0, %p0, 0;
   vote.sync.ballot.b32 %u0, %p0, %bad_mask;
 }
@@ -2671,6 +2689,19 @@ TEST(ResolvedModule, ResolvesAndChecksVoteSyncBallotB32Slice) {
     EXPECT_EQ(checked.error().front().kind,
               checker::CheckDiagnosticKind::OperandTypeMismatch);
   }
+
+  const auto compatible_dst = resolveModule(parseModule(R"ptx(
+.entry kernel() {
+  .reg .u32 %u0;
+  .reg .pred %p0;
+  vote.sync.ballot.b32 %u0, %p0, 0;
+}
+)ptx"));
+  ASSERT_TRUE(compatible_dst.has_value())
+      << compatible_dst.error().front().message;
+  EXPECT_TRUE(checker::check(
+                  std::get<Vote>(compatible_dst->functions.front().body.front()), context)
+                  .has_value());
 
   const auto bad_predicate = resolveModule(parseModule(R"ptx(
 .entry kernel() {
@@ -5219,8 +5250,16 @@ TEST(ResolvedModule, ChecksM12CvtScalarAndPackedTypes) {
                   checker::Context{.target = {.ptx_version = {7, 0}, .sm_version = 80}})
                   .has_value());
 
+  const auto packed_container = resolveModule(parseModule(
+      ".entry kernel() { .reg .f16x2 %dst; .reg .f32 %a, %b; cvt.rn.f16x2.f32 %dst, %a, %b; }"));
+  ASSERT_TRUE(packed_container.has_value())
+      << packed_container.error().front().message;
+  EXPECT_TRUE(checker::check(
+                  std::get<Cvt>(packed_container->functions.front().body.front()),
+                  checker::Context{.target = {.ptx_version = {7, 0}, .sm_version = 80}})
+                  .has_value());
+
   for (const auto source : {
-           ".entry kernel() { .reg .f16x2 %dst; .reg .f32 %a, %b; cvt.rn.f16x2.f32 %dst, %a, %b; }",
            ".entry kernel() { .reg .f32 %dst, %a, %b; cvt.rn.f16x2.f32 %dst, %a, %b; }",
        }) {
     SCOPED_TRACE(source);
@@ -5392,12 +5431,9 @@ TEST(ResolvedModule, ChecksMulHiAndWideU32OperandTypes) {
 )ptx"));
   ASSERT_TRUE(bit_wide_source.has_value()) << bit_wide_source.error().front().message;
   const auto& bit_instruction = std::get<Mul>(bit_wide_source->functions.front().body.front());
-  const auto& bit_variant = std::get<Mul::WideU32>(bit_instruction.variant);
   const auto bit_checked = checker::check(bit_instruction, context);
-  ASSERT_FALSE(bit_checked.has_value());
-  EXPECT_EQ(bit_checked.error().front().kind,
-            checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(bit_checked.error().front().range, bit_variant.src1.locs.front());
+  EXPECT_TRUE(bit_checked.has_value())
+      << bit_checked.error().front().message;
 
   const auto narrow_wide_dst = resolveModule(parseModule(R"ptx(
 .entry kernel() { .reg .u32 %dst, %src; mul.wide.u32 %dst, %src, %src; }
@@ -5520,13 +5556,10 @@ TEST(ResolvedModule, ChecksM12MadWideAndRnOperandTypes) {
 )ptx"));
   ASSERT_TRUE(bit_wide_source.has_value()) << bit_wide_source.error().front().message;
   const auto& bit_instruction = std::get<Mad>(bit_wide_source->functions.front().body.front());
-  const auto& bit_variant = std::get<Mad::WideU32>(bit_instruction.variant);
   const auto bit_checked = checker::check(
       bit_instruction, checker::Context{.target = {.ptx_version = {1, 0}, .sm_version = 0}});
-  ASSERT_FALSE(bit_checked.has_value());
-  EXPECT_EQ(bit_checked.error().front().kind,
-            checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(bit_checked.error().front().range, bit_variant.src1.locs.front());
+  EXPECT_TRUE(bit_checked.has_value())
+      << bit_checked.error().front().message;
 
   const auto narrow_wide_addend = resolveModule(parseModule(R"ptx(
 .entry kernel() { .reg .u64 %dst; .reg .u32 %src, %addend; mad.wide.u32 %dst, %src, %src, %addend; }
@@ -5559,13 +5592,10 @@ TEST(ResolvedModule, ChecksM12MadWideAndRnOperandTypes) {
 )ptx"));
   ASSERT_TRUE(bit_float_source.has_value()) << bit_float_source.error().front().message;
   const auto& float_instruction = std::get<Mad>(bit_float_source->functions.front().body.front());
-  const auto& float_variant = std::get<Mad::RnF32>(float_instruction.variant);
   const auto float_checked = checker::check(
       float_instruction, checker::Context{.target = {.ptx_version = {2, 0}, .sm_version = 20}});
-  ASSERT_FALSE(float_checked.has_value());
-  EXPECT_EQ(float_checked.error().front().kind,
-            checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(float_checked.error().front().range, float_variant.src1.locs.front());
+  EXPECT_TRUE(float_checked.has_value())
+      << float_checked.error().front().message;
 }
 
 TEST(ResolvedModule, ChecksFmaFloatingAndPackedOperandTypes) {
@@ -5815,26 +5845,18 @@ TEST(ResolvedModule, ChecksM12DivS32AndRnFloatingOperandTypes) {
 )ptx"));
   ASSERT_TRUE(bit_f32_source.has_value()) << bit_f32_source.error().front().message;
   const auto& f32_instruction = std::get<Div>(bit_f32_source->functions.front().body.front());
-  const auto& f32_variant = std::get<Div::RnF32>(f32_instruction.variant);
   const auto f32_checked = checker::check(
       f32_instruction, checker::Context{.target = {.ptx_version = {1, 4}, .sm_version = 20}});
-  ASSERT_FALSE(f32_checked.has_value());
-  EXPECT_EQ(f32_checked.error().front().kind,
-            checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(f32_checked.error().front().range, f32_variant.src1.locs.front());
+  EXPECT_TRUE(f32_checked.has_value()) << f32_checked.error().front().message;
 
   const auto bit_f64_source = resolveModule(parseModule(R"ptx(
 .entry kernel() { .reg .f64 %dst, %src2; .reg .b64 %src1; div.rn.f64 %dst, %src1, %src2; }
 )ptx"));
   ASSERT_TRUE(bit_f64_source.has_value()) << bit_f64_source.error().front().message;
   const auto& f64_instruction = std::get<Div>(bit_f64_source->functions.front().body.front());
-  const auto& f64_variant = std::get<Div::RnF64>(f64_instruction.variant);
   const auto f64_checked = checker::check(
       f64_instruction, checker::Context{.target = {.ptx_version = {1, 4}, .sm_version = 13}});
-  ASSERT_FALSE(f64_checked.has_value());
-  EXPECT_EQ(f64_checked.error().front().kind,
-            checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(f64_checked.error().front().range, f64_variant.src1.locs.front());
+  EXPECT_TRUE(f64_checked.has_value()) << f64_checked.error().front().message;
 }
 
 TEST(ResolvedModule, ChecksM12RemTypesAndZeroDivisor) {
@@ -5916,18 +5938,15 @@ TEST(ResolvedModule, ChecksM12MinTypes) {
   EXPECT_EQ(integer_checked.error().front().kind, checker::CheckDiagnosticKind::OperandTypeMismatch);
   EXPECT_EQ(integer_checked.error().front().range, integer_variant.src1.locs.front());
 
-  const auto wrong_nan_width = resolveModule(parseModule(R"ptx(
+  const auto bit_nan_source = resolveModule(parseModule(R"ptx(
 .entry kernel() { .reg .f32 %dst, %src2; .reg .b32 %src1; min.NaN.f32 %dst, %src1, %src2; }
 )ptx"));
-  ASSERT_TRUE(wrong_nan_width.has_value()) << wrong_nan_width.error().front().message;
-  const auto& nan_instruction = std::get<Min>(wrong_nan_width->functions.front().body.front());
-  const auto& nan_variant = std::get<Min::NanF32>(nan_instruction.variant);
+  ASSERT_TRUE(bit_nan_source.has_value()) << bit_nan_source.error().front().message;
+  const auto& nan_instruction = std::get<Min>(bit_nan_source->functions.front().body.front());
   const auto nan_checked = checker::check(
       nan_instruction,
       checker::Context{.target = {.ptx_version = {7, 0}, .sm_version = 80}});
-  ASSERT_FALSE(nan_checked.has_value());
-  EXPECT_EQ(nan_checked.error().front().kind, checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(nan_checked.error().front().range, nan_variant.src1.locs.front());
+  EXPECT_TRUE(nan_checked.has_value()) << nan_checked.error().front().message;
 }
 
 TEST(ResolvedModule, ChecksM12MaxTypes) {
@@ -5967,18 +5986,15 @@ TEST(ResolvedModule, ChecksM12MaxTypes) {
   EXPECT_EQ(integer_checked.error().front().kind, checker::CheckDiagnosticKind::OperandTypeMismatch);
   EXPECT_EQ(integer_checked.error().front().range, integer_variant.src1.locs.front());
 
-  const auto wrong_nan_width = resolveModule(parseModule(R"ptx(
+  const auto bit_nan_source = resolveModule(parseModule(R"ptx(
 .entry kernel() { .reg .f32 %dst, %src2; .reg .b32 %src1; max.NaN.f32 %dst, %src1, %src2; }
 )ptx"));
-  ASSERT_TRUE(wrong_nan_width.has_value()) << wrong_nan_width.error().front().message;
-  const auto& nan_instruction = std::get<Max>(wrong_nan_width->functions.front().body.front());
-  const auto& nan_variant = std::get<Max::NanF32>(nan_instruction.variant);
+  ASSERT_TRUE(bit_nan_source.has_value()) << bit_nan_source.error().front().message;
+  const auto& nan_instruction = std::get<Max>(bit_nan_source->functions.front().body.front());
   const auto nan_checked = checker::check(
       nan_instruction,
       checker::Context{.target = {.ptx_version = {7, 0}, .sm_version = 80}});
-  ASSERT_FALSE(nan_checked.has_value());
-  EXPECT_EQ(nan_checked.error().front().kind, checker::CheckDiagnosticKind::OperandTypeMismatch);
-  EXPECT_EQ(nan_checked.error().front().range, nan_variant.src1.locs.front());
+  EXPECT_TRUE(nan_checked.has_value()) << nan_checked.error().front().message;
 }
 
 TEST(ResolvedModule, ChecksM12AbsTypes) {
@@ -6153,8 +6169,17 @@ TEST(ResolvedModule, ChecksM12BfindTypes) {
   EXPECT_TRUE(checker::check(std::get<Bfind>(valid->functions.front().body.front()), context).has_value());
   for (const auto source : {
            ".entry kernel() { .reg .s32 %dst, %src; bfind.shiftamt.u32 %dst, %src; }",
-           ".entry kernel() { .reg .u64 %dst, %src; bfind.shiftamt.u32 %dst, %src; }",
            ".entry kernel() { .reg .u32 %dst; .reg .s32 %src; bfind.shiftamt.u32 %dst, %src; }",
+       }) {
+    SCOPED_TRACE(source);
+    const auto compatible = resolveModule(parseModule(source));
+    ASSERT_TRUE(compatible.has_value()) << compatible.error().front().message;
+    EXPECT_TRUE(checker::check(
+                    std::get<Bfind>(compatible->functions.front().body.front()), context)
+                    .has_value());
+  }
+  for (const auto source : {
+           ".entry kernel() { .reg .u64 %dst, %src; bfind.shiftamt.u32 %dst, %src; }",
        }) {
     const auto wrong = resolveModule(parseModule(source));
     ASSERT_TRUE(wrong.has_value()) << wrong.error().front().message;
@@ -6172,8 +6197,17 @@ TEST(ResolvedModule, ChecksM12BfeTypes) {
   EXPECT_TRUE(checker::check(std::get<Bfe>(valid->functions.front().body.front()), context).has_value());
   for (const auto source : {
            ".entry kernel() { .reg .s32 %dst, %src; bfe.u32 %dst, %src, 0, 8; }",
-           ".entry kernel() { .reg .u64 %dst, %src; bfe.u32 %dst, %src, 0, 8; }",
            ".entry kernel() { .reg .u32 %dst; .reg .s32 %src; bfe.u32 %dst, %src, 0, 8; }",
+       }) {
+    SCOPED_TRACE(source);
+    const auto compatible = resolveModule(parseModule(source));
+    ASSERT_TRUE(compatible.has_value()) << compatible.error().front().message;
+    EXPECT_TRUE(checker::check(
+                    std::get<Bfe>(compatible->functions.front().body.front()), context)
+                    .has_value());
+  }
+  for (const auto source : {
+           ".entry kernel() { .reg .u64 %dst, %src; bfe.u32 %dst, %src, 0, 8; }",
        }) {
     SCOPED_TRACE(source);
     const auto wrong = resolveModule(parseModule(source));

--- a/submod/resolved_ir/test/test_register_type_policy.cpp
+++ b/submod/resolved_ir/test/test_register_type_policy.cpp
@@ -1,0 +1,456 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** One independently specified register spelling accepted at a fundamental width. */
+struct FundamentalRegisterType {
+  /** PTX declaration suffix, without its leading period. */
+  std::string_view spelling;
+};
+
+/** One explicitly expected scalar-compatibility result, independent of YAML. */
+struct ScalarCompatibilityCase {
+  /** Declared type presented by the register. */
+  ScalarType actual;
+  /** Type required by the instruction operand. */
+  ScalarType required;
+  /** Whether same-width compatibility must accept this pair. */
+  bool same_width_accepted;
+};
+
+/** Fundamental 32-bit integer and bit containers for ordinary PTX operands. */
+constexpr std::array kFundamental32 = {
+    FundamentalRegisterType{"u32"},
+    FundamentalRegisterType{"s32"},
+    FundamentalRegisterType{"b32"},
+};
+
+/** Fundamental 64-bit integer and bit containers for ordinary PTX operands. */
+constexpr std::array kFundamental64 = {
+    FundamentalRegisterType{"u64"},
+    FundamentalRegisterType{"s64"},
+    FundamentalRegisterType{"b64"},
+};
+
+/** Complete 32-bit bit, unsigned, signed, and floating compatibility matrix. */
+constexpr std::array kScalarCompatibility32 = {
+    ScalarCompatibilityCase{ScalarType::B32, ScalarType::B32, true},
+    ScalarCompatibilityCase{ScalarType::B32, ScalarType::U32, true},
+    ScalarCompatibilityCase{ScalarType::B32, ScalarType::S32, true},
+    ScalarCompatibilityCase{ScalarType::B32, ScalarType::F32, true},
+    ScalarCompatibilityCase{ScalarType::U32, ScalarType::B32, true},
+    ScalarCompatibilityCase{ScalarType::U32, ScalarType::U32, true},
+    ScalarCompatibilityCase{ScalarType::U32, ScalarType::S32, true},
+    ScalarCompatibilityCase{ScalarType::U32, ScalarType::F32, false},
+    ScalarCompatibilityCase{ScalarType::S32, ScalarType::B32, true},
+    ScalarCompatibilityCase{ScalarType::S32, ScalarType::U32, true},
+    ScalarCompatibilityCase{ScalarType::S32, ScalarType::S32, true},
+    ScalarCompatibilityCase{ScalarType::S32, ScalarType::F32, false},
+    ScalarCompatibilityCase{ScalarType::F32, ScalarType::B32, true},
+    ScalarCompatibilityCase{ScalarType::F32, ScalarType::U32, false},
+    ScalarCompatibilityCase{ScalarType::F32, ScalarType::S32, false},
+    ScalarCompatibilityCase{ScalarType::F32, ScalarType::F32, true},
+};
+
+/** Complete 64-bit bit, unsigned, signed, and floating compatibility matrix. */
+constexpr std::array kScalarCompatibility64 = {
+    ScalarCompatibilityCase{ScalarType::B64, ScalarType::B64, true},
+    ScalarCompatibilityCase{ScalarType::B64, ScalarType::U64, true},
+    ScalarCompatibilityCase{ScalarType::B64, ScalarType::S64, true},
+    ScalarCompatibilityCase{ScalarType::B64, ScalarType::F64, true},
+    ScalarCompatibilityCase{ScalarType::U64, ScalarType::B64, true},
+    ScalarCompatibilityCase{ScalarType::U64, ScalarType::U64, true},
+    ScalarCompatibilityCase{ScalarType::U64, ScalarType::S64, true},
+    ScalarCompatibilityCase{ScalarType::U64, ScalarType::F64, false},
+    ScalarCompatibilityCase{ScalarType::S64, ScalarType::B64, true},
+    ScalarCompatibilityCase{ScalarType::S64, ScalarType::U64, true},
+    ScalarCompatibilityCase{ScalarType::S64, ScalarType::S64, true},
+    ScalarCompatibilityCase{ScalarType::S64, ScalarType::F64, false},
+    ScalarCompatibilityCase{ScalarType::F64, ScalarType::B64, true},
+    ScalarCompatibilityCase{ScalarType::F64, ScalarType::U64, false},
+    ScalarCompatibilityCase{ScalarType::F64, ScalarType::S64, false},
+    ScalarCompatibilityCase{ScalarType::F64, ScalarType::F64, true},
+};
+
+/** Checker context that enables every regression instruction in this file. */
+const checker::Context kContext{.target = {.ptx_version = {9, 3},
+                                           .sm_version = 100}};
+
+/** Parse and resolve exactly one instruction, keeping parser failures test-visible. */
+std::optional<ResolvedInstruction> resolveSingleInstruction(
+    std::string_view source) {
+  PtxSyntaxParser parser(source);
+  auto ast = parser.parseModule();
+  if (!ast || !ast.diagnostics.empty()) {
+    ADD_FAILURE() << (ast.diagnostics.empty() ? "PTX source did not parse."
+                                               : ast.diagnostics.front().message);
+    return std::nullopt;
+  }
+
+  auto module = resolveModule(*ast);
+  if (!module) {
+    ADD_FAILURE() << module.error().front().message;
+    return std::nullopt;
+  }
+  if (module->functions.size() != 1 || module->functions.front().body.size() != 1) {
+    ADD_FAILURE() << "Expected one resolved instruction.";
+    return std::nullopt;
+  }
+  return std::move(module->functions.front().body.front());
+}
+
+/** Return the source range of one selected occurrence in a single-line fixture. */
+SourceRange occurrenceRange(std::string_view source, std::string_view needle,
+                            size_t occurrence) {
+  if (occurrence == 0) {
+    ADD_FAILURE() << "Source-range occurrence is one-based.";
+    return {};
+  }
+  size_t position = 0;
+  for (size_t index = 0; index != occurrence; ++index) {
+    position = source.find(needle, position);
+    if (position == std::string_view::npos) {
+      ADD_FAILURE() << "Missing occurrence " << occurrence << " of '" << needle
+                    << "'.";
+      return {};
+    }
+    ++position;
+  }
+  --position;
+  const size_t end = position + needle.size() + 1;
+  if (end > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+    ADD_FAILURE() << "Fixture is too large for SourceRange.";
+    return {};
+  }
+  return SourceRange{{1, static_cast<int32_t>(position + 1)},
+                     {1, static_cast<int32_t>(end)}};
+}
+
+/** Require the generated checker to accept the resolved instruction. */
+void expectAccepted(const checker::CheckResult& checked) {
+  ASSERT_TRUE(checked.has_value()) << checked.error().front().message;
+}
+
+/** Require one type diagnostic at the independently computed operand range. */
+void expectTypeMismatch(const checker::CheckResult& checked,
+                        SourceRange expected_range) {
+  ASSERT_FALSE(checked.has_value());
+  ASSERT_EQ(checked.error().size(), 1u);
+  EXPECT_EQ(checked.error().front().kind,
+            checker::CheckDiagnosticKind::OperandTypeMismatch);
+  EXPECT_EQ(checked.error().front().range, expected_range);
+}
+
+/** Find a generated resolved variant by its stable public name. */
+const check_end::ResolvedVariantDescriptor* findResolvedVariant(
+    const check_end::ResolvedInstructionDescriptor& descriptor,
+    std::string_view name) {
+  const auto found = std::ranges::find_if(
+      descriptor.variants, [name](const check_end::ResolvedVariantDescriptor& variant) {
+        return variant.variant_name == name;
+      });
+  if (found == descriptor.variants.end()) {
+    ADD_FAILURE() << "Missing generated resolved variant '" << name << "'.";
+    return nullptr;
+  }
+  return &*found;
+}
+
+/** Assert the policy carried by every binding in one generated operand layout. */
+void expectBindingPolicy(const check_end::ResolvedInstructionDescriptor& descriptor,
+                         std::string_view variant_name,
+                         base::ScalarTypeSizePolicy policy) {
+  const auto* variant = findResolvedVariant(descriptor, variant_name);
+  ASSERT_NE(variant, nullptr);
+  ASSERT_EQ(variant->operand_layouts.size(), 1u) << variant_name;
+  ASSERT_FALSE(variant->operand_layouts.front().bindings.empty()) << variant_name;
+  for (const auto& binding : variant->operand_layouts.front().bindings)
+    EXPECT_EQ(binding.register_width_policy, policy)
+        << variant_name << "." << binding.target_field_id;
+}
+
+/** Base type semantics preserve fundamental compatibility while Exact remains identity. */
+TEST(RegisterTypePolicy, BaseFundamentalCompatibilityMatrixIsIndependent) {
+  const auto expect_matrix = [](const auto& matrix) {
+    for (const ScalarCompatibilityCase& entry : matrix) {
+      SCOPED_TRACE(static_cast<int>(entry.actual));
+      SCOPED_TRACE(static_cast<int>(entry.required));
+      EXPECT_EQ(base::scalar_types_compatible(
+                    entry.actual, entry.required,
+                    base::ScalarTypeSizePolicy::SameWidth),
+                entry.same_width_accepted);
+      EXPECT_EQ(base::scalar_types_compatible(entry.actual, entry.required,
+                                               base::ScalarTypeSizePolicy::Exact),
+                entry.actual == entry.required);
+    }
+  };
+  expect_matrix(kScalarCompatibility32);
+  expect_matrix(kScalarCompatibility64);
+}
+
+/** Construct a wide multiply fixture with independently chosen declaration types. */
+std::string wideMulSource(std::string_view destination_type,
+                          std::string_view first_multiplicand_type,
+                          std::string_view second_multiplicand_type = "") {
+  if (second_multiplicand_type.empty())
+    second_multiplicand_type = first_multiplicand_type;
+  return ".entry kernel() { .reg ." + std::string(destination_type) +
+         " %dst; .reg ." + std::string(first_multiplicand_type) +
+         " %src1; .reg ." + std::string(second_multiplicand_type) +
+         " %src2; mul.wide.u32 %dst, %src1, %src2; }";
+}
+
+/** Construct a wide multiply-add fixture with independently chosen declaration types. */
+std::string wideMadSource(std::string_view destination_type,
+                          std::string_view first_multiplicand_type,
+                          std::string_view second_multiplicand_type = "",
+                          std::string_view addend_type = "") {
+  if (second_multiplicand_type.empty())
+    second_multiplicand_type = first_multiplicand_type;
+  if (addend_type.empty())
+    addend_type = destination_type;
+  return ".entry kernel() { .reg ." + std::string(destination_type) +
+         " %dst; .reg ." + std::string(addend_type) +
+         " %src3; .reg ." + std::string(first_multiplicand_type) +
+         " %src1; .reg ." + std::string(second_multiplicand_type) +
+         " %src2; mad.wide.u32 %dst, %src1, %src2, %src3; }";
+}
+
+/** Ordinary wide arithmetic accepts every fundamental container of each width. */
+TEST(RegisterTypePolicy, WideIntegerFundamentalMatrixIsMetamorphic) {
+  for (const auto destination : kFundamental64) {
+    for (const auto multiplicand : kFundamental32) {
+      const std::string mul_source =
+          wideMulSource(destination.spelling, multiplicand.spelling);
+      SCOPED_TRACE(mul_source);
+      const auto mul = resolveSingleInstruction(mul_source);
+      ASSERT_TRUE(mul);
+      expectAccepted(checker::check(std::get<Mul>(*mul), kContext));
+
+      const std::string mad_source =
+          wideMadSource(destination.spelling, multiplicand.spelling);
+      SCOPED_TRACE(mad_source);
+      const auto mad = resolveSingleInstruction(mad_source);
+      ASSERT_TRUE(mad);
+      expectAccepted(checker::check(std::get<Mad>(*mad), kContext));
+    }
+  }
+}
+
+/** Wide arithmetic rejects wrong widths and non-bit cross-category register types. */
+TEST(RegisterTypePolicy, WideArithmeticRejectsWidthsAndCategoriesAtOperands) {
+  const std::string wide_multiplicand = wideMulSource("u64", "b64", "u32");
+  const auto wide_multiplicand_instruction = resolveSingleInstruction(wide_multiplicand);
+  ASSERT_TRUE(wide_multiplicand_instruction);
+  expectTypeMismatch(checker::check(std::get<Mul>(*wide_multiplicand_instruction), kContext),
+                     occurrenceRange(wide_multiplicand, "%src1", 2));
+
+  const std::string float_multiplicand = wideMadSource("u64", "f32", "u32");
+  const auto float_multiplicand_instruction =
+      resolveSingleInstruction(float_multiplicand);
+  ASSERT_TRUE(float_multiplicand_instruction);
+  expectTypeMismatch(checker::check(std::get<Mad>(*float_multiplicand_instruction), kContext),
+                     occurrenceRange(float_multiplicand, "%src1", 2));
+
+  const std::string narrow_result = wideMadSource("u32", "u32", "u32", "u64");
+  const auto narrow_result_instruction = resolveSingleInstruction(narrow_result);
+  ASSERT_TRUE(narrow_result_instruction);
+  expectTypeMismatch(checker::check(std::get<Mad>(*narrow_result_instruction), kContext),
+                     occurrenceRange(narrow_result, "%dst", 2));
+
+  const std::string float_result = wideMulSource("f64", "u32");
+  const auto float_result_instruction = resolveSingleInstruction(float_result);
+  ASSERT_TRUE(float_result_instruction);
+  expectTypeMismatch(checker::check(std::get<Mul>(*float_result_instruction), kContext),
+                     occurrenceRange(float_result, "%dst", 2));
+}
+
+/** Bit containers are valid ordinary operands, including scalar floating MAD. */
+TEST(RegisterTypePolicy, BitContainersWorkForOrdinaryArithmeticAndBitCounts) {
+  constexpr std::string_view source =
+      ".entry kernel() { .reg .b32 %f0, %f1, %f2, %f3; mad.rn.f32 %f0, %f1, %f2, %f3; }";
+  const auto mad = resolveSingleInstruction(source);
+  ASSERT_TRUE(mad);
+  expectAccepted(checker::check(std::get<Mad>(*mad), kContext));
+
+  constexpr std::string_view popc_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .s32 %src; popc.b32 %dst, %src; }";
+  const auto popc = resolveSingleInstruction(popc_source);
+  ASSERT_TRUE(popc);
+  expectAccepted(checker::check(std::get<Popc>(*popc), kContext));
+
+  constexpr std::string_view clz32_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .u32 %src; clz.b32 %dst, %src; }";
+  const auto clz32 = resolveSingleInstruction(clz32_source);
+  ASSERT_TRUE(clz32);
+  expectAccepted(checker::check(std::get<Clz>(*clz32), kContext));
+
+  constexpr std::string_view clz64_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .s64 %src; clz.b64 %dst, %src; }";
+  const auto clz64 = resolveSingleInstruction(clz64_source);
+  ASSERT_TRUE(clz64);
+  expectAccepted(checker::check(std::get<Clz>(*clz64), kContext));
+
+  constexpr std::string_view wrong_result =
+      ".entry kernel() { .reg .u64 %dst; .reg .b32 %src; popc.b32 %dst, %src; }";
+  const auto rejected = resolveSingleInstruction(wrong_result);
+  ASSERT_TRUE(rejected);
+  expectTypeMismatch(checker::check(std::get<Popc>(*rejected), kContext),
+                     occurrenceRange(wrong_result, "%dst", 2));
+}
+
+/** A target-bearing multi-instruction kernel retains the same wide-multiply contract. */
+TEST(RegisterTypePolicy, TargetedKernelUsesSameWideMultiplyPolicy) {
+  constexpr std::string_view source = R"ptx(.version 8.0
+.target sm_80
+.address_size 64
+.visible .entry kernel() {
+  .reg .b32 %src1, %src2;
+  .reg .b64 %dst;
+  mov.b32 %src1, 1;
+  mov.b32 %src2, 2;
+  mul.wide.u32 %dst, %src1, %src2;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  ASSERT_TRUE(ast.has_value()) << ast.diagnostics.front().message;
+  ASSERT_TRUE(ast.diagnostics.empty());
+  const auto module = resolveModule(*ast);
+  ASSERT_TRUE(module.has_value()) << module.error().front().message;
+  ASSERT_EQ(module->functions.size(), 1u);
+  const auto& body = module->functions.front().body;
+  ASSERT_EQ(body.size(), 4u);
+  const checker::Context target_context{
+      .target = {.ptx_version = {8, 0}, .sm_version = 80}};
+  for (const ResolvedInstruction& instruction : body) {
+    const auto checked = std::visit(
+        [&target_context](const auto& concrete) {
+          return checker::check(concrete, target_context);
+        },
+        instruction);
+    expectAccepted(checked);
+  }
+}
+
+/** Representative ordinary exact patterns remain compatible with bit/fundamental storage. */
+TEST(RegisterTypePolicy, OtherOrdinaryPatternsUseFundamentalCompatibility) {
+  constexpr std::string_view bfind_source =
+      ".entry kernel() { .reg .s32 %dst, %src; bfind.shiftamt.u32 %dst, %src; }";
+  const auto bfind = resolveSingleInstruction(bfind_source);
+  ASSERT_TRUE(bfind);
+  expectAccepted(checker::check(std::get<Bfind>(*bfind), kContext));
+
+  constexpr std::string_view bfe_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .s32 %src; bfe.u32 %dst, %src, 0, 8; }";
+  const auto bfe = resolveSingleInstruction(bfe_source);
+  ASSERT_TRUE(bfe);
+  expectAccepted(checker::check(std::get<Bfe>(*bfe), kContext));
+
+  constexpr std::string_view div_source =
+      ".entry kernel() { .reg .b64 %dst, %src1, %src2; div.rn.f64 %dst, %src1, %src2; }";
+  const auto div = resolveSingleInstruction(div_source);
+  ASSERT_TRUE(div);
+  expectAccepted(checker::check(std::get<Div>(*div), kContext));
+
+  constexpr std::string_view min_source =
+      ".entry kernel() { .reg .b32 %dst, %src1, %src2; min.NaN.f32 %dst, %src1, %src2; }";
+  const auto min = resolveSingleInstruction(min_source);
+  ASSERT_TRUE(min);
+  expectAccepted(checker::check(std::get<Min>(*min), kContext));
+
+  constexpr std::string_view max_source =
+      ".entry kernel() { .reg .b32 %dst, %src1, %src2; max.NaN.f32 %dst, %src1, %src2; }";
+  const auto max = resolveSingleInstruction(max_source);
+  ASSERT_TRUE(max);
+  expectAccepted(checker::check(std::get<Max>(*max), kContext));
+}
+
+/** Packed bfloat FMA still requires its exact b16 storage container. */
+TEST(RegisterTypePolicy, PackedBfloatStorageRemainsExact) {
+  constexpr std::string_view source =
+      ".entry kernel() { .reg .b16 %dst, %src2, %src3; .reg .f16 %src1; fma.rn.bf16 %dst, %src1, %src2, %src3; }";
+  const auto fma = resolveSingleInstruction(source);
+  ASSERT_TRUE(fma);
+  expectTypeMismatch(checker::check(std::get<Fma>(*fma), kContext),
+                     occurrenceRange(source, "%src1", 2));
+}
+
+/** Packed-half negation and conversion use compatible containers, not exact identity. */
+TEST(RegisterTypePolicy, PackedHalfContainersRemainSameWidth) {
+  constexpr std::string_view neg_source =
+      ".entry kernel() { .reg .f16x2 %dst; .reg .b32 %src; neg.f16x2 %dst, %src; }";
+  const auto neg = resolveSingleInstruction(neg_source);
+  ASSERT_TRUE(neg);
+  expectAccepted(checker::check(std::get<Neg>(*neg), kContext));
+
+  constexpr std::string_view cvt_f16x2_source =
+      ".entry kernel() { .reg .f16x2 %dst; .reg .b32 %src1, %src2; cvt.rn.f16x2.f32 %dst, %src1, %src2; }";
+  const auto cvt_f16x2 = resolveSingleInstruction(cvt_f16x2_source);
+  ASSERT_TRUE(cvt_f16x2);
+  expectAccepted(checker::check(std::get<Cvt>(*cvt_f16x2), kContext));
+
+  constexpr std::string_view cvt_b32_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .f32 %src1, %src2; cvt.rn.f16x2.f32 %dst, %src1, %src2; }";
+  const auto cvt_b32 = resolveSingleInstruction(cvt_b32_source);
+  ASSERT_TRUE(cvt_b32);
+  expectAccepted(checker::check(std::get<Cvt>(*cvt_b32), kContext));
+
+  constexpr std::string_view wrong_destination =
+      ".entry kernel() { .reg .u32 %dst; .reg .f32 %src1, %src2; cvt.rn.f16x2.f32 %dst, %src1, %src2; }";
+  const auto rejected_destination = resolveSingleInstruction(wrong_destination);
+  ASSERT_TRUE(rejected_destination);
+  expectTypeMismatch(checker::check(std::get<Cvt>(*rejected_destination), kContext),
+                     occurrenceRange(wrong_destination, "%dst", 2));
+
+  constexpr std::string_view wrong_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .u32 %src1; .reg .f32 %src2; cvt.rn.f16x2.f32 %dst, %src1, %src2; }";
+  const auto rejected_source = resolveSingleInstruction(wrong_source);
+  ASSERT_TRUE(rejected_source);
+  expectTypeMismatch(checker::check(std::get<Cvt>(*rejected_source), kContext),
+                     occurrenceRange(wrong_source, "%src1", 2));
+
+  constexpr std::string_view cvt_f32_s32_source =
+      ".entry kernel() { .reg .b32 %dst; .reg .u32 %src; cvt.rn.f32.s32 %dst, %src; }";
+  const auto cvt_f32_s32 = resolveSingleInstruction(cvt_f32_s32_source);
+  ASSERT_TRUE(cvt_f32_s32);
+  expectAccepted(checker::check(std::get<Cvt>(*cvt_f32_s32), kContext));
+}
+
+/** Generated metadata distinguishes ordinary compatibility from packed exact storage. */
+TEST(RegisterTypePolicy, GeneratedDescriptorsExposeTheWidthPolicy) {
+  const auto same_width = base::ScalarTypeSizePolicy::SameWidth;
+  expectBindingPolicy(Mul::get_resolved_descriptor(), "WideU32", same_width);
+  expectBindingPolicy(Mad::get_resolved_descriptor(), "WideU32", same_width);
+  expectBindingPolicy(Mad::get_resolved_descriptor(), "RnF32", same_width);
+  expectBindingPolicy(Popc::get_resolved_descriptor(), "B32", same_width);
+  expectBindingPolicy(Clz::get_resolved_descriptor(), "B32", same_width);
+  expectBindingPolicy(Clz::get_resolved_descriptor(), "B64", same_width);
+  expectBindingPolicy(Bfind::get_resolved_descriptor(), "ShiftamtU32", same_width);
+  expectBindingPolicy(Bfe::get_resolved_descriptor(), "U32", same_width);
+  expectBindingPolicy(Div::get_resolved_descriptor(), "RnF32", same_width);
+  expectBindingPolicy(Div::get_resolved_descriptor(), "RnF64", same_width);
+  expectBindingPolicy(Min::get_resolved_descriptor(), "NanF32", same_width);
+  expectBindingPolicy(Max::get_resolved_descriptor(), "NanF32", same_width);
+  expectBindingPolicy(Neg::get_resolved_descriptor(), "F16x2", same_width);
+  expectBindingPolicy(Cvt::get_resolved_descriptor(), "RnF16x2F32", same_width);
+  expectBindingPolicy(Fma::get_resolved_descriptor(), "Bf16",
+                      base::ScalarTypeSizePolicy::Exact);
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir


### PR DESCRIPTION
## Summary

Fixes #106

- Audit all 106 explicit exact-policy declarations across the three affected specification files; use same-width fundamental compatibility for ordinary operands.
- Preserve wide multiply/add operand widths, alternate-format and opaque-token restrictions, and the Exact utility itself. Encode f16x2 storage as f16x2 plus same-width compatibility.
- Add independent fundamental-type matrices, declaration-substitution regressions, real module/checker tests, diagnostic-range assertions, and generated-descriptor checks. Correct obsolete negative expectations.
- Add bilingual policy/source ledgers and the complete assembler-comparison sources, driver, exit codes, and diagnostics.

## Validation

- Baseline: initial six linked regression groups produced five expected failures and one passing exact-bf16 control.
- 506 resolved IR tests passed, including nine register-policy groups.
- Nine modern-operand code-generation tests passed.
- All 199 Python model/generator tests passed.
- Same 23 reconstructed PTX modules checked by frontend and NVIDIA ptxas: 15 accepted, eight rejected, complete accept/reject agreement, no assembler warnings.
- git diff --check and JSON syntax validation passed.

## Evidence boundaries

Normative source: archived CUDA 13.3.0 / PTX ISA 9.3 manual. Available assembler: CUDA 13.1, V13.1.115; comparison uses PTX 8.0, sm_80, and -O0. This is not a CUDA 13.3 toolchain validation. The original round-seven attachment was unavailable; supplied cases are reconstructed. Wider cvt-register behavior remains outside this focused same-width correction. Existing opaque report-value b8 storage is retained without claiming independent normative proof of its width.