### PR TITLE
fix: validate modifier domains and normalize extern alignment (#109, #112)

### DIFF
--- a/docs/us-en/declaration_semantics_design.md
+++ b/docs/us-en/declaration_semantics_design.md
@@ -64,8 +64,23 @@ decides whether the redeclaration is legal:
   definitions report diagnostics carrying the previous source range;
 - an `.extern .func` must be a prototype and cannot have a body.
 
-Explicit alignments, parameterized counts, and ABI-preserve counts compare by
-decoded integer value, so equivalent octal and decimal spellings match.
+Redeclaration alignment compares its effective value while retaining source
+provenance and ranges on every declaration occurrence. For modeled fundamental
+storage, an omitted alignment is the scalar byte size (also for scalar arrays)
+or the complete `.v2`/`.v4` element width (also for arrays of vectors). An
+explicit valid alignment compares by decoded integer value, so equivalent octal
+and decimal spellings match. Unsupported layouts and invalid alignment syntax
+do not receive an inferred default. Parameterized counts and ABI-preserve
+counts likewise compare by decoded integer value.
+
+Verification note: CUDA 13.1 `ptxas` V13.1.115 accepted both declaration orders
+for `.version 8.0` / `.target sm_80` / `.address_size 64` fixtures containing
+matching implicit and explicit scalar, scalar-array, byte-array, `.v2 .u32`,
+and `.v4 .u32` external declarations. For the `g` scalar fixture, whole-program
+compilation emitted exactly `ptxas warning : Unresolved extern variable 'g' in
+whole program compilation, ignoring extern qualifier`; the comparison is
+therefore successful with that warning, not warning-free. The same assembler
+rejected `.align 3` with `Alignment must be a power of two`.
 
 Every function prototype and definition still owns a lexical scope. The
 function symbol's `owned_scope` prefers the definition scope, so module

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -506,6 +506,13 @@ descriptors do not redo resolve bindings.
 
 Each generated `checker::check<T>` wrapper uses common checking for:
 
+- membership of every projected dynamic modifier value in the selected
+  variant's generated semantic domain. This check is independent of source
+  locations and modifier spelling-presence: an omitted optional modifier is
+  checked using that field's declared default, while an out-of-domain edited
+  value with no provenance remains invalid and uses the instruction range as
+  its diagnostic fallback. `ModifierValueDomainMismatch` reports a value
+  outside this domain.
 - minimum PTX version, SM version, and target family for the variant, selected operand layout, and actual modifier value;
 - layout-tag bounds;
 - layout-tag/payload agreement;
@@ -521,6 +528,18 @@ Each generated `checker::check<T>` wrapper uses common checking for:
 - explicit `.param` input/return direction and function-context availability
   from the generated operand constraint; direction mismatches take precedence
   over that contextual availability.
+
+The caller supplies `checker::Context::target` and `instruction_range` for a
+single-instruction check. The latter is the stable fallback diagnostic range
+when the edited field has no retained source provenance.
+
+Semantic-domain membership and target availability are separate questions. The
+domain is derived from the normalized variant modifier values together with the
+individual optional field default; it is not inferred from availability entries,
+and it does not admit a blanket enum sentinel. Availability keeps its existing
+source-presence behavior, because an omitted default need not have the same PTX
+or SM requirement as an explicitly spelled value. Therefore a legal value can
+pass domain membership yet still fail its target availability check.
 
 Generated vector projections also accept caller-constructed or mutated public
 IR without requiring a separate vector-size preverification pass. They retain

--- a/docs/zh-han/declaration_semantics_design.md
+++ b/docs/zh-han/declaration_semantics_design.md
@@ -53,8 +53,20 @@ module scope 的同名 item 先由 binding 合并到稳定的 `SymbolId`，再�
   诊断；
 - `.extern .func` 只能是 prototype，不能带 body。
 
-显式 alignment、parameterized count 和 ABI-preserve count 按解码后的整数值比较，
-因此等值的八进制与十进制拼写相匹配。
+redeclaration 的 alignment 按 effective value 比较，但每个 declaration occurrence
+仍保留 source provenance 与 range。对于已建模的 fundamental storage，省略的
+alignment 是 scalar byte size（scalar array 也相同），或完整 `.v2`/`.v4` element
+width（vector array 也相同）。显式且有效的 alignment 按解码后的整数值比较，
+因此等值的八进制与十进制拼写相匹配。unsupported layout 与 invalid alignment syntax
+不会被猜测出 default。parameterized count 和 ABI-preserve count 也按解码后的整数值比较。
+
+验证注记：CUDA 13.1 `ptxas` V13.1.115 接受 `.version 8.0` / `.target sm_80` /
+`.address_size 64` fixture 中 scalar、scalar-array、byte-array、`.v2 .u32` 与 `.v4
+.u32` external declaration 的 matching implicit/explicit form，且两种 declaration
+order 都成功。对于 `g` scalar fixture，whole-program compilation 精确给出警告
+`ptxas warning : Unresolved extern variable 'g' in whole program compilation, ignoring
+extern qualifier`；因此该比较是带此警告的成功，而非 warning-free。相同 assembler 以
+`Alignment must be a power of two` 拒绝 `.align 3`。
 
 function prototype 与 definition 各自仍拥有 lexical scope。function symbol 的
 `owned_scope` 优先指向 definition scope，从而使后续 module resolution 使用 definition

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -405,6 +405,11 @@ category 生成到 `resolved_ir_<category>.gen.cpp` 并编译进库。这一边�
 
 `checker::check<T>` 是每个 opcode 的生成 wrapper，公共 checker 至少检查：
 
+- 每个 projected dynamic modifier value 是否属于已选 variant 生成的 semantic domain。此检查
+  不依赖 source location 或 modifier 在源码中是否出现：省略 optional modifier 时检查该字段声明的
+  default；越出 domain 的编辑后 value 即使没有 provenance 也仍然非法，诊断 range 回退至
+  instruction range。
+  `ModifierValueDomainMismatch` 表示 value 不在该 domain 内。
 - variant、已选 operand layout 与实际 modifier value 的最低 PTX 版本、SM 版本与 target family；
 - layout tag 的范围；
 - layout tag/payload 一致性；
@@ -417,6 +422,15 @@ category 生成到 `resolved_ir_<category>.gen.cpp` 并编译进库。这一边�
   register、immediate 与 standalone base 的未知 space 不推断。
 - 由 generated operand constraint 描述的 explicit `.param` input/return direction 与
   function-context availability；方向错误优先于上下文 availability。
+
+单条 instruction 的 `checker::check<T>` 由调用方提供 `checker::Context::target` 与
+`instruction_range`；编辑字段没有保留 source provenance 时，后者是稳定的 diagnostic range 回退。
+
+semantic-domain membership 与 target availability 是两个独立问题。domain 由 normalized variant
+modifier values 及各 optional field 自身的 default 得出，不从 availability entry 推断，也不会笼统
+接受 enum sentinel。availability 保持现有 source-presence 行为，因为省略的 default 不必与显式
+spelling 具有相同的 PTX 或 SM 要求。因此 legal value 可以通过 domain membership，但仍因 target
+availability 被拒绝。
 
 生成的 vector projection 可接收调用方手工构造或修改的公开 IR，无需另行预验证
 向量长度。`OperandView::vector_arity` 保留原始 width/元素数量，对固定容量元素数组

--- a/python/code_gen/_frontend/gen_resolved_checker_descriptor.py
+++ b/python/code_gen/_frontend/gen_resolved_checker_descriptor.py
@@ -14,6 +14,7 @@ from .normalize import (
 )
 from ptx_frontend.ir.resolved_ir import (
     ResolvedInstruction,
+    ResolvedModifierValueDomain,
     ResolvedModifierValueAvailability,
     ResolvedOperandLayout,
     ResolvedOperandTypeCompatibility,
@@ -67,6 +68,10 @@ def _emit_instruction_descriptor_storage(instruction: ResolvedInstruction) -> st
         _emit_variant_modifier_value_descriptors(variant)
         for variant in instruction.variants
     )
+    modifier_domain_definitions = "\n\n".join(
+        _emit_variant_modifier_value_domain_descriptors(variant)
+        for variant in instruction.variants
+    )
     layout_definitions = "\n\n".join(
         _emit_variant_layout_descriptors(variant)
         for variant in instruction.variants
@@ -95,6 +100,8 @@ def _emit_instruction_descriptor_storage(instruction: ResolvedInstruction) -> st
     )
     return f"""struct {storage_name} {{
 {modifier_value_definitions}
+
+{modifier_domain_definitions}
 
 {layout_definitions}
 
@@ -177,6 +184,7 @@ def _emit_variant_descriptor(variant: ResolvedVariant) -> str:
     return f"""          checker::VariantDescriptor{{
               .variant_name = "{variant.cpp_name}",
               .availability = {_emit_availability(dict(variant.availability))},
+              .modifier_value_domains = {variant.cpp_name}_modifier_value_domains,
               .modifier_value_availabilities =
                   {variant.cpp_name}_modifier_value_availabilities,
               .operand_layouts = {variant.cpp_name}_operand_layouts,
@@ -262,9 +270,29 @@ def _emit_variant_modifier_value_descriptors(variant: ResolvedVariant) -> str:
       }};"""
 
 
-def _emit_modifier_value_descriptor(
-    entry: ResolvedModifierValueAvailability,
+def _emit_variant_modifier_value_domain_descriptors(
+    variant: ResolvedVariant,
 ) -> str:
+    """Emit every typed semantic modifier value admitted by one variant."""
+
+    entries = ",\n".join(
+        _emit_modifier_value_domain_descriptor(entry)
+        for entry in variant.modifier_value_domains
+    )
+    return f"""  static constexpr std::array<checker::ModifierValueDomainDescriptor, {len(variant.modifier_value_domains)}>
+      {variant.cpp_name}_modifier_value_domains = {{
+{entries}
+      }};"""
+
+
+def _emit_modifier_value_descriptor(
+    entry: ResolvedModifierValueAvailability | ResolvedModifierValueDomain,
+    *,
+    descriptor_type: str = "checker::ModifierValueAvailabilityDescriptor",
+    include_availability: bool = True,
+) -> str:
+    """Emit one typed modifier descriptor, with optional target metadata."""
+
     if entry.value_cpp_type == "bool":
         bool_value = "true" if entry.value else "false"
         scalar_type = cpp_default(CppDomain.SCALAR_TYPES)
@@ -381,7 +409,12 @@ def _emit_modifier_value_descriptor(
         raise ValueError(
             f"unsupported modifier availability value type {entry.value_cpp_type!r}"
         )
-    return f"""          checker::ModifierValueAvailabilityDescriptor{{
+    availability = (
+        f"              .availability = {_emit_availability(dict(entry.availability))},\n"
+        if include_availability
+        else ""
+    )
+    return f"""          {descriptor_type}{{
               .kind_id = "{entry.source_kind_id}",
               .value_kind = {cpp_value(CppDomain.CHECKER_MODIFIER_VALUE_KINDS, entry.value_cpp_type)},
               .bool_value = {bool_value},
@@ -399,8 +432,20 @@ def _emit_modifier_value_descriptor(
               .mbarrier_layout = {mbarrier_layout if entry.value_cpp_type == "MbarrierLayout" else cpp_default(CppDomain.MBARRIER_LAYOUTS)},
               .async_proxy_kind = {async_proxy_kind if entry.value_cpp_type == "AsyncProxyKind" else cpp_default(CppDomain.ASYNC_PROXY_KINDS)},
               .proxy_kind_pair = {proxy_kind_pair if entry.value_cpp_type == "ProxyKindPair" else cpp_default(CppDomain.PROXY_KIND_PAIRS)},
-              .availability = {_emit_availability(dict(entry.availability))},
+{availability}
           }}"""
+
+
+def _emit_modifier_value_domain_descriptor(
+    entry: ResolvedModifierValueDomain,
+) -> str:
+    """Emit one target-independent typed semantic modifier value."""
+
+    return _emit_modifier_value_descriptor(
+        entry,
+        descriptor_type="checker::ModifierValueDomainDescriptor",
+        include_availability=False,
+    )
 
 
 def _emit_variant_layout_descriptors(variant: ResolvedVariant) -> str:

--- a/python/code_gen/_frontend/gen_resolved_ir.py
+++ b/python/code_gen/_frontend/gen_resolved_ir.py
@@ -495,6 +495,14 @@ def _emit_check_variant_lambda(
             diagnostics.insert(diagnostics.end(), common.error().begin(),
                                common.error().end());
           }}
+          const auto modifier_domain = check_modifier_value_domain(
+              {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
+                  .modifier_value_domains,
+              modifier_values, context);
+          if (!modifier_domain) {{
+            diagnostics.insert(diagnostics.end(), modifier_domain.error().begin(),
+                               modifier_domain.error().end());
+          }}
           const auto modifier_availability = check_modifier_value_availability(
               {instruction.cpp_name}::get_checker_descriptor().variants[{variant_index}]
                   .modifier_value_availabilities,

--- a/python/ir/resolved_ir.py
+++ b/python/ir/resolved_ir.py
@@ -356,6 +356,7 @@ class ResolvedVariant:
     modifier_fields: tuple[ResolvedField, ...]
     modifier_bindings: tuple["ResolvedModifierBinding", ...]
     operand_layouts: tuple["ResolvedOperandLayout", ...]
+    modifier_value_domains: tuple["ResolvedModifierValueDomain", ...]
     modifier_value_availabilities: tuple["ResolvedModifierValueAvailability", ...]
     operand_type_compatibilities: tuple["ResolvedOperandTypeCompatibility", ...]
     memory_consistency: ResolvedMemoryConsistencyConstraint | None
@@ -406,6 +407,21 @@ class ResolvedModifierValueAvailability:
     value_cpp_type: str
     value: str | bool | int
     availability: tuple[tuple[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class ResolvedModifierValueDomain:
+    """One semantic modifier value admitted by a selected resolved variant.
+
+    This AST-free descriptor deliberately excludes target requirements: domain
+    membership answers whether a value belongs to the variant, while the
+    separate availability descriptor answers whether that legal value is
+    supported by a particular target profile.
+    """
+
+    source_kind_id: str
+    value_cpp_type: str
+    value: str | bool | int
 
 
 @dataclass(frozen=True)
@@ -583,6 +599,11 @@ def _build_variant(opcode: str, variant: VariantSpec) -> ResolvedVariant:
             )
         ),
         operand_layouts=operand_layouts,
+        modifier_value_domains=tuple(
+            _build_modifier_value_domain(modifier, value)
+            for modifier in active_modifiers
+            for value in _modifier_domain_values(modifier)
+        ),
         modifier_value_availabilities=tuple(
             _build_modifier_value_availability(modifier, value)
             for modifier in variant.modifiers
@@ -995,6 +1016,45 @@ def _build_modifier_value_availability(
         value_cpp_type=value_cpp_type,
         value=value.value,
         availability=tuple(value.availability.items()),
+    )
+
+
+def _modifier_domain_values(
+    modifier: ModifierSpec,
+) -> tuple[ModifierValueSpec, ...]:
+    """Return all semantic values admitted by one normalized modifier field.
+
+    YAML ``values`` define spelling-selectable values. A flag's spelling
+    implies ``true`` even though it has no value list, and an optional field's
+    normalized default is also a legal resolved value when syntax omits it.
+    """
+
+    values = list(modifier.values)
+    if not values:
+        if modifier.value is not None:
+            values.append(ModifierValueSpec(value=modifier.value))
+        elif modifier.kind == "flag":
+            values.append(ModifierValueSpec(value=True))
+    if modifier.presence == "optional":
+        if modifier.default is None:
+            raise ValueError(
+                f"optional modifier {modifier.name!r} has no normalized default"
+            )
+        if all(value.value != modifier.default for value in values):
+            values.append(ModifierValueSpec(value=modifier.default))
+    return tuple(values)
+
+
+def _build_modifier_value_domain(
+    modifier: ModifierSpec, value: ModifierValueSpec
+) -> ResolvedModifierValueDomain:
+    """Build one typed semantic-domain entry using common value validation."""
+
+    availability = _build_modifier_value_availability(modifier, value)
+    return ResolvedModifierValueDomain(
+        source_kind_id=availability.source_kind_id,
+        value_cpp_type=availability.value_cpp_type,
+        value=availability.value,
     )
 
 

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -4094,6 +4094,99 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertIn(".scalar_type = ScalarType::U64,", source)
         self.assertIn(".minimum_ptx_version = {2, 0},", source)
 
+    def test_modifier_value_domain_includes_legal_values_and_optional_default(
+        self,
+    ) -> None:
+        specs = normalize_instruction_spec(
+            {
+                "category": "test",
+                "codegen_category": "test",
+                "instructions": [
+                    {
+                        "opcode": "sample",
+                        "variants": [
+                            {
+                                "name": "sample_rounding",
+                                "availability": {"ptx": "1.0", "sm": 0},
+                                "modifiers": [
+                                    {
+                                        "name": "rounding",
+                                        "kind": "rounding",
+                                        "presence": "optional",
+                                        "default": "rn",
+                                        "values": [
+                                            "rn",
+                                            {"value": "rz", "availability": {"sm": 20}},
+                                        ],
+                                    },
+                                    {
+                                        "name": "saturate",
+                                        "kind": "flag",
+                                        "presence": "optional",
+                                        "default": False,
+                                        "token": ".sat",
+                                    },
+                                    {
+                                        "name": "cache",
+                                        "kind": "cache",
+                                        "presence": "optional",
+                                        "default": "unspecified",
+                                        "values": ["ca"],
+                                    },
+                                    {
+                                        "name": "required_static_flag",
+                                        "kind": "flag",
+                                        "presence": "fixed",
+                                        "value": True,
+                                        "token": ".fixed",
+                                    },
+                                ],
+                                "operands": [],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+        resolved = from_instruction_spec(specs[0])
+        variant = resolved.variants[0]
+        self.assertEqual(
+            [(entry.source_kind_id, entry.value) for entry in variant.modifier_value_domains],
+            [
+                ("rounding", "rn"),
+                ("rounding", "rz"),
+                ("saturate", True),
+                ("saturate", False),
+                ("cache", "ca"),
+                ("cache", "unspecified"),
+                ("required_static_flag", True),
+            ],
+        )
+        self.assertEqual(
+            [entry.value for entry in variant.modifier_value_availabilities], ["rz"]
+        )
+
+        database = CodegenDatabase(spec_schema="ptx-instr/v1", instructions=specs)
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = Path(directory) / "resolved_ir_checker_descriptor.gen.cpp"
+            generate_resolved_checker_descriptor_source(
+                database,
+                output_path=output_path,
+            )
+            source = output_path.read_text(encoding="utf-8")
+
+        self.assertIn("checker::ModifierValueDomainDescriptor", source)
+        self.assertIn("Rounding_modifier_value_domains", source)
+        self.assertIn(".rounding_mode = RoundingMode::Rn,", source)
+        self.assertIn(".rounding_mode = RoundingMode::Rz,", source)
+        self.assertIn('.kind_id = "saturate",', source)
+        self.assertIn(".bool_value = true,", source)
+        self.assertIn(".bool_value = false,", source)
+        self.assertIn('.kind_id = "cache",', source)
+        self.assertIn(".cache_operator = CacheOperator::Unspecified,", source)
+        self.assertIn('.kind_id = "required_static_flag",', source)
+        self.assertNotIn("RoundingMode::Rzi", source)
+
     def test_comparison_modifier_domain_emits_typed_availability(self) -> None:
         specs = normalize_instruction_spec(
             {

--- a/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_checker.hpp
@@ -38,6 +38,7 @@ enum class CheckDiagnosticKind : uint8_t {
   RuleViolation,
   ModuleSourceMismatch,
   MissingValidationContext,
+  ModifierValueDomainMismatch,
 };
 
 /** A checker failure anchored to a stable resolved-IR source range. */
@@ -87,6 +88,10 @@ CheckResult check_operand_layout_availability(const VariantDescriptor&,
 /** Check target requirements of selected dynamic modifier values. */
 CheckResult check_modifier_value_availability(
     std::span<const ModifierValueAvailabilityDescriptor>,
+    std::span<const ModifierValueView>, const Context&);
+/** Check selected modifier values against the variant's semantic value domain. */
+CheckResult check_modifier_value_domain(
+    std::span<const ModifierValueDomainDescriptor>,
     std::span<const ModifierValueView>, const Context&);
 /** Check generated ld/st memory-order and address-space cross constraints. */
 CheckResult check_memory_consistency(

--- a/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
@@ -309,6 +309,28 @@ struct ModifierValueAvailabilityDescriptor {
   ProxyKindPair proxy_kind_pair = ProxyKindPair::TensormapToGeneric;
   AvailabilityDescriptor availability;
 };
+/** One target-independent semantic modifier value admitted by a variant. */
+struct ModifierValueDomainDescriptor {
+  /** Borrowed generated modifier-kind text; storage outlives every check. */
+  std::string_view kind_id;
+  /** Selects the single meaningful typed payload member below. */
+  ModifierValueKind value_kind;
+  bool bool_value = false;
+  ScalarType scalar_type = ScalarType::Invalid;
+  RoundingMode rounding_mode = RoundingMode::Invalid;
+  ComparisonOperator comparison_operator = ComparisonOperator::Invalid;
+  BooleanOperator boolean_operator = BooleanOperator::Invalid;
+  CacheOperator cache_operator = CacheOperator::Unspecified;
+  EvictionPriority eviction_priority = EvictionPriority::Invalid;
+  VectorArity vector_arity = VectorArity::Invalid;
+  MemoryStateSpace memory_state_space = MemoryStateSpace::Invalid;
+  MemoryConsistency memory_consistency = MemoryConsistency::Omitted;
+  MemoryScope memory_scope = MemoryScope::None;
+  MbarrierPhaseType mbarrier_phase_type = MbarrierPhaseType::Primary;
+  MbarrierLayout mbarrier_layout = MbarrierLayout::V0;
+  AsyncProxyKind async_proxy_kind = AsyncProxyKind::Async;
+  ProxyKindPair proxy_kind_pair = ProxyKindPair::TensormapToGeneric;
+};
 struct ModifierValueView {
   std::string_view kind_id;
   ModifierValueKind value_kind;
@@ -333,6 +355,7 @@ struct ModifierValueView {
 struct VariantDescriptor {
   std::string_view variant_name;
   AvailabilityDescriptor availability;
+  std::span<const ModifierValueDomainDescriptor> modifier_value_domains;
   std::span<const ModifierValueAvailabilityDescriptor>
       modifier_value_availabilities;
   std::span<const OperandLayoutDescriptor> operand_layouts;

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -107,8 +107,17 @@ void append_value_availability_diagnostics(const OperandView& operand,
   }
 }
 
+/** Restrict shared typed-value comparison to generated modifier descriptors. */
+template <typename Descriptor>
+concept ModifierValueDescriptor =
+    std::same_as<std::remove_cvref_t<Descriptor>,
+                 ModifierValueAvailabilityDescriptor> ||
+    std::same_as<std::remove_cvref_t<Descriptor>, ModifierValueDomainDescriptor>;
+
+/** Compare one generated typed modifier value with a projected resolved value. */
+template <ModifierValueDescriptor Descriptor>
 bool matches_modifier_value(
-    const ModifierValueAvailabilityDescriptor& descriptor,
+    const Descriptor& descriptor,
     const ModifierValueView& actual) noexcept {
   if (descriptor.kind_id != actual.kind_id ||
       descriptor.value_kind != actual.value_kind) {
@@ -1067,6 +1076,31 @@ CheckResult check_modifier_value_availability(
     }
   }
 
+  if (diagnostics.empty())
+    return {};
+  return std::unexpected(std::move(diagnostics));
+}
+
+CheckResult check_modifier_value_domain(
+    std::span<const ModifierValueDomainDescriptor> descriptors,
+    std::span<const ModifierValueView> actual_values, const Context& context) {
+  CheckDiagnostics diagnostics;
+  for (const ModifierValueView& actual : actual_values) {
+    const auto it = std::ranges::find_if(
+        descriptors, [&actual](const ModifierValueDomainDescriptor& entry) {
+          return matches_modifier_value(entry, actual);
+        });
+    if (it != descriptors.end())
+      continue;
+    diagnostics.push_back(CheckDiagnostic{
+        .kind = CheckDiagnosticKind::ModifierValueDomainMismatch,
+        .range = diagnostic_range(actual.locations, context),
+        .message = fmt::format(
+            "Modifier '{}' has a value outside the selected instruction variant's "
+            "semantic domain.",
+            actual.kind_id),
+    });
+  }
   if (diagnostics.empty())
     return {};
   return std::unexpected(std::move(diagnostics));

--- a/submod/resolved_ir/test/package_consumer/CMakeLists.txt
+++ b/submod/resolved_ir/test/package_consumer/CMakeLists.txt
@@ -97,3 +97,9 @@ add_executable(ptx_frontend_model_consumer model_only.cpp)
 target_compile_features(ptx_frontend_model_consumer PRIVATE cxx_std_23)
 target_link_libraries(ptx_frontend_model_consumer PRIVATE ptx_frontend::resolved_ir)
 add_test(NAME runs_installed_model COMMAND ptx_frontend_model_consumer)
+
+add_executable(ptx_frontend_validation_consumer validation_regressions.cpp)
+target_compile_features(ptx_frontend_validation_consumer PRIVATE cxx_std_23)
+target_link_libraries(ptx_frontend_validation_consumer PRIVATE ptx_frontend::resolved_ir)
+add_test(NAME revalidates_installed_modifier_domain
+    COMMAND ptx_frontend_validation_consumer modifier)

--- a/submod/resolved_ir/test/package_consumer/CMakeLists.txt
+++ b/submod/resolved_ir/test/package_consumer/CMakeLists.txt
@@ -103,3 +103,5 @@ target_compile_features(ptx_frontend_validation_consumer PRIVATE cxx_std_23)
 target_link_libraries(ptx_frontend_validation_consumer PRIVATE ptx_frontend::resolved_ir)
 add_test(NAME revalidates_installed_modifier_domain
     COMMAND ptx_frontend_validation_consumer modifier)
+add_test(NAME normalizes_installed_external_alignment
+    COMMAND ptx_frontend_validation_consumer alignment)

--- a/submod/resolved_ir/test/package_consumer/validation_regressions.cpp
+++ b/submod/resolved_ir/test/package_consumer/validation_regressions.cpp
@@ -53,6 +53,36 @@ int check_modifier_domain() {
   return 0;
 }
 
+/** Verify implicit/explicit natural alignment through the installed pipeline. */
+int check_effective_alignment() {
+  for (const bool explicit_first : {false, true}) {
+    const std::string implicit = ".extern .global .u32 g;\n";
+    const std::string explicit_value = ".extern .global .align 4 .u32 g;\n";
+    const std::string source =
+        ".version 8.0\n.target sm_80\n.address_size 64\n" +
+        (explicit_first ? explicit_value + implicit : implicit + explicit_value) +
+        ".entry k() { ret; }\n";
+    ptx_frontend::PtxSyntaxParser parser(source);
+    auto ast = parser.parseModule();
+    if (!ast || !ast.diagnostics.empty())
+      return 20;
+    auto module = ir::resolveModule(*ast);
+    if (!module) {
+      for (const auto& diagnostic : module.error())
+        std::cerr << diagnostic.message << '\n';
+      return 21;
+    }
+    const auto& declarations = module->storage_declarations;
+    if (declarations.size() != 2 || declarations[0].alignment != 4 ||
+        declarations[1].alignment != 4 ||
+        declarations[0].symbol_id != declarations[1].symbol_id ||
+        declarations[0].explicit_alignment.has_value() != explicit_first ||
+        declarations[1].explicit_alignment.has_value() == explicit_first)
+      return 22;
+  }
+  return 0;
+}
+
 /** Run one separately reported installed-consumer regression. */
 int main(int argc, char** argv) {
   if (argc != 2)
@@ -60,5 +90,7 @@ int main(int argc, char** argv) {
   const std::string_view mode = argv[1];
   if (mode == "modifier")
     return check_modifier_domain();
+  if (mode == "alignment")
+    return check_effective_alignment();
   return 2;
 }

--- a/submod/resolved_ir/test/package_consumer/validation_regressions.cpp
+++ b/submod/resolved_ir/test/package_consumer/validation_regressions.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ir = ptx_frontend::resolved_ir;
+
+/** Verify copied public IR is revalidated using only the installed API. */
+int check_modifier_domain() {
+  constexpr std::string_view source = R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.entry k() {
+  .reg .f32 %f0, %f1, %f2;
+  mov.f32 %f1, 1.0;
+  mov.f32 %f2, 2.0;
+  add.rn.f32 %f0, %f1, %f2;
+  ret;
+}
+)ptx";
+  ptx_frontend::PtxSyntaxParser parser(source);
+  auto ast = parser.parseModule();
+  if (!ast || !ast.diagnostics.empty())
+    return 10;
+  auto module = ir::resolveModule(*ast);
+  if (!module)
+    return 11;
+  const auto profile = ptx_frontend::base::find_target_profile("sm_80");
+  if (!profile)
+    return 12;
+  const ir::checker::Context context{
+      .target = {.ptx_version = {8, 0},
+                 .sm_version = 80,
+                 .enabled_family_features = profile->enabled_family_features,
+                 .identity = profile->identity,
+                 .capabilities = profile->capabilities},
+      .instruction_range = module->functions.front().instruction_ranges.at(2),
+  };
+  const auto valid = std::get<ir::Add>(module->functions.front().body.at(2));
+  if (!ir::checker::check(valid, context))
+    return 13;
+  auto changed = valid;
+  std::get<ir::Add::FloatF32>(changed.variant).rounding.value =
+      ptx_frontend::base::RoundingMode::Rzi;
+  if (ir::checker::check(changed, context)) {
+    std::cerr << "Checker accepted out-of-domain Add rounding Rzi.\n";
+    return 14;
+  }
+  return 0;
+}
+
+/** Run one separately reported installed-consumer regression. */
+int main(int argc, char** argv) {
+  if (argc != 2)
+    return 1;
+  const std::string_view mode = argv[1];
+  if (mode == "modifier")
+    return check_modifier_domain();
+  return 2;
+}

--- a/submod/resolved_ir/test/test_modifier_domain_revalidation.cpp
+++ b/submod/resolved_ir/test/test_modifier_domain_revalidation.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Parse the complete module used to exercise public-IR revalidation. */
+syntax_ast::AstModule parse_module(std::string_view source) {
+  PtxSyntaxParser parser(source);
+  auto parsed = parser.parseModule();
+  if (!parsed || !parsed.diagnostics.empty()) {
+    ADD_FAILURE() << (parsed.diagnostics.empty()
+                         ? "PTX source did not parse."
+                         : parsed.diagnostics.front().message);
+    return {};
+  }
+  return std::move(*parsed);
+}
+
+/** Resolve one source-valid floating Add and retain its checker context. */
+struct ResolvedFloatAdd {
+  Add instruction;
+  checker::Context context;
+};
+
+/**
+ * Resolve a source-valid full module, then copy the Add for public-IR mutation.
+ *
+ * The returned context retains the module target and Add source range so the
+ * checker path is identical to a consumer revalidating one edited instruction.
+ */
+ResolvedFloatAdd resolve_float_add(std::string_view rounding_suffix = ".rn") {
+  const std::string source = std::string{R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.entry k() {
+  .reg .f32 %f<3>;
+  mov.f32 %f1, 1.0;
+  mov.f32 %f2, 2.0;
+)ptx"} +
+                             "  add" + std::string{rounding_suffix} +
+                             R"ptx(.f32 %f0, %f1, %f2;
+  ret;
+}
+)ptx";
+  const auto ast = parse_module(source);
+  const auto resolved = resolveModule(ast);
+  if (!resolved) {
+    ADD_FAILURE() << resolved.error().front().message;
+    return {};
+  }
+  if (resolved->functions.size() != 1 || resolved->functions.front().body.size() != 4 ||
+      resolved->functions.front().instruction_ranges.size() != 4) {
+    ADD_FAILURE() << "The valid module did not retain its expected Add body entry.";
+    return {};
+  }
+  const auto* add = std::get_if<Add>(&resolved->functions.front().body[2]);
+  if (add == nullptr) {
+    ADD_FAILURE() << "The selected source instruction did not resolve as Add.";
+    return {};
+  }
+  return {
+      .instruction = *add,
+      .context = {
+          .target = {.ptx_version = {8, 0}, .sm_version = 80},
+          .instruction_range = resolved->functions.front().instruction_ranges[2],
+      },
+  };
+}
+
+/** Return the expected domain failure and assert its source-range anchoring. */
+void expect_domain_failure(const checker::CheckResult& checked,
+                           const SourceRange& expected_range) {
+  ASSERT_FALSE(checked.has_value());
+  ASSERT_EQ(checked.error().size(), 1U);
+  EXPECT_EQ(checked.error().front().kind,
+            checker::CheckDiagnosticKind::ModifierValueDomainMismatch);
+  EXPECT_EQ(checked.error().front().range, expected_range);
+}
+
+/** Edited public IR must reject a named rounding enum outside the Add domain. */
+TEST(ModifierDomainRevalidation, RejectsMutatedFloatingAddRzi) {
+  auto candidate = resolve_float_add();
+  auto* selected = std::get_if<Add::FloatF32>(&candidate.instruction.variant);
+  ASSERT_NE(selected, nullptr);
+  selected->rounding.value = RoundingMode::Rzi;
+  ASSERT_FALSE(selected->rounding.locs.empty());
+
+  expect_domain_failure(checker::check(candidate.instruction, candidate.context),
+                        selected->rounding.locs.front());
+}
+
+/** Legal Add rounding values remain legal even without special availability. */
+TEST(ModifierDomainRevalidation, PreservesLegalFloatingAddRoundingValues) {
+  for (const RoundingMode rounding :
+       std::array{RoundingMode::Rn, RoundingMode::Rz, RoundingMode::Rm,
+                  RoundingMode::Rp}) {
+    SCOPED_TRACE(static_cast<int>(rounding));
+    auto candidate = resolve_float_add();
+    auto* selected = std::get_if<Add::FloatF32>(&candidate.instruction.variant);
+    ASSERT_NE(selected, nullptr);
+    selected->rounding.value = rounding;
+    EXPECT_TRUE(checker::check(candidate.instruction, candidate.context).has_value());
+  }
+}
+
+/** Omitted rounding retains its per-field default, while missing locs do not relax domain checks. */
+TEST(ModifierDomainRevalidation, UsesDefaultAndFallbackRangeWithoutProvenance) {
+  auto candidate = resolve_float_add("");
+  auto* selected = std::get_if<Add::FloatF32>(&candidate.instruction.variant);
+  ASSERT_NE(selected, nullptr);
+  EXPECT_EQ(selected->rounding.value, RoundingMode::Rn);
+  EXPECT_TRUE(selected->rounding.locs.empty());
+  EXPECT_TRUE(checker::check(candidate.instruction, candidate.context).has_value());
+
+  selected->rounding.value = RoundingMode::Rzi;
+  expect_domain_failure(checker::check(candidate.instruction, candidate.context),
+                        candidate.context.instruction_range);
+}
+
+/** Invalid and unnamed enum values share the same variant-domain invariant. */
+TEST(ModifierDomainRevalidation, RejectsInvalidAndUnnamedRoundingValues) {
+  for (const RoundingMode rounding :
+       std::array{RoundingMode::Invalid, static_cast<RoundingMode>(0xff)}) {
+    for (const bool retain_provenance : {true, false}) {
+      SCOPED_TRACE(static_cast<int>(rounding));
+      SCOPED_TRACE(retain_provenance);
+      auto candidate = resolve_float_add();
+      auto* selected = std::get_if<Add::FloatF32>(&candidate.instruction.variant);
+      ASSERT_NE(selected, nullptr);
+      selected->rounding.value = rounding;
+      ASSERT_FALSE(selected->rounding.locs.empty());
+      const SourceRange expected_range = retain_provenance
+                                             ? selected->rounding.locs.front()
+                                             : candidate.context.instruction_range;
+      if (!retain_provenance)
+        selected->rounding.locs.clear();
+      expect_domain_failure(checker::check(candidate.instruction, candidate.context),
+                            expected_range);
+    }
+  }
+}
+
+/** Domain membership does not replace target availability for a legal value. */
+TEST(ModifierDomainRevalidation, RetainsLegalRoundingAvailabilityChecks) {
+  auto candidate = resolve_float_add(".rm");
+  auto* selected = std::get_if<Add::FloatF32>(&candidate.instruction.variant);
+  ASSERT_NE(selected, nullptr);
+  ASSERT_FALSE(selected->rounding.locs.empty());
+  candidate.context.target.sm_version = 10;
+
+  const auto checked = checker::check(candidate.instruction, candidate.context);
+  ASSERT_FALSE(checked.has_value());
+  ASSERT_EQ(checked.error().size(), 1U);
+  EXPECT_EQ(checked.error().front().kind,
+            checker::CheckDiagnosticKind::UnsupportedSmVersion);
+  EXPECT_EQ(checked.error().front().range, selected->rounding.locs.front());
+}
+
+/** Source spelling rejection is distinct from public resolved-IR revalidation. */
+TEST(ModifierDomainRevalidation, SourceTextStillRejectsAddRzi) {
+  PtxSyntaxParser parser("add.rzi.f32 %f0, %f1, %f2;");
+  const auto parsed = parser.parseInstruction();
+  ASSERT_TRUE(parsed.has_value()) << parsed.diagnostics.front().message;
+  EXPECT_FALSE(resolve<Add>(*parsed).has_value());
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir

--- a/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
+++ b/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
@@ -51,6 +51,17 @@ const ResolvedStorageDeclaration& storageNamed(const ResolvedModule& module,
   return *match;
 }
 
+/** Return every source declaration occurrence for one bound storage symbol. */
+std::vector<const ResolvedStorageDeclaration*> storageOccurrencesNamed(
+    const ResolvedModule& module, std::string_view name) {
+  std::vector<const ResolvedStorageDeclaration*> occurrences;
+  for (const auto& declaration : module.storage_declarations) {
+    if (module.symbols.symbol(declaration.symbol_id).name == name)
+      occurrences.push_back(&declaration);
+  }
+  return occurrences;
+}
+
 /** Report whether resolution retained a declaration-stage diagnostic category. */
 bool hasDeclarationKind(const ModuleResolveDiagnostics& diagnostics,
                         declaration_semantics::DeclarationDiagnosticKind kind) {
@@ -426,6 +437,51 @@ TEST(ResolvedStorageDeclarations, PreservesExternalRedeclarationOccurrences) {
   EXPECT_NE(definition.symbol_id, first_external.symbol_id);
   EXPECT_EQ(definition.declaration_kind, StorageDeclarationKind::Definition);
   EXPECT_EQ(definition.linkage, binding::SymbolLinkage::None);
+}
+
+/** Mixed implicit and explicit external alignment retains occurrence provenance. */
+TEST(ResolvedStorageDeclarations,
+     NormalizesNaturalExternalAlignmentWithoutCollapsingDeclarations) {
+  const auto resolved = resolveSource(R"ptx(
+.extern .global .u32 scalar;
+.extern .global .align 4 .u32 scalar;
+.extern .global .align 8 .u64 word;
+.extern .global .u64 word;
+.extern .global .u8 bytes[32];
+.extern .global .align 1 .u8 bytes[32];
+.extern .global .align 8 .v2 .u32 pair[4];
+.extern .global .v2 .u32 pair[4];
+.extern .global .v4 .u32 quad[3];
+.extern .global .align 16 .v4 .u32 quad[3];
+)ptx");
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+
+  /** Expected effective alignment and explicitness order for one symbol. */
+  struct AlignmentCase {
+    std::string_view name;
+    uint64_t alignment;
+    bool first_is_explicit;
+  };
+  constexpr std::array cases{
+      AlignmentCase{"scalar", 4u, false}, AlignmentCase{"word", 8u, true},
+      AlignmentCase{"bytes", 1u, false},  AlignmentCase{"pair", 8u, true},
+      AlignmentCase{"quad", 16u, false},
+  };
+  for (const auto& expected : cases) {
+    const auto occurrences = storageOccurrencesNamed(*resolved, expected.name);
+    ASSERT_EQ(occurrences.size(), 2u) << expected.name;
+    EXPECT_EQ(occurrences[0]->symbol_id, occurrences[1]->symbol_id)
+        << expected.name;
+    EXPECT_NE(occurrences[0]->range, occurrences[1]->range) << expected.name;
+    for (const auto* occurrence : occurrences)
+      EXPECT_EQ(occurrence->alignment, expected.alignment) << expected.name;
+    EXPECT_EQ(occurrences[0]->explicit_alignment.has_value(),
+              expected.first_is_explicit)
+        << expected.name;
+    EXPECT_EQ(occurrences[1]->explicit_alignment.has_value(),
+              !expected.first_is_explicit)
+        << expected.name;
+  }
 }
 
 /** Flattened initializer entries retain byte offsets and distinguish implicit fill. */

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -542,6 +542,11 @@ std::optional<uint64_t> positiveCount(std::string_view text) {
   return count;
 }
 
+bool isValidAlignment(std::string_view text) {
+  const auto value = positiveCount(text);
+  return value && (*value & (*value - 1)) == 0;
+}
+
 /** Normalize known effective alignment while retaining invalid source for diagnostics. */
 std::optional<std::string> parameterAlignmentContract(
     const std::optional<syntax_ast::AstSyntax>& explicit_alignment,
@@ -582,12 +587,52 @@ FunctionParameterContract parameterContract(
   };
 }
 
+/** Return the natural alignment for a storage layout modeled by resolution. */
+std::optional<uint64_t> naturalStorageAlignment(
+    const syntax_ast::AstVariableDeclaration& declaration) {
+  auto scalar = parameterScalarType(declaration.type.text);
+  if (!scalar && declaration.type.text == ".f16x2")
+    scalar = base::ScalarType::F16x2;
+  if (!scalar)
+    return std::nullopt;
+  const uint64_t scalar_bytes = base::scalar_size_of(*scalar);
+  if (scalar_bytes == 0)
+    return std::nullopt;
+
+  uint64_t lanes = 1;
+  if (declaration.vector_type) {
+    if (declaration.vector_type->text == ".v2")
+      lanes = 2;
+    else if (declaration.vector_type->text == ".v4")
+      lanes = 4;
+    else
+      return std::nullopt;
+  }
+  if (scalar_bytes > 16 / lanes)
+    return std::nullopt;
+  return scalar_bytes * lanes;
+}
+
+/** Normalize storage alignment only when its omitted natural value is known. */
+std::optional<std::string> variableAlignmentContract(
+    const syntax_ast::AstVariableDeclaration& declaration) {
+  if (declaration.alignment) {
+    const auto value = positiveCount(declaration.alignment->text);
+    return value && isValidAlignment(declaration.alignment->text)
+               ? std::optional{std::to_string(*value)}
+               : std::optional{declaration.alignment->text};
+  }
+  const auto natural_alignment = naturalStorageAlignment(declaration);
+  return natural_alignment ? std::optional{std::to_string(*natural_alignment)}
+                           : std::nullopt;
+}
+
 std::string variableSignature(
     const syntax_ast::AstVariableDeclaration& declaration,
     const syntax_ast::AstVariableDeclarator& declarator) {
   std::string signature = fmt::format(
       "variable:{}:{}:{}:{}:{}", static_cast<int>(declaration.state_space),
-      declaration.alignment ? integerSyntaxKey(*declaration.alignment) : "-",
+      variableAlignmentContract(declaration).value_or("-"),
       optionalSyntaxKey(declaration.vector_type), declaration.type.text,
       declarator.parameterized_count ? integerSyntaxKey(*declarator.parameterized_count)
                                      : "-");
@@ -620,11 +665,6 @@ bool initializerTypeAccepts(std::string_view type,
            type.starts_with(".tf") || type.starts_with(".e");
   }
   return false;
-}
-
-bool isValidAlignment(std::string_view text) {
-  const auto value = positiveCount(text);
-  return value && (*value & (*value - 1)) == 0;
 }
 
 class Checker {

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -136,6 +136,94 @@ TEST(PtxDeclarationSemantics, CanonicalizesOctalRedeclarationValues) {
   }
 }
 
+/** External storage redeclarations compare known natural and written alignments. */
+TEST(PtxDeclarationSemantics,
+     NormalizesNaturalExternalStorageAlignmentInEitherDeclarationOrder) {
+  /** One implicit/explicit external declaration pair and its expected default. */
+  struct AlignmentCase {
+    std::string_view omitted;
+    std::string_view explicit_alignment;
+  };
+  constexpr std::array cases{
+      AlignmentCase{".extern .global .u32 scalar;\n",
+                    ".extern .global .align 4 .u32 scalar;\n"},
+      AlignmentCase{".extern .global .u64 word;\n",
+                    ".extern .global .align 8 .u64 word;\n"},
+      AlignmentCase{".extern .global .u32 values[8];\n",
+                    ".extern .global .align 4 .u32 values[8];\n"},
+      AlignmentCase{".extern .global .u8 bytes[32];\n",
+                    ".extern .global .align 1 .u8 bytes[32];\n"},
+      AlignmentCase{".extern .global .v2 .u32 pair[4];\n",
+                    ".extern .global .align 8 .v2 .u32 pair[4];\n"},
+      AlignmentCase{".extern .global .v4 .u32 quad[3];\n",
+                    ".extern .global .align 16 .v4 .u32 quad[3];\n"},
+      AlignmentCase{".extern .global .u32 octal;\n",
+                    ".extern .global .align 04 .u32 octal;\n"},
+  };
+
+  for (const auto& alignment : cases) {
+    for (const bool reverse : std::array{false, true}) {
+      const std::string source = reverse
+                                     ? std::string{alignment.explicit_alignment} +
+                                           std::string{alignment.omitted}
+                                     : std::string{alignment.omitted} +
+                                           std::string{alignment.explicit_alignment};
+      const CheckedModule result = check(source);
+      EXPECT_TRUE(result.binding.diagnostics.empty()) << source;
+      EXPECT_EQ(diagnosticCount(result,
+                                DeclarationDiagnosticKind::IncompatibleRedeclaration),
+                0u)
+          << source;
+      EXPECT_TRUE(result.diagnostics.empty()) << source;
+    }
+  }
+}
+
+/** Existing identical and equivalently explicit external declarations remain valid. */
+TEST(PtxDeclarationSemantics, RetainsMatchingExternalStorageAlignmentControls) {
+  const CheckedModule result = check(R"ptx(
+.extern .global .u32 omitted;
+.extern .global .u32 omitted;
+.extern .global .align 4 .u32 numeric;
+.extern .global .align 04 .u32 numeric;
+)ptx");
+  EXPECT_TRUE(result.binding.diagnostics.empty());
+  EXPECT_TRUE(result.diagnostics.empty());
+}
+
+/** Alignment normalization does not weaken invalid or unrelated redeclaration checks. */
+TEST(PtxDeclarationSemantics,
+     RetainsInvalidAndIncompatibleStorageRedeclarationControls) {
+  /** One source fixture and the diagnostic category it must preserve. */
+  struct RejectedCase {
+    std::string_view source;
+    DeclarationDiagnosticKind kind;
+  };
+  constexpr std::array cases{
+      RejectedCase{".extern .global .u32 invalid_alignment;\n"
+                   ".extern .global .align 3 .u32 invalid_alignment;\n",
+                   DeclarationDiagnosticKind::InvalidAlignment},
+      RejectedCase{".extern .global .pred unknown;\n"
+                   ".extern .global .align 1 .pred unknown;\n",
+                   DeclarationDiagnosticKind::IncompatibleRedeclaration},
+      RejectedCase{".extern .global .u32 shaped[4];\n"
+                   ".extern .global .align 4 .u32 shaped[5];\n",
+                   DeclarationDiagnosticKind::IncompatibleRedeclaration},
+      RejectedCase{".extern .global .u32 changed_type;\n"
+                   ".extern .global .align 8 .u64 changed_type;\n",
+                   DeclarationDiagnosticKind::IncompatibleRedeclaration},
+      RejectedCase{".extern .global .u32 linkage;\n"
+                   ".visible .global .align 4 .u32 linkage;\n",
+                   DeclarationDiagnosticKind::IncompatibleRedeclaration},
+      RejectedCase{".global .u32 definition;\n.global .u32 definition;\n",
+                   DeclarationDiagnosticKind::MultipleDefinitions},
+  };
+  for (const auto& rejected : cases) {
+    const CheckedModule result = check(rejected.source);
+    EXPECT_GT(diagnosticCount(result, rejected.kind), 0u) << rejected.source;
+  }
+}
+
 TEST(PtxDeclarationSemantics, ValidatesArrayDimensionsAndInitializerShape) {
   const CheckedModule result = check(R"ptx(
 .global .u32 too_many[2] = {1, 2, 3};


### PR DESCRIPTION
## Summary
- Reject out-of-domain public Resolved IR modifier values using generated per-variant semantic domains, independently of source provenance and conditional target availability.
- Compare repeated external storage declarations by effective alignment while preserving declaration occurrences, source ranges, and shared symbol IDs.
- Keep the changes in separate commits for #109 and #112, with bilingual documentation and installed-consumer regression coverage.

## Stack
Depends on #114. This PR targets fix/issues_70_71_73 so its diff contains only the two issue-specific commits. Retarget after the parent stack is merged.

## Validation
- Full C++ build passed.
- 200 Python tests passed; the subsequently expanded focused domain test also passed.
- All 753 CTest tests passed, including installed consumers and code-generation gates.
- Independent review found no substantive correctness gaps.
- CUDA 13.1 ptxas accepted the alignment comparison fixtures. Whole-program compilation warns about unresolved extern variables and ignores the extern qualifier; an additional scalar fixture check with ptxas -c succeeded without warnings. Full external-symbol linking was not tested.
- Target availability retains existing source-presence behavior; the new semantic-domain check does not depend on source locations.

Closes #109
Closes #112