### PR TITLE
fix(binding): eliminate quadratic symbol-table scans (#116)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.28.0)
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Select optional manifest dependencies before project() loads the vcpkg toolchain.
+option(PTX_FRONTEND_BUILD_BENCHMARKS "Build frontend performance benchmarks" OFF)
+if(PTX_FRONTEND_BUILD_BENCHMARKS)
+    list(APPEND VCPKG_MANIFEST_FEATURES benchmarks)
+    list(REMOVE_DUPLICATES VCPKG_MANIFEST_FEATURES)
+endif()
+
 project(ptx_frontend VERSION 0.0.1 LANGUAGES C CXX)
 
 include(GNUInstallDirs)

--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ without repeating the C++ or Python test suites. The library-only
 See the [CI workflow and cache contract](.github/CONTRIBUTING.md)
 for scope and local smoke commands.
 
+### Optional performance benchmarks
+
+Google Benchmark is available through the optional vcpkg `benchmarks` feature.
+`PTX_FRONTEND_BUILD_BENCHMARKS` defaults to `OFF`; enabling it selects that
+feature before vcpkg configuration and builds the benchmark executable without
+adding benchmark dependencies to the installed frontend package.
+
+```sh
+cmake --preset ci-linux-gcc-release -DPTX_FRONTEND_BUILD_BENCHMARKS=ON
+cmake --build --preset ci-linux-gcc-release --target frontend_symbol_table_scaling
+```
+
+See [benchmark usage and methodology](submod/resolved_ir/benchmark/README.md)
+for filtering, result export, and comparisons against installed revisions.
+
 ## Use after installing
 
 Build and install the package into the configured prefix:

--- a/docs/us-en/symbol_binding_design.md
+++ b/docs/us-en/symbol_binding_design.md
@@ -93,6 +93,15 @@ When a scope has just one parameterized group, lookup checks that group's
 member directly after the ordinary-name probe, avoiding prefix-trie overhead
 without changing bounds, canonical suffix handling, or parent fallback.
 
+`exactDeclaration(scope, spelling, parameterized)` exposes the corresponding
+same-scope exact index for consumers that associate an AST declarator with its
+bound identity. It neither walks parents nor treats a generated compact member
+as a declaration. Metadata remains excluded, and a legal redeclaration retains
+the first stable `SymbolId`. `initializerReference(range)` similarly indexes
+only initializer references by their exact source range, retaining the first
+record even when it is unresolved; declaration semantics and storage lowering
+therefore do not rescan all instruction and initializer references per symbol.
+
 Parameterized overlap checking uses a sparse 32-bit member-range trie keyed
 by canonical spelling decompositions. It identifies existing explicit names,
 existing group bases, and group first-member spellings relevant to the new

--- a/docs/us-en/symbol_binding_design.md
+++ b/docs/us-en/symbol_binding_design.md
@@ -79,6 +79,35 @@ Parameterized names are valid in every state space, but cannot also declare an
 array or initializer. The previous `.reg`-only restriction was removed, and
 the public CST/AST field is now consistently named `parameterized_count`.
 
+## Lookup indexes and compact groups
+
+The table retains its owning `symbols` vector as the source of stable
+`SymbolId` values. It additionally keeps private, scope-aligned indexes with
+their own string keys: ordinary exact names, parameterized exact bases, and a
+prefix trie for parameterized bases. Lookup therefore checks the current
+scope's ordinary exact name, then only parameterized bases that can prefix the
+queried spelling, before moving to the parent scope. This preserves the
+current-scope ordinary, current-scope parameterized, then parent precedence.
+Debug metadata is deliberately excluded from these lexical indexes.
+When a scope has just one parameterized group, lookup checks that group's
+member directly after the ordinary-name probe, avoiding prefix-trie overhead
+without changing bounds, canonical suffix handling, or parent fallback.
+
+Parameterized overlap checking uses a sparse 32-bit member-range trie keyed
+by canonical spelling decompositions. It identifies existing explicit names,
+existing group bases, and group first-member spellings relevant to the new
+base/count, then retains the first stored overlapping identity for the
+diagnostic. The existing name-set-overlap predicate remains authoritative.
+The indexes store no logical members: a declaration with a very large count
+uses storage proportional to its spelling and the fixed 32-bit trie paths,
+not to its count. Index keys and trie storage are owned by the table, so
+`symbols` vector growth and supported table copies or moves cannot leave
+borrowed name keys dangling.
+
+The [scaling benchmark](../../submod/resolved_ir/benchmark/README.md) records
+separate parser, binding, direct-lookup, and module-resolution measurements,
+including compact-group controls and a generated PTX corpus input.
+
 ## Reference binding
 
 The pass visits:

--- a/docs/zh-han/symbol_binding_design.md
+++ b/docs/zh-han/symbol_binding_design.md
@@ -65,6 +65,28 @@ program declaration 可以使用相同 spelling。`.loc` 的 basic 与 `inlined_
 Parameterized name 可用于任意 state space，但不能同时声明 array 或 initializer。原先
 只允许 `.reg` 的限制已移除，公共 CST/AST 字段也统一命名为 `parameterized_count`。
 
+## Lookup index 与紧凑 group
+
+表仍以拥有字符串的 `symbols` vector 作为稳定 `SymbolId` 的唯一来源；另外维护与 scope
+对齐的私有 index，其 key 也独立拥有：ordinary exact name、parameterized exact base，以及
+parameterized base 的 prefix trie。lookup 因此在当前 scope 先查 ordinary exact name，再只查
+可能成为 query spelling prefix 的 parameterized base，之后才走向 parent scope。这保持了
+“current-scope ordinary、current-scope parameterized、parent”的既有优先级。debug metadata
+有意不进入这些 lexical index。
+当 scope 只有一个 parameterized group 时，lookup 在 ordinary-name probe 之后直接检查
+该 group 的 member，省去 prefix trie 的开销，但不改变边界、canonical suffix 或 parent fallback。
+
+Parameterized overlap check 使用按 canonical spelling decomposition 建立的稀疏 32-bit member
+range trie。它定位与新 base/count 有关的已有 explicit name、已有 group base 与 group 的
+first-member spelling，并为 diagnostic 保留最先存储的 overlap identity；现有的 name-set-
+overlap predicate 仍是最终事实来源。index 不会展开逻辑 member：count 很大的 declaration
+只消耗与 spelling 长度及固定 32-bit trie path 成比例的存储，而不与 count 成比例。index key
+和 trie storage 都由表拥有，所以 `symbols` vector 增长以及支持的 table copy/move 都不会留下
+悬空的 borrowed name key。
+
+[扩展性基准](../../submod/resolved_ir/benchmark/README.md) 分别记录 parser、binding、
+直接 lookup 和 module resolution 的测量结果，并包含 compact group 对照及生成 PTX 语料。
+
 ## Reference binding
 
 binding pass 会访问：

--- a/docs/zh-han/symbol_binding_design.md
+++ b/docs/zh-han/symbol_binding_design.md
@@ -76,6 +76,13 @@ parameterized base 的 prefix trie。lookup 因此在当前 scope 先查 ordinar
 当 scope 只有一个 parameterized group 时，lookup 在 ordinary-name probe 之后直接检查
 该 group 的 member，省去 prefix trie 的开销，但不改变边界、canonical suffix 或 parent fallback。
 
+`exactDeclaration(scope, spelling, parameterized)` 为需要将 AST declarator 关联到其
+bound identity 的 consumer 暴露同 scope 的 exact index；它不走 parent，也不把 compact group
+生成的 member 当作 declaration。metadata 仍被排除，合法 redeclaration 保留第一个稳定
+`SymbolId`。`initializerReference(range)` 则仅按精确 source range 索引 initializer reference，
+即使首条记录是 unresolved 也会保留它，因此 declaration semantics 和 storage lowering 不必为
+每个 symbol 重扫全部 instruction/initializer reference。
+
 Parameterized overlap check 使用按 canonical spelling decomposition 建立的稀疏 32-bit member
 range trie。它定位与新 base/count 有关的已有 explicit name、已有 group base 与 group 的
 first-member spelling，并为 diagnostic 保留最先存储的 overlap identity；现有的 name-set-

--- a/submod/binding/include/ptx_symbol_table.hpp
+++ b/submod/binding/include/ptx_symbol_table.hpp
@@ -168,6 +168,28 @@ class SymbolTable {
   [[nodiscard]] std::optional<SymbolLookup> lookup(ScopeId scope,
                                                    std::string_view name) const;
 
+  /**
+   * Return the first non-metadata declaration with this exact spelling and
+   * parameterized form in ``scope``.
+   *
+   * This does not interpret generated parameterized members and never walks a
+   * parent scope.  It is therefore suitable for associating an AST declarator
+   * with its bound exact declaration identity.  Legal redeclarations retain
+   * the first stable identity.
+   */
+  [[nodiscard]] std::optional<SymbolId> exactDeclaration(
+      ScopeId scope, std::string_view name, bool parameterized) const;
+
+  /**
+   * Return the first initializer reference recorded at ``range``.
+   *
+   * The returned reference may be unresolved.  Its pointer remains valid until
+   * this table is moved, assigned, or destroyed.  Other reference kinds are
+   * deliberately excluded.
+   */
+  [[nodiscard]] const SymbolReference* initializerReference(
+      SourceRange range) const noexcept;
+
  private:
   friend struct SymbolTableBuilder;
 
@@ -188,6 +210,12 @@ class SymbolTable {
                                   std::string_view right) const noexcept {
       return left == right;
     }
+  };
+
+  /** Hash a source range for the initializer-reference occurrence index. */
+  struct SourceRangeHash {
+    /** Return a stable hash of both endpoints of a source range. */
+    [[nodiscard]] size_t operator()(const SourceRange& range) const noexcept;
   };
 
   /** A compact binary trie node for a range of decimal member indices. */
@@ -257,6 +285,9 @@ class SymbolTable {
   std::vector<Scope> scopes_;
   std::vector<Symbol> symbols_;
   std::vector<SymbolReference> references_;
+  /** First initializer reference by exact source range; values index references_. */
+  std::unordered_map<SourceRange, size_t, SourceRangeHash>
+      initializer_reference_indexes_;
   /** Scope-aligned owned accelerators; never borrow Symbol::name storage. */
   std::vector<ScopeNameIndex> scope_name_indexes_;
 };

--- a/submod/binding/include/ptx_symbol_table.hpp
+++ b/submod/binding/include/ptx_symbol_table.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <ptx_frontend/base/ptx_ast_types.hpp>
@@ -167,9 +171,94 @@ class SymbolTable {
  private:
   friend struct SymbolTableBuilder;
 
+  /** Transparent owned-string hash supporting allocation-free string-view probes. */
+  struct StringViewHash {
+    using is_transparent = void;
+    /** Hash a string-like spelling without requiring an owned temporary. */
+    [[nodiscard]] size_t operator()(std::string_view value) const noexcept {
+      return std::hash<std::string_view>{}(value);
+    }
+  };
+
+  /** Transparent spelling equality for owned index keys and lookup views. */
+  struct StringViewEqual {
+    using is_transparent = void;
+    /** Compare two string-like spellings without copying either operand. */
+    [[nodiscard]] bool operator()(std::string_view left,
+                                  std::string_view right) const noexcept {
+      return left == right;
+    }
+  };
+
+  /** A compact binary trie node for a range of decimal member indices. */
+  struct NumericMemberIndexNode {
+    /** Children selected by the corresponding bit of a 32-bit member index. */
+    std::array<std::optional<uint32_t>, 2> children;
+    /** Lowest inserted SymbolId reachable from this node, if any. */
+    std::optional<SymbolId> earliest_symbol;
+  };
+
+  /** Owns the sparse binary trie used to find members below a group count. */
+  struct NumericMemberIndex {
+    /** Root-first trie storage; vector relocation does not invalidate node IDs. */
+    std::vector<NumericMemberIndexNode> nodes{1};
+  };
+
+  /** A character-trie node identifying parameterized bases that share a prefix. */
+  struct ParameterizedPrefixNode {
+    /** Owned outgoing edges, indexed by the next spelling character. */
+    std::unordered_map<char, uint32_t> children;
+    /** Parameterized declaration whose base ends at this node, if present. */
+    std::optional<SymbolId> symbol;
+  };
+
+  /** Owns the parameterized-base prefix trie for one lexical scope. */
+  struct ParameterizedPrefixIndex {
+    /** Root-first trie storage; edges refer to stable numeric node IDs. */
+    std::vector<ParameterizedPrefixNode> nodes{1};
+  };
+
+  /** All owned lookup and overlap indexes for a single lexical scope. */
+  struct ScopeNameIndex {
+    /** Exact ordinary declaration spelling to its first stable identity. */
+    std::unordered_map<std::string, SymbolId, StringViewHash, StringViewEqual>
+        ordinary_exact;
+    /** Exact parameterized base spelling to its first stable identity. */
+    std::unordered_map<std::string, SymbolId, StringViewHash, StringViewEqual>
+        parameterized_exact;
+    /** Prefix index of compact parameterized declaration bases. */
+    ParameterizedPrefixIndex parameterized_prefixes;
+    /** Member-spelling base to sparse numeric range index. */
+    std::unordered_map<std::string, NumericMemberIndex, StringViewHash,
+                       StringViewEqual>
+        member_prefixes;
+  };
+
+  /** Retain the lower stable identity while combining index candidates. */
+  static void keepEarliest(std::optional<SymbolId>& destination,
+                           SymbolId candidate);
+  /** Insert one concrete member number into a compact range index. */
+  static void indexMemberNumber(NumericMemberIndex& index, uint32_t member,
+                                SymbolId symbol);
+  /** Return the first identity associated with a member below ``limit``. */
+  [[nodiscard]] static std::optional<SymbolId> earliestMemberBelow(
+      const NumericMemberIndex& index, uint32_t limit);
+  /** Insert one parameterized declaration base into its prefix index. */
+  static void indexParameterizedBase(ParameterizedPrefixIndex& index,
+                                     std::string_view base, SymbolId symbol);
+  /** Find the earliest compact group whose generated member matches spelling. */
+  [[nodiscard]] static std::optional<SymbolId> parameterizedContaining(
+      const ParameterizedPrefixIndex& index, const std::vector<Symbol>& symbols,
+      std::string_view spelling);
+  /** Index every valid base/member decomposition of one stored spelling. */
+  static void indexMemberSpelling(ScopeNameIndex& index,
+                                  std::string_view spelling, SymbolId symbol);
+
   std::vector<Scope> scopes_;
   std::vector<Symbol> symbols_;
   std::vector<SymbolReference> references_;
+  /** Scope-aligned owned accelerators; never borrow Symbol::name storage. */
+  std::vector<ScopeNameIndex> scope_name_indexes_;
 };
 
 struct SymbolBinding {

--- a/submod/binding/src/ptx_symbol_table.cpp
+++ b/submod/binding/src/ptx_symbol_table.cpp
@@ -75,6 +75,19 @@ void SymbolTable::keepEarliest(std::optional<SymbolId>& destination,
     destination = candidate;
 }
 
+size_t SymbolTable::SourceRangeHash::operator()(
+    const SourceRange& range) const noexcept {
+  size_t result = std::hash<int32_t>{}(range.start.line);
+  const auto combine = [&result](int32_t value) {
+    result ^= std::hash<int32_t>{}(value) + 0x9e3779b9u + (result << 6u) +
+              (result >> 2u);
+  };
+  combine(range.start.column);
+  combine(range.end.line);
+  combine(range.end.column);
+  return result;
+}
+
 void SymbolTable::indexMemberNumber(NumericMemberIndex& index, uint32_t member,
                                     SymbolId symbol) {
   uint32_t node = 0;
@@ -333,6 +346,24 @@ std::optional<SymbolLookup> SymbolTable::lookup(ScopeId scope_id,
       return std::nullopt;
     scope_id = *current.parent;
   }
+}
+
+std::optional<SymbolId> SymbolTable::exactDeclaration(
+    ScopeId scope, std::string_view name, bool parameterized) const {
+  const ScopeNameIndex& index = scope_name_indexes_.at(scope.value);
+  const auto& declarations = parameterized ? index.parameterized_exact
+                                           : index.ordinary_exact;
+  const auto found = declarations.find(name);
+  return found == declarations.end() ? std::nullopt
+                                     : std::optional<SymbolId>{found->second};
+}
+
+const SymbolReference* SymbolTable::initializerReference(
+    SourceRange range) const noexcept {
+  const auto found = initializer_reference_indexes_.find(range);
+  if (found == initializer_reference_indexes_.end())
+    return nullptr;
+  return &references_[found->second];
 }
 
 struct SymbolTableBuilder {
@@ -726,6 +757,10 @@ struct SymbolTableBuilder {
         .classification = classification,
         .target = target,
     });
+    if (kind == ReferenceKind::Initializer) {
+      result.table.initializer_reference_indexes_.try_emplace(
+          identifier.syntax.range, result.table.references_.size() - 1);
+    }
     if (classification == ReferenceClassification::Unresolved) {
       result.diagnostics.push_back(BindDiagnostic{
           .kind = BindDiagnosticKind::UnresolvedReference,

--- a/submod/binding/src/ptx_symbol_table.cpp
+++ b/submod/binding/src/ptx_symbol_table.cpp
@@ -12,15 +12,16 @@
 
 #include <fmt/format.h>
 
-#include <ptx_frontend/base/ptx_special_register.hpp>
 #include <ptx_frontend/base/ptx_integer.hpp>
+#include <ptx_frontend/base/ptx_special_register.hpp>
 
 namespace ptx_frontend::binding {
 namespace {
 
 std::optional<uint32_t> parseParameterizedIndex(std::string_view base,
                                                 std::string_view name) {
-  if (!name.starts_with(base) || name.size() == base.size())
+  if (base.size() >= name.size() || name.size() - base.size() > 10 ||
+      !name.starts_with(base))
     return std::nullopt;
   const std::string_view suffix = name.substr(base.size());
   if (suffix.size() > 1 && suffix.front() == '0')
@@ -66,10 +67,115 @@ bool symbolNameSetsOverlap(const Symbol& existing, std::string_view name,
          parameterizedNameContains(name, *parameterized_count, existing_first);
 }
 
-bool isMetadataSymbol(SymbolKind kind) {
-  return kind == SymbolKind::DebugFile ||
-         kind == SymbolKind::DebugStringLabel;
+}  // namespace
+
+void SymbolTable::keepEarliest(std::optional<SymbolId>& destination,
+                               SymbolId candidate) {
+  if (!destination || candidate.value < destination->value)
+    destination = candidate;
 }
+
+void SymbolTable::indexMemberNumber(NumericMemberIndex& index, uint32_t member,
+                                    SymbolId symbol) {
+  uint32_t node = 0;
+  keepEarliest(index.nodes[node].earliest_symbol, symbol);
+  for (int bit = 31; bit >= 0; --bit) {
+    const auto branch = static_cast<size_t>((member >> bit) & 1u);
+    const std::optional<uint32_t> child = index.nodes[node].children[branch];
+    if (!child) {
+      const uint32_t next = static_cast<uint32_t>(index.nodes.size());
+      index.nodes[node].children[branch] = next;
+      index.nodes.push_back({});
+      node = next;
+    } else {
+      node = *child;
+    }
+    keepEarliest(index.nodes[node].earliest_symbol, symbol);
+  }
+}
+
+std::optional<SymbolId> SymbolTable::earliestMemberBelow(
+    const NumericMemberIndex& index, uint32_t limit) {
+  if (limit == 0 || index.nodes.empty())
+    return std::nullopt;
+
+  std::optional<SymbolId> result;
+  uint32_t node = 0;
+  for (int bit = 31; bit >= 0; --bit) {
+    const auto branch = static_cast<size_t>((limit >> bit) & 1u);
+    if (branch != 0 && index.nodes[node].children[0]) {
+      keepEarliest(
+          result, *index.nodes[*index.nodes[node].children[0]].earliest_symbol);
+    }
+    const std::optional<uint32_t>& next = index.nodes[node].children[branch];
+    if (!next)
+      return result;
+    node = *next;
+  }
+  return result;
+}
+
+void SymbolTable::indexParameterizedBase(ParameterizedPrefixIndex& index,
+                                         std::string_view base,
+                                         SymbolId symbol) {
+  uint32_t node = 0;
+  for (const char character : base) {
+    uint32_t next;
+    if (const auto found = index.nodes[node].children.find(character);
+        found != index.nodes[node].children.end()) {
+      next = found->second;
+    } else {
+      next = static_cast<uint32_t>(index.nodes.size());
+      index.nodes[node].children.emplace(character, next);
+      index.nodes.push_back({});
+    }
+    node = next;
+  }
+  keepEarliest(index.nodes[node].symbol, symbol);
+}
+
+std::optional<SymbolId> SymbolTable::parameterizedContaining(
+    const ParameterizedPrefixIndex& index, const std::vector<Symbol>& symbols,
+    std::string_view spelling) {
+  if (index.nodes.empty())
+    return std::nullopt;
+
+  std::optional<SymbolId> result;
+  uint32_t node = 0;
+  for (const char character : spelling) {
+    const auto found = index.nodes[node].children.find(character);
+    if (found == index.nodes[node].children.end())
+      break;
+    node = found->second;
+    if (!index.nodes[node].symbol)
+      continue;
+    const Symbol& candidate = symbols[index.nodes[node].symbol->value];
+    const auto member = parseParameterizedIndex(candidate.name, spelling);
+    if (member && candidate.parameterized_count &&
+        *member < *candidate.parameterized_count) {
+      keepEarliest(result, candidate.id);
+    }
+  }
+  return result;
+}
+
+void SymbolTable::indexMemberSpelling(ScopeNameIndex& index,
+                                      std::string_view spelling,
+                                      SymbolId symbol) {
+  const size_t first_base_length =
+      std::max<size_t>(1, spelling.size() > 10 ? spelling.size() - 10 : 1);
+  for (size_t base_length = first_base_length; base_length < spelling.size();
+       ++base_length) {
+    const std::string_view base = spelling.substr(0, base_length);
+    const auto member = parseParameterizedIndex(base, spelling);
+    if (!member)
+      continue;
+    const auto insertion = index.member_prefixes.try_emplace(std::string{base});
+    indexMemberNumber(insertion.first->second, *member, symbol);
+  }
+}
+
+namespace {
 
 std::optional<uint64_t> parseDebugFileId(std::string_view text) {
   return base::parseIntegerMagnitude(text);
@@ -90,17 +196,15 @@ SymbolLinkage linkageFromSpelling(std::string_view spelling) {
 }
 
 std::optional<uint64_t> scalarAlignment(std::string_view type) {
-  if (type == ".u8" || type == ".s8" || type == ".b8" ||
-      type == ".pred")
+  if (type == ".u8" || type == ".s8" || type == ".b8" || type == ".pred")
     return 1;
-  if (type == ".u16" || type == ".s16" || type == ".b16" ||
-      type == ".f16" || type == ".bf16")
+  if (type == ".u16" || type == ".s16" || type == ".b16" || type == ".f16" ||
+      type == ".bf16")
     return 2;
-  if (type == ".u32" || type == ".s32" || type == ".b32" ||
-      type == ".f32" || type == ".f16x2" || type == ".tf32")
+  if (type == ".u32" || type == ".s32" || type == ".b32" || type == ".f32" ||
+      type == ".f16x2" || type == ".tf32")
     return 4;
-  if (type == ".u64" || type == ".s64" || type == ".b64" ||
-      type == ".f64")
+  if (type == ".u64" || type == ".s64" || type == ".b64" || type == ".f64")
     return 8;
   if (type == ".b128")
     return 16;
@@ -194,8 +298,8 @@ std::optional<ScopeId> SymbolTable::functionScope(SourceRange range) const {
 
 std::optional<ScopeId> SymbolTable::blockScope(ScopeId parent,
                                                SourceRange range) const {
-  const auto found = std::ranges::find_if(
-      scopes_, [parent, range](const Scope& scope) {
+  const auto found =
+      std::ranges::find_if(scopes_, [parent, range](const Scope& scope) {
         return scope.kind == ScopeKind::Block && scope.parent == parent &&
                scope.range == range;
       });
@@ -205,19 +309,24 @@ std::optional<ScopeId> SymbolTable::blockScope(ScopeId parent,
 std::optional<SymbolLookup> SymbolTable::lookup(ScopeId scope_id,
                                                 std::string_view name) const {
   for (;;) {
-    for (const Symbol& candidate : symbols_) {
-      if (candidate.scope != scope_id || isMetadataSymbol(candidate.kind))
-        continue;
-      if (!candidate.parameterized_count && candidate.name == name)
-        return SymbolLookup{candidate.id, std::nullopt};
+    const ScopeNameIndex& index = scope_name_indexes_.at(scope_id.value);
+    if (const auto ordinary = index.ordinary_exact.find(name);
+        ordinary != index.ordinary_exact.end()) {
+      return SymbolLookup{ordinary->second, std::nullopt};
     }
-    for (const Symbol& candidate : symbols_) {
-      if (candidate.scope != scope_id || isMetadataSymbol(candidate.kind) ||
-          !candidate.parameterized_count)
-        continue;
-      const auto index = parseParameterizedIndex(candidate.name, name);
-      if (index && *index < *candidate.parameterized_count)
-        return SymbolLookup{candidate.id, *index};
+    // A single compact group needs no prefix traversal or candidate ordering.
+    if (index.parameterized_exact.size() == 1) {
+      const Symbol& symbol =
+          symbols_[index.parameterized_exact.begin()->second.value];
+      const auto member = parseParameterizedIndex(symbol.name, name);
+      if (member && symbol.parameterized_count &&
+          *member < *symbol.parameterized_count)
+        return SymbolLookup{symbol.id, *member};
+    } else if (const auto parameterized = parameterizedContaining(
+                   index.parameterized_prefixes, symbols_, name)) {
+      const Symbol& symbol = symbols_[parameterized->value];
+      return SymbolLookup{*parameterized,
+                          parseParameterizedIndex(symbol.name, name)};
     }
     const Scope& current = scope(scope_id);
     if (!current.parent)
@@ -243,6 +352,7 @@ struct SymbolTableBuilder {
         .owner = std::nullopt,
         .range = std::nullopt,
     });
+    result.table.scope_name_indexes_.emplace_back();
   }
 
   /** Associate a declaration's range with its scope, not its canonical symbol. */
@@ -256,6 +366,7 @@ struct SymbolTableBuilder {
         .owner = owner,
         .range = range,
     });
+    result.table.scope_name_indexes_.emplace_back();
     Symbol& symbol = result.table.symbols_[owner.value];
     if (!symbol.owned_scope || prefer_as_owned_scope)
       symbol.owned_scope = id;
@@ -271,21 +382,63 @@ struct SymbolTableBuilder {
         .owner = std::nullopt,
         .range = range,
     });
+    result.table.scope_name_indexes_.emplace_back();
     return id;
   }
 
   std::optional<SymbolId> exactSymbol(
       ScopeId scope, std::string_view name,
       std::optional<uint32_t> parameterized_count) const {
-    for (const Symbol& symbol : result.table.symbols_) {
-      if (!isMetadataSymbol(symbol.kind) && symbol.scope == scope &&
-          symbol.name == name &&
-          symbol.parameterized_count.has_value() ==
-              parameterized_count.has_value()) {
-        return symbol.id;
-      }
+    const SymbolTable::ScopeNameIndex& index =
+        result.table.scope_name_indexes_.at(scope.value);
+    const auto& exact =
+        parameterized_count ? index.parameterized_exact : index.ordinary_exact;
+    const auto found = exact.find(name);
+    return found == exact.end() ? std::nullopt
+                                : std::optional<SymbolId>{found->second};
+  }
+
+  /** Find the earliest same-scope declaration matching the overlap predicate. */
+  std::optional<SymbolId> overlappingSymbol(
+      ScopeId scope, std::string_view name,
+      std::optional<uint32_t> parameterized_count) const {
+    const SymbolTable::ScopeNameIndex& index =
+        result.table.scope_name_indexes_.at(scope.value);
+    std::optional<SymbolId> result_symbol;
+    if (!parameterized_count)
+      return SymbolTable::parameterizedContaining(index.parameterized_prefixes,
+                                                  result.table.symbols_, name);
+
+    if (const auto containing = SymbolTable::parameterizedContaining(
+            index.parameterized_prefixes, result.table.symbols_, name))
+      SymbolTable::keepEarliest(result_symbol, *containing);
+    const std::string first_member = std::string{name} + "0";
+    if (const auto containing = SymbolTable::parameterizedContaining(
+            index.parameterized_prefixes, result.table.symbols_, first_member))
+      SymbolTable::keepEarliest(result_symbol, *containing);
+    if (const auto members = index.member_prefixes.find(name);
+        members != index.member_prefixes.end()) {
+      if (const auto member = SymbolTable::earliestMemberBelow(
+              members->second, *parameterized_count))
+        SymbolTable::keepEarliest(result_symbol, *member);
     }
-    return std::nullopt;
+    return result_symbol;
+  }
+
+  /** Add one non-metadata declaration to its scope-local owned indexes. */
+  void indexSymbol(const Symbol& symbol) {
+    SymbolTable::ScopeNameIndex& index =
+        result.table.scope_name_indexes_.at(symbol.scope.value);
+    if (!symbol.parameterized_count) {
+      index.ordinary_exact.emplace(symbol.name, symbol.id);
+      SymbolTable::indexMemberSpelling(index, symbol.name, symbol.id);
+      return;
+    }
+    index.parameterized_exact.emplace(symbol.name, symbol.id);
+    SymbolTable::indexParameterizedBase(index.parameterized_prefixes,
+                                        symbol.name, symbol.id);
+    SymbolTable::indexMemberSpelling(index, symbol.name, symbol.id);
+    SymbolTable::indexMemberSpelling(index, symbol.name + "0", symbol.id);
   }
 
   SymbolId addSymbol(
@@ -312,21 +465,20 @@ struct SymbolTableBuilder {
       return *previous;
     }
 
-    for (const Symbol& existing : result.table.symbols_) {
-      if (isMetadataSymbol(existing.kind) || existing.scope != scope ||
-          !symbolNameSetsOverlap(existing, name, parameterized_count)) {
-        continue;
+    if (const auto overlap =
+            overlappingSymbol(scope, name, parameterized_count)) {
+      const Symbol& existing = result.table.symbol(*overlap);
+      if (symbolNameSetsOverlap(existing, name, parameterized_count)) {
+        result.diagnostics.push_back(BindDiagnostic{
+            .kind = BindDiagnosticKind::DuplicateSymbol,
+            .range = declaration_range,
+            .previous_range = existing.declaration_range,
+            .message = fmt::format(
+                "Declarations '{}' and '{}' produce overlapping symbol names "
+                "in the same scope.",
+                name, existing.name),
+        });
       }
-      result.diagnostics.push_back(BindDiagnostic{
-          .kind = BindDiagnosticKind::DuplicateSymbol,
-          .range = declaration_range,
-          .previous_range = existing.declaration_range,
-          .message = fmt::format(
-              "Declarations '{}' and '{}' produce overlapping symbol names "
-              "in the same scope.",
-              name, existing.name),
-      });
-      break;
     }
 
     const SymbolId id{static_cast<uint32_t>(result.table.symbols_.size())};
@@ -347,11 +499,12 @@ struct SymbolTableBuilder {
         .function_is_entry = function_is_entry,
         .canonical_function = std::nullopt,
     });
+    indexSymbol(result.table.symbols_.back());
     return id;
   }
 
   std::optional<SymbolId> findMetadataSymbol(SymbolKind kind,
-                                              std::string_view name) const {
+                                             std::string_view name) const {
     for (const Symbol& symbol : result.table.symbols_) {
       if (symbol.scope == result.table.moduleScope() && symbol.kind == kind &&
           symbol.name == name) {
@@ -362,17 +515,15 @@ struct SymbolTableBuilder {
   }
 
   SymbolId addMetadataSymbol(SymbolKind kind, std::string_view name,
-                             SourceRange declaration_range,
-                             bool idempotent) {
+                             SourceRange declaration_range, bool idempotent) {
     if (const auto previous = findMetadataSymbol(kind, name)) {
       if (!idempotent) {
         result.diagnostics.push_back(BindDiagnostic{
             .kind = BindDiagnosticKind::DuplicateSymbol,
             .range = declaration_range,
-            .previous_range =
-                result.table.symbol(*previous).declaration_range,
-            .message = fmt::format("Duplicate symbol '{}' in debug metadata.",
-                                   name),
+            .previous_range = result.table.symbol(*previous).declaration_range,
+            .message =
+                fmt::format("Duplicate symbol '{}' in debug metadata.", name),
         });
       }
       return *previous;
@@ -417,7 +568,8 @@ struct SymbolTableBuilder {
       return std::nullopt;
     const auto count =
         base::parseIntegerMagnitude(declarator.parameterized_count->text);
-    if (!count || *count == 0 || *count > std::numeric_limits<uint32_t>::max()) {
+    if (!count || *count == 0 ||
+        *count > std::numeric_limits<uint32_t>::max()) {
       result.diagnostics.push_back(BindDiagnostic{
           .kind = BindDiagnosticKind::InvalidParameterizedCount,
           .range = declarator.parameterized_count->range,
@@ -482,29 +634,26 @@ struct SymbolTableBuilder {
   }
 
   void collectFunction(const syntax_ast::AstFunction& function) {
-    const SymbolId function_symbol =
-        addSymbol(result.table.moduleScope(), SymbolKind::Function,
-                  function.name.syntax.text, function.name.syntax.range,
-                  linkage(function.qualifiers, function.range), std::nullopt,
-                  std::nullopt, std::nullopt, std::nullopt, true,
-                  function.is_entry);
-    const ScopeId function_scope =
-        addFunctionScope(function_symbol, function.range, !function.is_prototype);
+    const SymbolId function_symbol = addSymbol(
+        result.table.moduleScope(), SymbolKind::Function,
+        function.name.syntax.text, function.name.syntax.range,
+        linkage(function.qualifiers, function.range), std::nullopt,
+        std::nullopt, std::nullopt, std::nullopt, true, function.is_entry);
+    const ScopeId function_scope = addFunctionScope(
+        function_symbol, function.range, !function.is_prototype);
     functions.push_back(FunctionContext{&function, function_scope});
 
     for (const auto& parameter : function.return_parameters) {
       addSymbol(function_scope, SymbolKind::ReturnParameter,
                 parameter.name.syntax.text, parameter.name.syntax.range,
-                SymbolLinkage::None, parameter.state_space,
-                parameter.type.text,
+                SymbolLinkage::None, parameter.state_space, parameter.type.text,
                 declarationAlignment(parameter.alignment, std::nullopt,
                                      parameter.type.text));
     }
     for (const auto& parameter : function.parameters) {
       addSymbol(function_scope, SymbolKind::InputParameter,
                 parameter.name.syntax.text, parameter.name.syntax.range,
-                SymbolLinkage::None, parameter.state_space,
-                parameter.type.text,
+                SymbolLinkage::None, parameter.state_space, parameter.type.text,
                 declarationAlignment(parameter.alignment, std::nullopt,
                                      parameter.type.text));
     }
@@ -516,11 +665,10 @@ struct SymbolTableBuilder {
                                     alias.aliasee.syntax.text, std::nullopt);
     if (!target || result.table.symbol(*target).kind != SymbolKind::Function)
       return;
-    const SymbolId alias_symbol =
-        addSymbol(result.table.moduleScope(), SymbolKind::Function,
-                  alias.alias.syntax.text, alias.alias.syntax.range,
-                  SymbolLinkage::None, std::nullopt, std::nullopt,
-                  std::nullopt, std::nullopt, true, false);
+    const SymbolId alias_symbol = addSymbol(
+        result.table.moduleScope(), SymbolKind::Function,
+        alias.alias.syntax.text, alias.alias.syntax.range, SymbolLinkage::None,
+        std::nullopt, std::nullopt, std::nullopt, std::nullopt, true, false);
     Symbol& symbol = result.table.symbols_[alias_symbol.value];
     if (symbol.kind == SymbolKind::Function)
       symbol.canonical_function = *target;
@@ -538,8 +686,7 @@ struct SymbolTableBuilder {
       } else if (const auto* prototype =
                      std::get_if<syntax_ast::AstCallPrototype>(&item)) {
         addSymbol(function_scope, SymbolKind::CallPrototype,
-                  prototype->label.syntax.text,
-                  prototype->label.syntax.range);
+                  prototype->label.syntax.text, prototype->label.syntax.range);
       } else if (const auto* targets =
                      std::get_if<syntax_ast::AstCallTargets>(&item)) {
         addSymbol(function_scope, SymbolKind::CallTargetSet,
@@ -549,8 +696,7 @@ struct SymbolTableBuilder {
         addSymbol(function_scope, SymbolKind::BranchTargetSet,
                   targets->label.syntax.text, targets->label.syntax.range);
       } else if (const auto* block =
-                     std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(
-                         &item);
+                     std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(&item);
                  block != nullptr && *block) {
         collectBody((*block)->body, function_scope,
                     addBlockScope(lexical_scope, (*block)->range));
@@ -598,8 +744,7 @@ struct SymbolTableBuilder {
     std::optional<SymbolId> target;
     if (kind == ReferenceKind::DebugFile) {
       if (const auto id = parseDebugFileId(syntax.text)) {
-        target = findMetadataSymbol(SymbolKind::DebugFile,
-                                    std::to_string(*id));
+        target = findMetadataSymbol(SymbolKind::DebugFile, std::to_string(*id));
       }
     } else {
       target = findMetadataSymbol(SymbolKind::DebugStringLabel, syntax.text);
@@ -627,8 +772,7 @@ struct SymbolTableBuilder {
   }
 
   void bindLoc(ScopeId scope, const syntax_ast::AstLocDirective& directive) {
-    addMetadataReference(scope, ReferenceKind::DebugFile,
-                         directive.file_index);
+    addMetadataReference(scope, ReferenceKind::DebugFile, directive.file_index);
     if (!directive.inline_context)
       return;
     addMetadataReference(scope, ReferenceKind::DebugFunctionName,
@@ -820,11 +964,12 @@ struct SymbolTableBuilder {
               const SymbolKind kind =
                   result.table.symbol(reference.target->symbol).kind;
               diagnoseInvalidTarget(
-                  reference, kind == SymbolKind::CallPrototype ||
-                                 kind == SymbolKind::CallTargetSet,
+                  reference,
+                  kind == SymbolKind::CallPrototype ||
+                      kind == SymbolKind::CallTargetSet,
                   fmt::format("Call target set '{}' must name a "
                               ".callprototype or .calltargets declaration.",
-                                value.name.syntax.text));
+                              value.name.syntax.text));
             }
           } else if constexpr (std::same_as<Value,
                                             syntax_ast::AstBranchTargetSet>) {
@@ -834,8 +979,9 @@ struct SymbolTableBuilder {
               const Symbol& symbol =
                   result.table.symbol(reference.target->symbol);
               diagnoseInvalidTarget(
-                  reference, symbol.kind == SymbolKind::BranchTargetSet &&
-                                 symbol.scope == function_scope,
+                  reference,
+                  symbol.kind == SymbolKind::BranchTargetSet &&
+                      symbol.scope == function_scope,
                   fmt::format("Branch target set '{}' must name a "
                               ".branchtargets declaration in the current "
                               "function.",
@@ -848,8 +994,9 @@ struct SymbolTableBuilder {
               const Symbol& symbol =
                   result.table.symbol(reference.target->symbol);
               diagnoseInvalidTarget(
-                  reference, symbol.kind == SymbolKind::Label &&
-                                 symbol.scope == function_scope,
+                  reference,
+                  symbol.kind == SymbolKind::Label &&
+                      symbol.scope == function_scope,
                   fmt::format("Branch target '{}' must name a label in the "
                               "current function.",
                               value.name.syntax.text));
@@ -898,8 +1045,7 @@ struct SymbolTableBuilder {
                      std::get_if<syntax_ast::AstLocDirective>(&item)) {
         bindLoc(lexical_scope, *loc);
       } else if (const auto* block =
-                     std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(
-                         &item);
+                     std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(&item);
                  block != nullptr && *block) {
         const auto block_scope =
             result.table.blockScope(lexical_scope, (*block)->range);

--- a/submod/binding/test/test_ptx_symbol_table.cpp
+++ b/submod/binding/test/test_ptx_symbol_table.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include <ptx_frontend/base/ptx_special_register.hpp>
 #include <ptx_frontend/binding/ptx_symbol_table.hpp>
@@ -153,6 +154,110 @@ start:
   ASSERT_TRUE(label->target.has_value());
   EXPECT_EQ(table.symbol(label->target->symbol).kind,
             binding::SymbolKind::Label);
+}
+
+/** Exact declaration lookup remains local and distinguishes compact bases. */
+TEST(PtxSymbolTable, ExactDeclarationPreservesLocalCompactIdentity) {
+  PtxSyntaxParser parser(R"ptx(
+.file 1 "source.ptx"
+.global .u32 value;
+.entry kernel() {
+  .reg .u32 %r<2>;
+  {
+    .local .u32 value;
+    .shared .u32 %r<3>;
+  }
+}
+)ptx");
+  const auto module = parser.parseModule();
+  ASSERT_TRUE(module.has_value());
+  ASSERT_TRUE(module.diagnostics.empty());
+  const auto binding_result = binding::bindSymbols(*module);
+  ASSERT_TRUE(binding_result.diagnostics.empty());
+  const auto& table = binding_result.table;
+
+  const auto kernel = table.lookup(table.moduleScope(), "kernel");
+  ASSERT_TRUE(kernel.has_value());
+  const auto function_scope = table.symbol(kernel->symbol).owned_scope;
+  ASSERT_TRUE(function_scope.has_value());
+  const auto block = std::ranges::find_if(
+      table.scopes(), [function_scope](const binding::Scope& scope) {
+        return scope.kind == binding::ScopeKind::Block &&
+               scope.parent == function_scope;
+      });
+  ASSERT_NE(block, table.scopes().end());
+
+  const auto module_value =
+      table.exactDeclaration(table.moduleScope(), "value", false);
+  const auto function_register =
+      table.exactDeclaration(*function_scope, "%r", true);
+  const auto block_value = table.exactDeclaration(block->id, "value", false);
+  const auto block_register = table.exactDeclaration(block->id, "%r", true);
+  ASSERT_TRUE(module_value.has_value());
+  ASSERT_TRUE(function_register.has_value());
+  ASSERT_TRUE(block_value.has_value());
+  ASSERT_TRUE(block_register.has_value());
+  EXPECT_FALSE(table.exactDeclaration(*function_scope, "value", false));
+  EXPECT_FALSE(table.exactDeclaration(block->id, "%r", false));
+  EXPECT_FALSE(table.exactDeclaration(table.moduleScope(), "1", false));
+  EXPECT_NE(*function_register, *block_register);
+  EXPECT_EQ(table.symbol(*module_value).scope, table.moduleScope());
+  EXPECT_EQ(table.symbol(*block_value).scope, block->id);
+  EXPECT_EQ(table.symbol(*function_register).parameterized_count, 2u);
+  EXPECT_EQ(table.symbol(*block_register).parameterized_count, 3u);
+}
+
+/** Initializer occurrence indexing retains first unresolved references after copying. */
+TEST(PtxSymbolTable, InitializerReferenceIndexRetainsFirstUnresolvedRange) {
+  PtxSyntaxParser parser(R"ptx(
+.global .u64 target;
+.global .u64 first = missing;
+.global .u64 second = target;
+)ptx");
+  auto module = parser.parseModule();
+  ASSERT_TRUE(module.has_value());
+  ASSERT_TRUE(module.diagnostics.empty());
+  auto* first_declaration =
+      std::get_if<syntax_ast::AstVariableDeclaration>(&module->items[1]);
+  auto* second_declaration =
+      std::get_if<syntax_ast::AstVariableDeclaration>(&module->items[2]);
+  ASSERT_NE(first_declaration, nullptr);
+  ASSERT_NE(second_declaration, nullptr);
+  auto* first_expression = std::get_if<syntax_ast::AstConstantExpression>(
+      &first_declaration->declarators[0].initializer->value);
+  auto* second_expression = std::get_if<syntax_ast::AstConstantExpression>(
+      &second_declaration->declarators[0].initializer->value);
+  ASSERT_NE(first_expression, nullptr);
+  ASSERT_NE(second_expression, nullptr);
+  auto* first_symbol =
+      std::get_if<syntax_ast::AstConstantSymbol>(&first_expression->node);
+  auto* second_symbol =
+      std::get_if<syntax_ast::AstConstantSymbol>(&second_expression->node);
+  ASSERT_NE(first_symbol, nullptr);
+  ASSERT_NE(second_symbol, nullptr);
+  second_symbol->name.syntax.range = first_symbol->name.syntax.range;
+
+  const auto bound = binding::bindSymbols(*module);
+  ASSERT_FALSE(bound.diagnostics.empty());
+  const binding::SymbolReference* first = bound.table.initializerReference(
+      first_symbol->name.syntax.range);
+  ASSERT_NE(first, nullptr);
+  EXPECT_EQ(first->spelling, "missing");
+  EXPECT_FALSE(first->target.has_value());
+
+  auto copied = bound.table;
+  const binding::SymbolReference* copied_first = copied.initializerReference(
+      first_symbol->name.syntax.range);
+  ASSERT_NE(copied_first, nullptr);
+  EXPECT_EQ(copied_first->spelling, "missing");
+  EXPECT_FALSE(copied_first->target.has_value());
+
+  auto moved = std::move(copied);
+  const binding::SymbolReference* moved_first = moved.initializerReference(
+      first_symbol->name.syntax.range);
+  ASSERT_NE(moved_first, nullptr);
+  EXPECT_EQ(moved_first->spelling, "missing");
+  EXPECT_FALSE(moved_first->target.has_value());
 }
 
 TEST(PtxSymbolTable, BindsNestedBlocksLexicallyButKeepsControlMetadataLocal) {

--- a/submod/binding/test/test_symbol_table_index_equivalence.cpp
+++ b/submod/binding/test/test_symbol_table_index_equivalence.cpp
@@ -47,6 +47,21 @@ std::optional<SymbolLookup> linearLookup(const SymbolTable& table, ScopeId scope
   }
 }
 
+/** Independently retain exact local declaration matching as an oracle. */
+std::optional<SymbolId> linearExactDeclaration(const SymbolTable& table,
+                                               ScopeId scope,
+                                               std::string_view name,
+                                               bool parameterized) {
+  for (const Symbol& symbol : table.symbols()) {
+    if (symbol.scope == scope && symbol.kind != SymbolKind::DebugFile &&
+        symbol.kind != SymbolKind::DebugStringLabel && symbol.name == name &&
+        symbol.parameterized_count.has_value() == parameterized) {
+      return symbol.id;
+    }
+  }
+  return std::nullopt;
+}
+
 /** Test represented membership without using the production overlap helpers. */
 bool memberOf(std::string_view base, uint32_t count, std::string_view name) {
   if (!name.starts_with(base) || name.size() == base.size())
@@ -92,6 +107,7 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
   for (int function = 0; function < 4; ++function) {
     source += ".entry k" + std::to_string(function) + "() {\n";
     source += ".reg .u32 child<10>;\n.reg .u32 outer;\n";
+    source += ".reg .u32 zero<0>;\n";
     for (int group = 0; group < 16; ++group) {
       const std::string base = "%r" + std::to_string(group) + "_";
       source += ".reg .u32 " + base + "<12>;\n";
@@ -109,10 +125,18 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
   const auto bound = bindSymbols(*parsed);
   // Overlapping declarations are intentionally retained to test first-ID wins.
   ASSERT_FALSE(bound.diagnostics.empty());
+  std::vector<const BindDiagnostic*> duplicate_diagnostics;
+  size_t invalid_parameterized_count = 0;
   for (const auto& diagnostic : bound.diagnostics) {
+    if (diagnostic.kind == BindDiagnosticKind::InvalidParameterizedCount) {
+      ++invalid_parameterized_count;
+      continue;
+    }
     EXPECT_EQ(diagnostic.kind, BindDiagnosticKind::DuplicateSymbol);
     EXPECT_TRUE(diagnostic.previous_range.has_value());
+    duplicate_diagnostics.push_back(&diagnostic);
   }
+  EXPECT_EQ(invalid_parameterized_count, 4u);
   size_t overlap_count = 0;
   for (const auto& current : bound.table.symbols()) {
     for (const auto& previous : bound.table.symbols()) {
@@ -123,14 +147,14 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
           previous.kind == SymbolKind::DebugStringLabel ||
           !overlaps(previous, current))
         continue;
-      ASSERT_LT(overlap_count, bound.diagnostics.size());
-      const auto& diagnostic = bound.diagnostics[overlap_count++];
+      ASSERT_LT(overlap_count, duplicate_diagnostics.size());
+      const BindDiagnostic& diagnostic = *duplicate_diagnostics[overlap_count++];
       EXPECT_EQ(diagnostic.range, current.declaration_range);
       EXPECT_EQ(diagnostic.previous_range, previous.declaration_range);
       break;
     }
   }
-  EXPECT_EQ(overlap_count, bound.diagnostics.size());
+  EXPECT_EQ(overlap_count, duplicate_diagnostics.size());
 
   std::vector<std::string> queries{"missing", "metadata_only", "1", "child3",
                                    "sibling", "outer10"};
@@ -153,6 +177,17 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
       if (expected) {
         EXPECT_EQ(actual->symbol, expected->symbol);
         EXPECT_EQ(actual->parameterized_index, expected->parameterized_index);
+      }
+    }
+    for (const auto& query : queries) {
+      for (const bool parameterized : {false, true}) {
+        SCOPED_TRACE(query);
+        SCOPED_TRACE(scope.id.value);
+        SCOPED_TRACE(parameterized);
+        const auto expected = linearExactDeclaration(
+            bound.table, scope.id, query, parameterized);
+        EXPECT_EQ(bound.table.exactDeclaration(scope.id, query, parameterized),
+                  expected);
       }
     }
   }

--- a/submod/binding/test/test_symbol_table_index_equivalence.cpp
+++ b/submod/binding/test/test_symbol_table_index_equivalence.cpp
@@ -1,0 +1,162 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <charconv>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <ptx_frontend/binding/ptx_symbol_table.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::binding {
+namespace {
+
+/** Independently retain the original vector-search contract as a test oracle. */
+std::optional<SymbolLookup> linearLookup(const SymbolTable& table, ScopeId scope,
+                                        std::string_view name) {
+  for (;;) {
+    for (const auto& symbol : table.symbols()) {
+      if (symbol.scope == scope && symbol.kind != SymbolKind::DebugFile &&
+          symbol.kind != SymbolKind::DebugStringLabel &&
+          !symbol.parameterized_count && symbol.name == name)
+        return SymbolLookup{symbol.id, std::nullopt};
+    }
+    for (const auto& symbol : table.symbols()) {
+      if (symbol.scope != scope || !symbol.parameterized_count ||
+          !name.starts_with(symbol.name) || name.size() == symbol.name.size())
+        continue;
+      const auto suffix = name.substr(symbol.name.size());
+      if (suffix.size() > 1 && suffix.front() == '0')
+        continue;
+      bool decimal = true;
+      for (char character : suffix)
+        decimal = decimal && character >= '0' && character <= '9';
+      uint32_t index = 0;
+      const auto [end, error] = std::from_chars(
+          suffix.data(), suffix.data() + suffix.size(), index);
+      if (decimal && error == std::errc{} &&
+          end == suffix.data() + suffix.size() &&
+          index < *symbol.parameterized_count)
+        return SymbolLookup{symbol.id, index};
+    }
+    if (!table.scope(scope).parent)
+      return std::nullopt;
+    scope = *table.scope(scope).parent;
+  }
+}
+
+/** Test represented membership without using the production overlap helpers. */
+bool memberOf(std::string_view base, uint32_t count, std::string_view name) {
+  if (!name.starts_with(base) || name.size() == base.size())
+    return false;
+  const auto suffix = name.substr(base.size());
+  if (suffix.size() > 1 && suffix.front() == '0')
+    return false;
+  for (char character : suffix)
+    if (character < '0' || character > '9')
+      return false;
+  uint32_t index = 0;
+  const auto [end, error] = std::from_chars(
+      suffix.data(), suffix.data() + suffix.size(), index);
+  return error == std::errc{} && end == suffix.data() + suffix.size() &&
+         index < count;
+}
+
+/** Retain the existing overlap contract, including group-base comparisons. */
+bool overlaps(const Symbol& previous, const Symbol& current) {
+  if (previous.parameterized_count &&
+      memberOf(previous.name, *previous.parameterized_count, current.name))
+    return true;
+  if (current.parameterized_count &&
+      memberOf(current.name, *current.parameterized_count, previous.name))
+    return true;
+  return previous.parameterized_count && current.parameterized_count &&
+         (memberOf(previous.name, *previous.parameterized_count,
+                   current.name + "0") ||
+          memberOf(current.name, *current.parameterized_count,
+                   previous.name + "0"));
+}
+
+/** Check indexes against lexical vector search, including diagnosed overlaps. */
+TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
+  std::string source = R"ptx(
+.file 1 "oracle.ptx"
+.section .debug_str { metadata_only: .b8 0; };
+.global .u32 outer<12>;
+.global .u32 outer10;
+.global .u32 child3;
+.global .u32 metadata_only;
+)ptx";
+  for (int function = 0; function < 4; ++function) {
+    source += ".entry k" + std::to_string(function) + "() {\n";
+    source += ".reg .u32 child<10>;\n.reg .u32 outer;\n";
+    for (int group = 0; group < 16; ++group) {
+      const std::string base = "%r" + std::to_string(group) + "_";
+      source += ".reg .u32 " + base + "<12>;\n";
+      source += ".reg .u32 " + base + "1<3>;\n";
+      source += ".reg .u32 " + base + "10;\n";
+      source += ".reg .u32 " + base + ";\n";
+    }
+    source += "{ .reg .u32 child3; .reg .u32 sibling; }\n";
+    source += "{ .reg .u32 child<2>; .reg .u32 outer10; }\nret;\n}\n";
+  }
+  PtxSyntaxParser parser(source);
+  const auto parsed = parser.parseModule();
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_TRUE(parsed.diagnostics.empty());
+  const auto bound = bindSymbols(*parsed);
+  // Overlapping declarations are intentionally retained to test first-ID wins.
+  ASSERT_FALSE(bound.diagnostics.empty());
+  for (const auto& diagnostic : bound.diagnostics) {
+    EXPECT_EQ(diagnostic.kind, BindDiagnosticKind::DuplicateSymbol);
+    EXPECT_TRUE(diagnostic.previous_range.has_value());
+  }
+  size_t overlap_count = 0;
+  for (const auto& current : bound.table.symbols()) {
+    for (const auto& previous : bound.table.symbols()) {
+      if (previous.id.value >= current.id.value)
+        break;
+      if (previous.scope != current.scope ||
+          previous.kind == SymbolKind::DebugFile ||
+          previous.kind == SymbolKind::DebugStringLabel ||
+          !overlaps(previous, current))
+        continue;
+      ASSERT_LT(overlap_count, bound.diagnostics.size());
+      const auto& diagnostic = bound.diagnostics[overlap_count++];
+      EXPECT_EQ(diagnostic.range, current.declaration_range);
+      EXPECT_EQ(diagnostic.previous_range, previous.declaration_range);
+      break;
+    }
+  }
+  EXPECT_EQ(overlap_count, bound.diagnostics.size());
+
+  std::vector<std::string> queries{"missing", "metadata_only", "1", "child3",
+                                   "sibling", "outer10"};
+  for (const auto& symbol : bound.table.symbols()) {
+    queries.push_back(symbol.name);
+    if (symbol.parameterized_count) {
+      for (std::string_view suffix :
+           std::array{"0", "1", "2", "9", "10", "11", "12", "19", "20",
+                      "00", "01", "4294967295", "4294967296"})
+        queries.push_back(symbol.name + std::string{suffix});
+    }
+  }
+  for (const auto& scope : bound.table.scopes()) {
+    for (const auto& query : queries) {
+      SCOPED_TRACE(query);
+      SCOPED_TRACE(scope.id.value);
+      const auto expected = linearLookup(bound.table, scope.id, query);
+      const auto actual = bound.table.lookup(scope.id, query);
+      ASSERT_EQ(actual.has_value(), expected.has_value());
+      if (expected) {
+        EXPECT_EQ(actual->symbol, expected->symbol);
+        EXPECT_EQ(actual->parameterized_index, expected->parameterized_index);
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace ptx_frontend::binding

--- a/submod/binding/test/test_symbol_table_index_lifetime.cpp
+++ b/submod/binding/test/test_symbol_table_index_lifetime.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <ptx_frontend/binding/ptx_symbol_table.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::binding {
+namespace {
+
+/** Assert that a table still resolves the expected compact and exact names. */
+void expectIndexedLookups(const SymbolTable& table, ScopeId scope) {
+  const auto global = table.lookup(table.moduleScope(), "global_511");
+  ASSERT_TRUE(global.has_value());
+  EXPECT_EQ(global->symbol.value, 511u);
+  EXPECT_EQ(table.symbol(global->symbol).name, "global_511");
+
+  const auto local = table.lookup(scope, "%local_511");
+  ASSERT_TRUE(local.has_value());
+  EXPECT_EQ(local->symbol.value, 1025u);
+  EXPECT_EQ(table.symbol(local->symbol).name, "%local_511");
+
+  const auto final_member = table.lookup(scope, "%huge4294967294");
+  ASSERT_TRUE(final_member.has_value());
+  EXPECT_EQ(final_member->symbol.value, 513u);
+  EXPECT_EQ(table.symbol(final_member->symbol).name, "%huge");
+  EXPECT_EQ(final_member->parameterized_index, 4294967294u);
+  EXPECT_FALSE(table.lookup(scope, "%huge4294967295").has_value());
+}
+
+/** Vector growth, copy, and move preserve owned lookup-index keys and IDs. */
+TEST(SymbolTableIndexLifetime, SurvivesGrowthCopyAndMove) {
+  std::string source;
+  for (uint32_t index = 0; index < 512; ++index)
+    source += ".global .u32 global_" + std::to_string(index) + ";\n";
+  source += ".entry indexed() {\n.reg .u32 %huge<4294967295>;\n";
+  for (uint32_t index = 0; index < 512; ++index)
+    source += ".reg .u32 %local_" + std::to_string(index) + ";\n";
+  source += "ret;\n}\n";
+
+  PtxSyntaxParser parser(source);
+  const auto parsed = parser.parseModule();
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_TRUE(parsed.diagnostics.empty());
+  SymbolTable moved;
+  SymbolTable move_assigned;
+  ScopeId scope{};
+  {
+    const auto bound = bindSymbols(*parsed);
+    ASSERT_TRUE(bound.diagnostics.empty());
+    ASSERT_EQ(bound.table.symbols().size(), 1026u);
+
+    const auto function =
+        bound.table.lookup(bound.table.moduleScope(), "indexed");
+    ASSERT_TRUE(function.has_value());
+    const auto function_scope =
+        bound.table.symbol(function->symbol).owned_scope;
+    ASSERT_TRUE(function_scope.has_value());
+    scope = *function_scope;
+    expectIndexedLookups(bound.table, scope);
+
+    SymbolTable copied(bound.table);
+    SymbolTable copy_assigned;
+    copy_assigned = bound.table;
+    moved = std::move(copied);
+    move_assigned = std::move(copy_assigned);
+  }
+
+  expectIndexedLookups(moved, scope);
+  expectIndexedLookups(move_assigned, scope);
+}
+
+/** Preserve legacy base-name overlap diagnostics in either declaration order. */
+TEST(SymbolTableIndexLifetime, RetainsParameterizedBaseOverlapDiagnostics) {
+  for (const std::string_view declarations :
+       {".reg .u32 %r<1>; .reg .u32 %r0<1>;",
+        ".reg .u32 %r0<1>; .reg .u32 %r<1>;"}) {
+    PtxSyntaxParser parser(std::string{".entry indexed() { "} +
+                           std::string{declarations} + " ret; }");
+    const auto parsed = parser.parseModule();
+    ASSERT_TRUE(parsed.has_value());
+    ASSERT_TRUE(parsed.diagnostics.empty());
+    const auto bound = bindSymbols(*parsed);
+    ASSERT_EQ(bound.diagnostics.size(), 1u);
+    EXPECT_EQ(bound.diagnostics.front().kind,
+              BindDiagnosticKind::DuplicateSymbol);
+    EXPECT_TRUE(bound.diagnostics.front().previous_range.has_value());
+    EXPECT_NE(
+        bound.diagnostics.front().message.find("overlapping symbol names"),
+        std::string::npos);
+  }
+}
+
+/** Invalid zero-count groups retain their legacy overlap and count diagnostics. */
+TEST(SymbolTableIndexLifetime, RetainsZeroCountOverlapDiagnostics) {
+  for (const std::string_view declarations :
+       {".reg .u32 %r<1>; .reg .u32 %r0<0>;",
+        ".reg .u32 %r0<0>; .reg .u32 %r<1>;"}) {
+    PtxSyntaxParser parser(std::string{".entry indexed() { "} +
+                           std::string{declarations} + " ret; }");
+    const auto parsed = parser.parseModule();
+    ASSERT_TRUE(parsed.has_value());
+    ASSERT_TRUE(parsed.diagnostics.empty());
+    const auto bound = bindSymbols(*parsed);
+
+    size_t invalid_count = 0;
+    size_t duplicate_count = 0;
+    for (const BindDiagnostic& diagnostic : bound.diagnostics) {
+      invalid_count +=
+          diagnostic.kind == BindDiagnosticKind::InvalidParameterizedCount;
+      duplicate_count += diagnostic.kind == BindDiagnosticKind::DuplicateSymbol;
+    }
+    EXPECT_EQ(invalid_count, 1u);
+    EXPECT_EQ(duplicate_count, 1u);
+  }
+}
+
+}  // namespace
+}  // namespace ptx_frontend::binding

--- a/submod/resolved_ir/CMakeLists.txt
+++ b/submod/resolved_ir/CMakeLists.txt
@@ -24,6 +24,10 @@ target_link_libraries(
 )
 add_dependencies(resolved_ir resolved_ir_codegen)
 
+if(PTX_FRONTEND_BUILD_BENCHMARKS)
+    add_subdirectory(benchmark)
+endif()
+
 install(
     DIRECTORY "${PTX_RESOLVED_IR_GENERATED_PUBLIC_INCLUDE_DIR}/"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"

--- a/submod/resolved_ir/benchmark/CMakeLists.txt
+++ b/submod/resolved_ir/benchmark/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.28)
+
+# Standalone mode compares the same driver against separately installed revisions.
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    get_filename_component(_frontend_source "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
+    set(VCPKG_MANIFEST_DIR "${_frontend_source}" CACHE PATH "Frontend dependency manifest")
+    list(APPEND VCPKG_MANIFEST_FEATURES benchmarks)
+    list(REMOVE_DUPLICATES VCPKG_MANIFEST_FEATURES)
+    project(ptx_frontend_benchmarks LANGUAGES CXX)
+    find_package(ptx_frontend CONFIG REQUIRED)
+endif()
+
+find_package(benchmark CONFIG REQUIRED)
+get_filename_component(_default_corpus
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../corpus/m12/natural_kernel_sm80.ptx" ABSOLUTE)
+set(PTX_BENCHMARK_CORPUS_FILE "${_default_corpus}" CACHE FILEPATH
+    "PTX source used by the corpus benchmark cases")
+add_executable(frontend_symbol_table_scaling symbol_table_scaling.cpp)
+target_compile_features(frontend_symbol_table_scaling PRIVATE cxx_std_23)
+target_link_libraries(frontend_symbol_table_scaling PRIVATE
+    ptx_frontend::resolved_ir benchmark::benchmark)
+target_compile_definitions(frontend_symbol_table_scaling PRIVATE
+    PTX_BENCHMARK_CORPUS_PATH="${PTX_BENCHMARK_CORPUS_FILE}")

--- a/submod/resolved_ir/benchmark/README.md
+++ b/submod/resolved_ir/benchmark/README.md
@@ -1,0 +1,86 @@
+# Frontend symbol-table benchmarks
+
+These Google Benchmark cases exercise the real parser, `bindSymbols()`,
+`SymbolTable::lookup()`, and `resolveModule()`. They live with the module that
+provides the complete frontend pipeline, not in the installed public library.
+
+## Optional build
+
+The root option `PTX_FRONTEND_BUILD_BENCHMARKS` is `OFF` by default. Enabling it
+selects the optional vcpkg manifest feature `benchmarks`, which installs Google
+Benchmark at the repository's pinned vcpkg baseline. No benchmark dependency or
+executable is exported by the frontend package, and timing is not a CTest gate.
+
+```sh
+cmake --preset ci-linux-gcc-release -DPTX_FRONTEND_BUILD_BENCHMARKS=ON
+cmake --build --preset ci-linux-gcc-release --target frontend_symbol_table_scaling
+out/build/ci-linux-gcc-release/submod/resolved_ir/benchmark/frontend_symbol_table_scaling \
+  --benchmark_list_tests=true
+```
+
+For an existing build that disables automatic manifest installation, install
+the feature explicitly into the same dependency tree before configuring:
+
+```sh
+"$VCPKG_ROOT/vcpkg" install --x-feature=benchmarks \
+  --x-install-root=out/build/ci-linux-gcc-release/vcpkg_installed
+```
+
+## Comparing installed revisions
+
+Build/install each frontend revision with the same compiler, build type, flags,
+and dependency versions into separate prefixes. Build this same driver source
+against each exported package; do not mix headers and libraries from different
+revisions. Standalone mode also uses the root vcpkg manifest's optional feature.
+
+```sh
+cmake -S submod/resolved_ir/benchmark -B /tmp/frontend-benchmark-before \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+  -Dptx_frontend_DIR=/path/to/before/lib/cmake/ptx_frontend
+cmake --build /tmp/frontend-benchmark-before -j2
+```
+
+Repeat with the after prefix and a different build directory. Check the
+registered case names with `--benchmark_list_tests=true`, then start with the
+smallest workload under an external timeout. For example:
+
+```sh
+timeout 300s /tmp/frontend-benchmark-before/frontend_symbol_table_scaling \
+  --benchmark_filter='.*1000.*' \
+  --benchmark_min_time=1x --benchmark_repetitions=5 \
+  --benchmark_out=/tmp/frontend-before.json --benchmark_out_format=json
+```
+
+`--benchmark_min_time=1x` fixes each repetition at one iteration for expensive
+baseline cases. Use longer automatic sampling for short operations when noise
+matters. Run before and after serially without competing builds, and retain
+compiler/build metadata alongside the framework's JSON/CSV output in PR or CI
+artifacts. Machine-specific output and one-off timing summaries do not belong
+in this source directory.
+
+## Workloads and interpretation
+
+Cases cover 1,000, 2,000, 4,000, and 8,000 logical registers, ordinary versus
+compact declarations, and a single scope versus two functions with nested
+blocks. Declaration-only and reference-bearing sources use the same logical
+names. A compact group remains one stored declaration, not N expanded records.
+The generated `corpus/m12/natural_kernel_sm80.ptx` provides a representative
+corpus control; reading its source file is outside the measured operation.
+Override `PTX_BENCHMARK_CORPUS_FILE` at configuration time to use another PTX
+source. A missing or invalid file makes a selected corpus case fail, not pass
+with an empty workload.
+
+Parsing, declaration-only binding, binding with references, direct lookups,
+and complete module resolution are separate measurements. Module resolution
+includes its own binding and other checks; do not add or subtract these times
+as though they were disjoint stages. Correctness checks must reject parse,
+binding, resolution, identity, or count failures instead of reporting early
+failure as a speedup. Benchmark errors result in a nonzero process exit.
+
+Google Benchmark owns timing, repetitions, aggregates, and result output.
+Inspect both ordinary and compact cases: an index can improve growth with many
+stored symbols while adding constant overhead for small or compact tables.
+Use Release measurements for operational conclusions; Debug runs are useful
+only as explicitly labeled comparative evidence. Complexity estimates and
+absolute milliseconds are not pass/fail thresholds on shared CI machines.

--- a/submod/resolved_ir/benchmark/symbol_table_scaling.cpp
+++ b/submod/resolved_ir/benchmark/symbol_table_scaling.cpp
@@ -1,0 +1,669 @@
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <ptx_frontend/binding/ptx_symbol_table.hpp>
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir_resolution.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+#ifndef PTX_BENCHMARK_CORPUS_PATH
+#error "PTX_BENCHMARK_CORPUS_PATH must be supplied by the benchmark target."
+#endif
+
+namespace {
+
+/** Physical declaration spelling used for otherwise identical logical registers. */
+enum class DeclarationLayout { Ordinary, Compact };
+
+/** Distribution of declarations across lexical scopes. */
+enum class ScopeLayout { Single, Nested };
+
+/** Immutable parameters identifying one generated symbol-table workload. */
+struct WorkloadConfiguration {
+  /** Number of logical registers represented by the generated declarations. */
+  std::size_t logical_registers{};
+  /** Whether the source uses individual or parameterized register declarations. */
+  DeclarationLayout declarations{};
+  /** Whether declarations occupy one function scope or nested block scopes. */
+  ScopeLayout scopes{};
+};
+
+/** One generated workload and the names expected to resolve in its late scopes. */
+struct Workload {
+  /** Stable case label used in diagnostics and benchmark names. */
+  std::string name;
+  /** Source containing declarations but no instruction references. */
+  std::string declaration_source;
+  /** Source containing declarations and late instruction references. */
+  std::string full_source;
+  /** One late-register spelling for each scope exercised by lookup-only. */
+  std::vector<std::string> late_names;
+  /** Number of logical registers represented by this workload. */
+  std::size_t logical_registers{};
+  /** Source declaration representation. */
+  DeclarationLayout declarations{};
+  /** Lexical scope distribution. */
+  ScopeLayout scopes{};
+};
+
+/** Observable results retained after one benchmark operation completes. */
+struct BenchmarkOutcome {
+  /** Deterministic value derived from validated operation output. */
+  uint64_t checksum{};
+  /** Number of symbols retained by the associated binding result. */
+  std::size_t stored_symbols{};
+  /** Number of references retained by the associated binding result. */
+  std::size_t references{};
+  /** Number of direct table lookup calls made by the operation. */
+  std::size_t lookup_calls{};
+};
+
+/** Parsed corpus source and the invariants reused by its selected benchmarks. */
+struct CorpusWorkload {
+  /** Path-independent owning copy of the representative PTX source. */
+  std::string source;
+  /** Expected number of functions in every successful parse. */
+  std::size_t functions{};
+  /** Expected recursive instruction count in every successful parse. */
+  std::size_t instructions{};
+};
+
+/** Tracks validation failures so the custom benchmark main returns nonzero. */
+bool validation_failed = false;
+
+/** Return the diagnostic label for a declaration layout. */
+std::string_view layout_name(DeclarationLayout layout) {
+  return layout == DeclarationLayout::Ordinary ? "ordinary" : "compact";
+}
+
+/** Return the diagnostic label for a scope layout. */
+std::string_view scope_name(ScopeLayout layout) {
+  return layout == ScopeLayout::Single ? "single" : "nested";
+}
+
+/** Serialize one ordinary or parameterized register declaration. */
+void append_declarations(std::string& source, std::size_t count,
+                         DeclarationLayout layout) {
+  if (layout == DeclarationLayout::Compact) {
+    source += "  .reg .u32 %r<" + std::to_string(count) + ">;\n";
+    return;
+  }
+  for (std::size_t index = 0; index < count; ++index)
+    source += "  .reg .u32 %r" + std::to_string(index) + ";\n";
+}
+
+/** Append instruction references while preserving declaration-only source separately. */
+void append_references(std::string& source, std::size_t destination,
+                       std::size_t source_register, std::size_t count) {
+  for (std::size_t index = 0; index < count; ++index)
+    source += "  mov.u32 %r" + std::to_string(destination) + ", %r" +
+              std::to_string(source_register) + ";\n";
+}
+
+/** Construct a valid module with N logical registers and N late-register references. */
+Workload make_workload(WorkloadConfiguration configuration) {
+  const std::size_t register_count = configuration.logical_registers;
+  if (register_count < 4 || register_count % 4 != 0)
+    throw std::invalid_argument("register count must be a multiple of four");
+
+  Workload workload{
+      .name = std::string(layout_name(configuration.declarations)) + "_" +
+              std::string(scope_name(configuration.scopes)) + "_" +
+              std::to_string(register_count),
+      .logical_registers = register_count,
+      .declarations = configuration.declarations,
+      .scopes = configuration.scopes};
+  std::string declarations_source =
+      ".version 8.0\n.target sm_80\n.address_size 64\n";
+
+  if (configuration.scopes == ScopeLayout::Single) {
+    declarations_source += ".visible .entry issue116_single() {\n";
+    append_declarations(declarations_source, register_count,
+                        configuration.declarations);
+    workload.late_names.push_back("%r" + std::to_string(register_count - 1));
+    workload.declaration_source = declarations_source + "}\n";
+    workload.full_source = declarations_source;
+    append_references(workload.full_source, register_count - 1,
+                      register_count - 1, register_count);
+    workload.full_source += "}\n";
+    return workload;
+  }
+
+  const std::size_t registers_per_function = register_count / 2;
+  const std::size_t registers_per_scope = registers_per_function / 2;
+  for (std::size_t function = 0; function < 2; ++function) {
+    declarations_source += ".visible .entry issue116_nested_" +
+                           std::to_string(function) + "() {\n";
+    append_declarations(declarations_source, registers_per_scope,
+                        configuration.declarations);
+    declarations_source += "  {\n";
+    append_declarations(declarations_source, registers_per_scope,
+                        configuration.declarations);
+    declarations_source += "  }\n}\n";
+    workload.late_names.push_back("%r" +
+                                  std::to_string(registers_per_scope - 1));
+    workload.late_names.push_back("%r" +
+                                  std::to_string(registers_per_scope - 1));
+  }
+  workload.declaration_source = declarations_source;
+
+  std::string full_source = ".version 8.0\n.target sm_80\n.address_size 64\n";
+  for (std::size_t function = 0; function < 2; ++function) {
+    const std::size_t last_register = registers_per_scope - 1;
+    full_source += ".visible .entry issue116_nested_" +
+                   std::to_string(function) + "() {\n";
+    append_declarations(full_source, registers_per_scope,
+                        configuration.declarations);
+    full_source += "  {\n";
+    append_declarations(full_source, registers_per_scope,
+                        configuration.declarations);
+    append_references(full_source, last_register, last_register,
+                      registers_per_function / 2);
+    full_source += "  }\n";
+    append_references(full_source, last_register, last_register,
+                      registers_per_function / 2);
+    full_source += "}\n";
+  }
+  workload.full_source = std::move(full_source);
+  return workload;
+}
+
+/** Parse a complete module and reject partial ASTs or parser diagnostics. */
+ptx_frontend::syntax_ast::AstModule parse_clean(std::string_view source,
+                                                std::string_view name) {
+  ptx_frontend::PtxSyntaxParser parser(source);
+  auto parsed = parser.parseModule();
+  if (!parsed.value || !parsed.diagnostics.empty())
+    throw std::runtime_error("parse validation failed for " +
+                             std::string(name));
+  return std::move(*parsed.value);
+}
+
+/** Mix stable SymbolIds and parameterized member indexes into an observable value. */
+uint64_t mix_lookup(uint64_t checksum,
+                    const ptx_frontend::binding::SymbolLookup& lookup) {
+  constexpr uint64_t multiplier = 1'099'511'628'211ULL;
+  checksum ^= static_cast<uint64_t>(lookup.symbol.value) + 1;
+  checksum *= multiplier;
+  checksum ^= lookup.parameterized_index.value_or(0) + 1;
+  return checksum * multiplier;
+}
+
+/** Count function declarations represented in a parsed module. */
+std::size_t ast_function_count(
+    const ptx_frontend::syntax_ast::AstModule& module) {
+  return std::count_if(
+      module.items.begin(), module.items.end(), [](const auto& item) {
+        return std::holds_alternative<ptx_frontend::syntax_ast::AstFunction>(
+            item);
+      });
+}
+
+/** Count instructions recursively, including instructions inside lexical blocks. */
+std::size_t ast_instruction_count(
+    const std::vector<ptx_frontend::syntax_ast::AstFunctionBodyItem>& body) {
+  std::size_t count = 0;
+  for (const auto& item : body) {
+    if (std::holds_alternative<ptx_frontend::syntax_ast::AstInstruction>(item))
+      ++count;
+    if (const auto* block =
+            std::get_if<std::unique_ptr<ptx_frontend::syntax_ast::AstBlock>>(
+                &item))
+      count += ast_instruction_count((*block)->body);
+  }
+  return count;
+}
+
+/** Count every instruction represented by a module's function bodies. */
+std::size_t ast_instruction_count(
+    const ptx_frontend::syntax_ast::AstModule& module) {
+  std::size_t count = 0;
+  for (const auto& item : module.items) {
+    if (const auto* function =
+            std::get_if<ptx_frontend::syntax_ast::AstFunction>(&item))
+      count += ast_instruction_count(function->body);
+  }
+  return count;
+}
+
+/** Validate that generated source retained all expected functions and instructions. */
+void validate_workload_ast(const ptx_frontend::syntax_ast::AstModule& module,
+                           const Workload& workload, bool has_references) {
+  const std::size_t expected_functions =
+      workload.scopes == ScopeLayout::Single ? 1 : 2;
+  if (ast_function_count(module) != expected_functions)
+    throw std::runtime_error("unexpected function count for " + workload.name);
+  const std::size_t expected_instructions =
+      has_references ? workload.logical_registers : 0;
+  if (ast_instruction_count(module) != expected_instructions)
+    throw std::runtime_error("unexpected instruction count for " +
+                             workload.name);
+}
+
+/** Validate a binding result and return a deterministic identity/count checksum. */
+uint64_t validate_binding(const ptx_frontend::binding::SymbolBinding& binding,
+                          const Workload& workload, bool has_references) {
+  if (!binding.diagnostics.empty())
+    throw std::runtime_error("binding diagnostics for " + workload.name);
+  const std::size_t expected_variables =
+      workload.declarations == DeclarationLayout::Ordinary
+          ? workload.logical_registers
+      : workload.scopes == ScopeLayout::Single ? 1
+                                               : 4;
+  const std::size_t expected_symbols =
+      expected_variables + (workload.scopes == ScopeLayout::Single ? 1 : 2);
+  if (binding.table.symbols().size() != expected_symbols)
+    throw std::runtime_error("unexpected symbol count for " + workload.name);
+  const std::size_t expected_references =
+      has_references ? 2 * workload.logical_registers : 0;
+  if (binding.table.references().size() != expected_references)
+    throw std::runtime_error("unexpected reference count for " + workload.name);
+  uint64_t checksum = binding.table.symbols().size();
+  for (const auto& symbol : binding.table.symbols())
+    checksum = (checksum * 131) ^ symbol.id.value;
+  return checksum;
+}
+
+/** Locate function and block scopes in creation order for direct table lookup tests. */
+std::vector<ptx_frontend::binding::ScopeId> lookup_scopes(
+    const ptx_frontend::binding::SymbolTable& table, ScopeLayout layout) {
+  std::vector<ptx_frontend::binding::ScopeId> result;
+  for (const auto& scope : table.scopes()) {
+    if (layout == ScopeLayout::Single &&
+        scope.kind == ptx_frontend::binding::ScopeKind::Function)
+      result.push_back(scope.id);
+    if (layout == ScopeLayout::Nested &&
+        (scope.kind == ptx_frontend::binding::ScopeKind::Function ||
+         scope.kind == ptx_frontend::binding::ScopeKind::Block))
+      result.push_back(scope.id);
+  }
+  return result;
+}
+
+/** Verify a lookup result's symbol, scope, and parameterized member identity. */
+void validate_lookup(const ptx_frontend::binding::SymbolTable& table,
+                     const Workload& workload,
+                     ptx_frontend::binding::ScopeId lookup_scope,
+                     std::string_view name,
+                     const ptx_frontend::binding::SymbolLookup& found) {
+  const auto& symbol = table.symbol(found.symbol);
+  if (symbol.scope != lookup_scope)
+    throw std::runtime_error("late lookup crossed its expected scope for " +
+                             workload.name);
+  if (workload.declarations == DeclarationLayout::Compact) {
+    const uint32_t expected_member =
+        workload.scopes == ScopeLayout::Single
+            ? static_cast<uint32_t>(workload.logical_registers - 1)
+            : static_cast<uint32_t>(workload.logical_registers / 4 - 1);
+    if (!found.parameterized_index ||
+        *found.parameterized_index != expected_member || symbol.name != "%r")
+      throw std::runtime_error("compact member identity missing for " +
+                               workload.name);
+    return;
+  }
+  if (found.parameterized_index || symbol.name != name)
+    throw std::runtime_error("ordinary lookup became parameterized for " +
+                             workload.name);
+}
+
+/** Validate a resolved module's function and flattened instruction totals. */
+void validate_resolved_module(
+    const ptx_frontend::resolved_ir::ResolvedModule& resolved,
+    std::size_t expected_functions, std::size_t expected_instructions,
+    std::string_view name) {
+  std::size_t resolved_instructions = 0;
+  for (const auto& function : resolved.functions)
+    resolved_instructions += function.body.size();
+  if (resolved.functions.size() != expected_functions ||
+      resolved_instructions != expected_instructions)
+    throw std::runtime_error("resolved model count mismatch for " +
+                             std::string(name));
+}
+
+/** Populate framework counters from one validated operation result. */
+void set_counters(benchmark::State& state, std::size_t logical_registers,
+                  const BenchmarkOutcome& outcome) {
+  constexpr uint64_t lower_32_bits = 0xFFFF'FFFFULL;
+  state.counters["logical_registers"] = static_cast<double>(logical_registers);
+  state.counters["stored_symbols"] =
+      static_cast<double>(outcome.stored_symbols);
+  state.counters["references"] = static_cast<double>(outcome.references);
+  state.counters["lookup_calls"] = static_cast<double>(outcome.lookup_calls);
+  state.counters["checksum_hi"] = static_cast<double>(outcome.checksum >> 32U);
+  state.counters["checksum_lo"] =
+      static_cast<double>(outcome.checksum & lower_32_bits);
+}
+
+/** Mark a failed validation as a skipped benchmark and preserve a failing process status. */
+void report_validation_failure(benchmark::State& state,
+                               const std::exception& error) {
+  validation_failed = true;
+  state.SkipWithError(error.what());
+}
+
+/** Mark an unknown validation failure as a skipped benchmark and failing status. */
+void report_unknown_validation_failure(benchmark::State& state) {
+  validation_failed = true;
+  state.SkipWithError("unknown benchmark validation failure");
+}
+
+/** Benchmark parsing a generated source with declarations and instruction references. */
+void benchmark_parse(benchmark::State& state,
+                     WorkloadConfiguration configuration) {
+  try {
+    const Workload workload = make_workload(configuration);
+    const auto initial = parse_clean(workload.full_source, workload.name);
+    validate_workload_ast(initial, workload, true);
+    BenchmarkOutcome outcome{};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      auto parsed = parse_clean(workload.full_source, workload.name);
+      validate_workload_ast(parsed, workload, true);
+      outcome = {.checksum = workload.full_source.size() ^
+                             static_cast<uint64_t>(ast_function_count(parsed))};
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, workload.logical_registers, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Benchmark binding declarations after parsing their source outside framework timing. */
+void benchmark_bind_declarations(benchmark::State& state,
+                                 WorkloadConfiguration configuration) {
+  try {
+    const Workload workload = make_workload(configuration);
+    const auto declarations =
+        parse_clean(workload.declaration_source, workload.name);
+    validate_workload_ast(declarations, workload, false);
+    BenchmarkOutcome outcome{};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      const auto binding = ptx_frontend::binding::bindSymbols(declarations);
+      outcome = {.checksum = validate_binding(binding, workload, false),
+                 .stored_symbols = binding.table.symbols().size(),
+                 .references = binding.table.references().size()};
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, workload.logical_registers, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Benchmark binding declarations and instruction references after parsing outside timing. */
+void benchmark_bind_with_references(benchmark::State& state,
+                                    WorkloadConfiguration configuration) {
+  try {
+    const Workload workload = make_workload(configuration);
+    const auto parsed = parse_clean(workload.full_source, workload.name);
+    validate_workload_ast(parsed, workload, true);
+    BenchmarkOutcome outcome{};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      const auto binding = ptx_frontend::binding::bindSymbols(parsed);
+      outcome = {.checksum = validate_binding(binding, workload, true),
+                 .stored_symbols = binding.table.symbols().size(),
+                 .references = binding.table.references().size(),
+                 .lookup_calls = binding.table.references().size()};
+      if (outcome.references == 0)
+        throw std::runtime_error("expected instruction references for " +
+                                 workload.name);
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, workload.logical_registers, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Benchmark direct late-register symbol-table lookups using a prebuilt binding. */
+void benchmark_lookup_only(benchmark::State& state,
+                           WorkloadConfiguration configuration) {
+  try {
+    const Workload workload = make_workload(configuration);
+    const auto parsed = parse_clean(workload.full_source, workload.name);
+    validate_workload_ast(parsed, workload, true);
+    const auto binding = ptx_frontend::binding::bindSymbols(parsed);
+    const uint64_t binding_checksum = validate_binding(binding, workload, true);
+    const auto scopes = lookup_scopes(binding.table, workload.scopes);
+    if (scopes.size() != workload.late_names.size())
+      throw std::runtime_error("unexpected scope count for " + workload.name);
+
+    BenchmarkOutcome outcome{.stored_symbols = binding.table.symbols().size(),
+                             .references = binding.table.references().size(),
+                             .lookup_calls = workload.logical_registers};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      uint64_t checksum = binding_checksum;
+      for (std::size_t lookup_index = 0;
+           lookup_index < workload.logical_registers; ++lookup_index) {
+        const std::size_t scope_index = lookup_index % scopes.size();
+        const auto found = binding.table.lookup(
+            scopes[scope_index], workload.late_names[scope_index]);
+        if (!found)
+          throw std::runtime_error("late lookup failed for " + workload.name);
+        validate_lookup(binding.table, workload, scopes[scope_index],
+                        workload.late_names[scope_index], *found);
+        checksum = mix_lookup(checksum, *found);
+      }
+      outcome.checksum = checksum;
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, workload.logical_registers, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Benchmark resolving a pre-parsed generated module. */
+void benchmark_resolve_module(benchmark::State& state,
+                              WorkloadConfiguration configuration) {
+  try {
+    const Workload workload = make_workload(configuration);
+    const auto parsed = parse_clean(workload.full_source, workload.name);
+    validate_workload_ast(parsed, workload, true);
+    const auto binding = ptx_frontend::binding::bindSymbols(parsed);
+    const uint64_t binding_checksum = validate_binding(binding, workload, true);
+    BenchmarkOutcome outcome{.stored_symbols = binding.table.symbols().size(),
+                             .references = binding.table.references().size(),
+                             .lookup_calls = workload.logical_registers};
+    const std::size_t expected_functions =
+        workload.scopes == ScopeLayout::Single ? 1 : 2;
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      const auto resolved = ptx_frontend::resolved_ir::resolveModule(parsed);
+      if (!resolved)
+        throw std::runtime_error("module resolution diagnostics for " +
+                                 workload.name);
+      validate_resolved_module(*resolved, expected_functions,
+                               workload.logical_registers, workload.name);
+      outcome.checksum = binding_checksum ^ workload.full_source.size();
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, workload.logical_registers, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Read a corpus source file as an owning string. */
+std::string read_file(std::string_view path) {
+  std::ifstream input{std::string(path)};
+  if (!input)
+    throw std::runtime_error("cannot open corpus file: " + std::string(path));
+  return {std::istreambuf_iterator<char>(input),
+          std::istreambuf_iterator<char>()};
+}
+
+/** Lazily prepare the representative corpus only when a corpus benchmark is selected. */
+CorpusWorkload make_corpus_workload() {
+  CorpusWorkload workload{.source = read_file(PTX_BENCHMARK_CORPUS_PATH)};
+  const auto parsed = parse_clean(workload.source, PTX_BENCHMARK_CORPUS_PATH);
+  workload.functions = ast_function_count(parsed);
+  workload.instructions = ast_instruction_count(parsed);
+  if (workload.functions == 0)
+    throw std::runtime_error("corpus contains no parsed functions: " +
+                             std::string(PTX_BENCHMARK_CORPUS_PATH));
+  return workload;
+}
+
+/** Verify that a corpus parse preserves the source-derived AST shape. */
+void validate_corpus_ast(const ptx_frontend::syntax_ast::AstModule& parsed,
+                         const CorpusWorkload& workload) {
+  if (ast_function_count(parsed) != workload.functions ||
+      ast_instruction_count(parsed) != workload.instructions)
+    throw std::runtime_error("corpus parse changed AST counts for " +
+                             std::string(PTX_BENCHMARK_CORPUS_PATH));
+}
+
+/** Benchmark parsing the representative corpus source. */
+void benchmark_corpus_parse(benchmark::State& state) {
+  try {
+    const CorpusWorkload workload = make_corpus_workload();
+    BenchmarkOutcome outcome{};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      const auto parsed =
+          parse_clean(workload.source, PTX_BENCHMARK_CORPUS_PATH);
+      validate_corpus_ast(parsed, workload);
+      outcome.checksum = workload.source.size() ^ workload.functions;
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, 0, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Benchmark resolving a pre-parsed representative corpus module. */
+void benchmark_corpus_resolve_module(benchmark::State& state) {
+  try {
+    const CorpusWorkload workload = make_corpus_workload();
+    const auto parsed = parse_clean(workload.source, PTX_BENCHMARK_CORPUS_PATH);
+    validate_corpus_ast(parsed, workload);
+    const auto binding = ptx_frontend::binding::bindSymbols(parsed);
+    if (!binding.diagnostics.empty())
+      throw std::runtime_error("binding diagnostics for corpus " +
+                               std::string(PTX_BENCHMARK_CORPUS_PATH));
+    BenchmarkOutcome outcome{.stored_symbols = binding.table.symbols().size(),
+                             .references = binding.table.references().size(),
+                             .lookup_calls = binding.table.references().size()};
+    for (auto iteration : state) {
+      static_cast<void>(iteration);
+      const auto resolved = ptx_frontend::resolved_ir::resolveModule(parsed);
+      if (!resolved)
+        throw std::runtime_error("corpus resolution changed outcome: " +
+                                 std::string(PTX_BENCHMARK_CORPUS_PATH));
+      validate_resolved_module(*resolved, workload.functions,
+                               workload.instructions,
+                               PTX_BENCHMARK_CORPUS_PATH);
+      outcome.checksum = workload.source.size() ^ outcome.stored_symbols;
+      benchmark::DoNotOptimize(outcome.checksum);
+    }
+    set_counters(state, 0, outcome);
+  } catch (const std::exception& error) {
+    report_validation_failure(state, error);
+  } catch (...) {
+    report_unknown_validation_failure(state);
+  }
+}
+
+/** Construct a readable benchmark name for one generated operation and workload. */
+std::string benchmark_name(std::string_view operation,
+                           WorkloadConfiguration configuration) {
+  return "symbol_table_scaling/" + std::string(operation) + "/" +
+         std::string(layout_name(configuration.declarations)) + "/" +
+         std::string(scope_name(configuration.scopes)) + "/N" +
+         std::to_string(configuration.logical_registers);
+}
+
+/** Register every generated operation without constructing source or AST fixtures. */
+void register_generated_benchmarks() {
+  constexpr std::size_t sizes[] = {1000, 2000, 4000, 8000};
+  constexpr DeclarationLayout declarations[] = {DeclarationLayout::Ordinary,
+                                                DeclarationLayout::Compact};
+  constexpr ScopeLayout scopes[] = {ScopeLayout::Single, ScopeLayout::Nested};
+  for (const std::size_t size : sizes) {
+    for (const DeclarationLayout declaration : declarations) {
+      for (const ScopeLayout scope : scopes) {
+        const WorkloadConfiguration configuration{size, declaration, scope};
+        benchmark::RegisterBenchmark(benchmark_name("parse", configuration),
+                                     benchmark_parse, configuration)
+            ->UseRealTime();
+        benchmark::RegisterBenchmark(
+            benchmark_name("bind_declarations_only", configuration),
+            benchmark_bind_declarations, configuration)
+            ->UseRealTime();
+        benchmark::RegisterBenchmark(
+            benchmark_name("bind_with_references", configuration),
+            benchmark_bind_with_references, configuration)
+            ->UseRealTime();
+        benchmark::RegisterBenchmark(
+            benchmark_name("lookup_only", configuration), benchmark_lookup_only,
+            configuration)
+            ->UseRealTime();
+        benchmark::RegisterBenchmark(
+            benchmark_name("resolve_module", configuration),
+            benchmark_resolve_module, configuration)
+            ->UseRealTime();
+      }
+    }
+  }
+}
+
+/** Register corpus operations without eagerly reading the corpus source. */
+void register_corpus_benchmarks() {
+  benchmark::RegisterBenchmark(
+      "symbol_table_scaling/corpus_parse/natural_kernel_sm80",
+      benchmark_corpus_parse)
+      ->UseRealTime();
+  benchmark::RegisterBenchmark(
+      "symbol_table_scaling/corpus_resolve_module/natural_kernel_sm80",
+      benchmark_corpus_resolve_module)
+      ->UseRealTime();
+}
+
+}  // namespace
+
+/** Register benchmark cases, execute selected cases, and signal validation failure. */
+int main(int argc, char** argv) {
+  try {
+    register_generated_benchmarks();
+    register_corpus_benchmarks();
+    benchmark::Initialize(&argc, argv);
+    if (benchmark::ReportUnrecognizedArguments(argc, argv))
+      return 1;
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+    return validation_failed ? 1 : 0;
+  } catch (const std::exception& error) {
+    std::cerr << "frontend_symbol_table_scaling: " << error.what() << '\n';
+    return 1;
+  }
+}

--- a/submod/resolved_ir/src/ptx_resolved_module.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_module.cpp
@@ -148,16 +148,9 @@ CallArgumentProperties call_argument_properties(
 std::optional<binding::SymbolId> declared_symbol(
     const binding::SymbolTable& symbols, binding::ScopeId scope,
     const syntax_ast::AstVariableDeclarator& declarator) {
-  const bool parameterized = declarator.parameterized_count.has_value();
-  const auto found = std::ranges::find_if(symbols.symbols(),
-                                          [&](const binding::Symbol& symbol) {
-    return symbol.scope == scope &&
-           symbol.name == declarator.name.syntax.text &&
-           symbol.parameterized_count.has_value() == parameterized;
-  });
-  if (found == symbols.symbols().end())
-    return std::nullopt;
-  return found->id;
+  return symbols.exactDeclaration(
+      scope, declarator.name.syntax.text,
+      declarator.parameterized_count.has_value());
 }
 
 binding::ScopeId block_scope(const binding::SymbolTable& symbols,

--- a/submod/resolved_ir/src/ptx_storage_declarations.cpp
+++ b/submod/resolved_ir/src/ptx_storage_declarations.cpp
@@ -166,15 +166,9 @@ std::optional<uint64_t> unsigned_value(std::string_view text) {
 std::optional<binding::SymbolId> declaration_symbol(
     const binding::SymbolTable& symbols, binding::ScopeId scope,
     const syntax_ast::AstVariableDeclarator& declarator) {
-  const bool parameterized = declarator.parameterized_count.has_value();
-  const auto found = std::ranges::find_if(
-      symbols.symbols(), [&](const binding::Symbol& symbol) {
-        return symbol.scope == scope &&
-               symbol.name == declarator.name.syntax.text &&
-               symbol.parameterized_count.has_value() == parameterized;
-      });
-  return found == symbols.symbols().end() ? std::nullopt
-                                          : std::optional{found->id};
+  return symbols.exactDeclaration(
+      scope, declarator.name.syntax.text,
+      declarator.parameterized_count.has_value());
 }
 
 /** Find the nearest owning function for a lexical declaration scope. */
@@ -407,12 +401,9 @@ std::optional<StorageRelocation> symbol_relocation(
     const binding::SymbolTable& symbols,
     const std::optional<PtxVersion>& version,
     std::vector<DeclarationDiagnostic>& diagnostics) {
-  const auto reference = std::ranges::find_if(
-      symbols.references(), [&](const binding::SymbolReference& candidate) {
-        return candidate.kind == binding::ReferenceKind::Initializer &&
-               candidate.range == symbol.name.syntax.range;
-      });
-  if (reference == symbols.references().end() || !reference->target) {
+  const binding::SymbolReference* reference =
+      symbols.initializerReference(symbol.name.syntax.range);
+  if (reference == nullptr || !reference->target) {
     diagnose(diagnostics,
              DeclarationDiagnosticKind::UnsupportedStorageInitializer,
              symbol.name.syntax.range,

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -744,7 +744,13 @@ class Checker {
     CallPrototypeReturn,
   };
 
+  using LabelIndex =
+      std::unordered_map<uint32_t,
+                         std::unordered_map<std::string_view, SourceRange>>;
+
   const binding::SymbolTable& symbols_;
+  /** Lazily built first label ranges; string views borrow immutable symbols_. */
+  std::optional<LabelIndex> labels_by_function_;
   std::vector<DeclarationDiagnostic> diagnostics_;
   std::unordered_map<std::string, SeenDeclaration> declarations_;
 
@@ -757,6 +763,19 @@ class Checker {
         .previous_range = previous,
         .message = std::move(message),
     });
+  }
+
+  /** Build the function-label cache only when branch metadata requires it. */
+  void indexBranchLabels() {
+    if (labels_by_function_)
+      return;
+    labels_by_function_.emplace();
+    for (const binding::Symbol& symbol : symbols_.symbols()) {
+      if (symbol.kind != binding::SymbolKind::Label)
+        continue;
+      labels_by_function_->operator[](symbol.scope.value)
+          .emplace(symbol.name, symbol.declaration_range);
+    }
   }
 
   void rememberDeclaration(
@@ -1310,18 +1329,15 @@ class Checker {
   void checkBranchTargets(
       binding::ScopeId function_scope,
       const syntax_ast::AstBranchTargets& targets) {
-    std::unordered_map<std::string_view, SourceRange> labels;
-    for (const binding::Symbol& symbol : symbols_.symbols()) {
-      if (symbol.scope == function_scope &&
-          symbol.kind == binding::SymbolKind::Label) {
-        labels.emplace(symbol.name, symbol.declaration_range);
-      }
-    }
+    indexBranchLabels();
+    const auto index = labels_by_function_->find(function_scope.value);
+    const auto* labels = index == labels_by_function_->end()
+                             ? nullptr
+                             : &index->second;
 
-    const auto check_label = [this, function_scope, &labels](
+    const auto check_label = [this, function_scope, labels](
                                  std::string_view name, SourceRange range) {
-      const auto label = labels.find(name);
-      if (label == labels.end()) {
+      if (labels == nullptr || labels->find(name) == labels->end()) {
         const auto bound = symbols_.lookup(function_scope, name);
         if (bound) {
           diagnose(DeclarationDiagnosticKind::InvalidMetadataTarget, range,
@@ -1354,12 +1370,14 @@ class Checker {
       }
 
       uint64_t matched = 0;
-      for (const auto& entry : labels) {
-        const auto index =
-            compactLabelIndex(target.name.syntax.text, entry.first);
-        if (!index || *index >= *count)
-          continue;
-        ++matched;
+      if (labels != nullptr) {
+        for (const auto& entry : *labels) {
+          const auto index =
+              compactLabelIndex(target.name.syntax.text, entry.first);
+          if (!index || *index >= *count)
+            continue;
+          ++matched;
+        }
       }
       if (matched != *count) {
         diagnose(DeclarationDiagnosticKind::UnresolvedMetadataTarget,
@@ -1929,13 +1947,9 @@ class Checker {
   /** Return the binding target recorded for this exact initializer token. */
   std::optional<binding::SymbolLookup> initializerTarget(
       SourceRange range) const {
-    const auto reference = std::ranges::find_if(
-        symbols_.references(),
-        [range](const binding::SymbolReference& candidate) {
-          return candidate.kind == binding::ReferenceKind::Initializer &&
-                 candidate.range == range;
-        });
-    if (reference == symbols_.references().end())
+    const binding::SymbolReference* reference =
+        symbols_.initializerReference(range);
+    if (reference == nullptr)
       return std::nullopt;
     return reference->target;
   }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,5 +8,13 @@
     "fmt",
     "gtest",
     "magic-enum"
-  ]
+  ],
+  "features": {
+    "benchmarks": {
+      "description": "Build optional frontend performance benchmarks",
+      "dependencies": [
+        "benchmark"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Replace whole-symbol-array construction and lookup scans with owned, scope-local exact-name, parameterized-prefix, and sparse numeric-member indexes.
- Preserve stable symbol/member identities, lexical precedence, deterministic overlap diagnostics, debug-metadata separation, and compact parameterized groups. Cover vector growth, copy/move lifetime, zero counts, and maximum uint32 counts.
- Add opt-in Google Benchmark cases under `submod/resolved_ir/benchmark/`. The default-off `PTX_FRONTEND_BUILD_BENCHMARKS` option selects the optional vcpkg `benchmarks` feature before toolchain configuration. No benchmark dependency leaks into installed frontend exports.
- Remove the provisional root-level benchmark and handwritten timing/statistics code. Keep reusable source and methodology in the repository; machine-specific JSON results remain outside Git.

## Verification

- Full C++ build and all 757 CTest tests passed, including installed-package consumption and code-generation gates.
- Targeted binding ASan/UBSan run: all 24 tests passed.
- Benchmark-disabled configure omits the target; default vcpkg manifest does not request Google Benchmark. Benchmark-enabled configure/build passed with vcpkg Google Benchmark 1.9.5.
- Installed before/after packages both compiled the same standalone Google Benchmark driver.
- All 82 benchmark cases completed five repetitions per revision. Exact split checksums, logical/stored symbol counts, reference counts, and lookup counts agree between all repetitions and revisions.
- Missing-corpus negative test reports a benchmark error and exits nonzero.
- Independent indexing and build-integration reviews found no blocking issues; `git diff --check` passed.

## Fresh Google Benchmark measurements

These measurements replace the provisional handwritten-timer results. Baseline: `d6d74a0`; after: this change. GCC 15.2, C++23, Debug `-g`, Google Benchmark 1.9.5, same exported-package linkage/dependency configuration, no LTO, five repetitions with `--benchmark_min_time=1x`. Wall-clock medians in milliseconds; runs were serial with no competing repository build. Setup is outside framework timing; the selected operation includes its correctness checks and result destruction.

Ordinary declarations in one function scope:

| Logical registers / direct lookups | Declaration-only binding, before → after | Binding with references | Direct lookups | Module resolution |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 18.948 → 5.368 | 73.632 → 8.247 | 26.319 → 0.224 | 312.391 → 98.113 |
| 2,000 | 64.812 → 12.295 | 246.545 → 16.708 | 87.336 → 0.462 | 973.492 → 220.720 |
| 4,000 | 279.951 → 28.626 | 1,089.061 → 35.387 | 404.150 → 0.871 | 3,896.006 → 552.610 |
| 8,000 | 1,184.895 → 55.577 | 4,495.132 → 70.259 | 1,647.258 → 1.754 | 15,624.248 → 1,596.124 |

The matrix also covers two functions with nested scopes, equivalent compact declarations, and the generated `natural_kernel_sm80.ptx` corpus. This is evidence of improved bounded scaling, not a claim that full module resolution is linear or every workload is faster.

### Limits and tradeoffs

- At 8,000 logical registers, compact single-scope lookup was 2.252 → 2.434 ms; compact module resolution was 400.137 → 395.121 ms. Large logical counts still retain only a compact declaration record.
- Natural-corpus resolution was 1.526 → 1.675 ms (parse: 0.316 → 0.286 ms). Small Debug differences are noisy observations, not causal or user-visible performance claims.
- Google Benchmark reported a Debug build and enabled ASLR. No Release performance claim, GPU benchmark, or absolute-millisecond CI gate is introduced.
- Existing unrelated metadata and block/function-scope lookup scans are outside this change.

Closes #116
