### PR TITLE
fix(frontend): correct parameterized overlap and integer use-site conversion

### DIFF
--- a/.agents/gpt-5.3-codex-spark.md
+++ b/.agents/gpt-5.3-codex-spark.md
@@ -4,6 +4,12 @@ Read [orchestration.md](orchestration.md) for model availability, effort, and
 fallback rules. This role is optional; do not make work depend on Spark being
 offered by the session.
 
+Terra remains the default owner of routine issue delivery, including tests and
+failure repair. Spark is only an explicitly assigned local helper within that
+delivery task; it does not replace Terra's end-to-end responsibility or create a
+mandatory handoff. Use it only when the extra delegation has a concrete benefit
+and the session permits it.
+
 Accept clearly specified, local tasks: trace a known call path, fix a localized
 failure, or implement a small change after its design is settled.
 

--- a/.agents/luna.md
+++ b/.agents/luna.md
@@ -6,6 +6,11 @@ Perform bounded scans, builds, tests, artifact inspection, or authorized Git
 operations. Report evidence; do not expand a diagnostic task into a source
 rewrite. Trivial mechanical edits are allowed only when assigned.
 
+Own complete bounded batches rather than isolated commands: collect the requested
+evidence, interpret check outcomes within scope, and return a concise completion
+or blocker report. Reuse the implementation owner's valid results; independent
+verification is risk-based, not a mandatory extra handoff for every issue.
+
 ## Bounded evidence tasks
 
 - Work within the assigned files/search area and answer the named questions.
@@ -28,8 +33,11 @@ rewrite. Trivial mechanical edits are allowed only when assigned.
   changed. Do not add redundant full-suite runs.
 - Report commands, exit status, relevant failures/warnings, and skipped checks.
 - Distinguish observed failures, likely causes, and speculation.
-- If a failure requires a design or implementation decision, return evidence
-  to the primary agent. Do not modify tests merely to obtain a passing result.
+- Route ordinary implementation failures with evidence to the assigned Terra
+  owner, through the primary if the session requires it. Escalate architectural
+  or unresolved semantic conflicts to the primary; a failing check alone does
+  not require Astra to repair it. Do not modify tests merely to obtain a passing
+  result.
 
 ## Authorized Git work
 

--- a/.agents/orchestration.md
+++ b/.agents/orchestration.md
@@ -6,37 +6,53 @@ The primary agent owns requirements, architecture, task decomposition, final
 integration, acceptance, and communication. Model preferences are centralized
 below; worker documents define role-specific behavior, not competing defaults.
 
-Small or tightly coupled tasks may be completed directly by the primary agent,
-including exploration, implementation, checks, and authorized Git operations.
-No task must pass through a fixed sequence of agents.
+Ownership of the outcome does not mean personally executing every step. Terra
+owns routine issue delivery from investigation through implementation, tests,
+and failure repair. Luna owns bounded evidence collection, verification batches,
+and authorized Git work. Sol provides risk-based independent review. The primary
+focuses on architecture, complex semantic disputes, conflicting review findings,
+final acceptance, and communication rather than routine execution.
+
+The primary may complete genuinely trivial changes directly when a task packet
+would cost more than the work, or handle a specific unresolved design concern.
+Tightly coupled implementation belongs in one cohesive Terra task, not
+automatically on the primary. No task must pass through a fixed agent sequence.
 
 Delegate bounded work when it can progress independently alongside useful
 primary-agent work, or when an independent review materially improves confidence.
 Prefer parallel read-only discovery and isolated implementation tasks for
 substantial work. Do not delegate a single routine command merely to satisfy a
-role label. Delegation remains subject to the session's tool and permission rules.
+role label. Cost reduction is also a routing consideration; lack of parallel work
+alone does not justify moving a complete routine task onto Astra. Delegation
+remains subject to the session's tool and permission rules, including any
+requirement for useful independent work alongside the primary. If those rules
+prevent the preferred routing, report the constraint rather than bypassing it.
 
 ## Task decomposition
 
 For substantial work, separate evidence collection, implementation, verification,
-and decision-making before starting a broad scan or change. Prefer delegating a
-bounded evidence or verification task to Luna when it can run independently
-alongside useful primary work. Do not keep all discovery and checking on the
-primary merely because the primary already knows the repository.
+and decision-making before starting a broad scan or change. Assign a complete
+routine implementation task to Terra and separate bounded evidence or independent
+verification to Luna where useful and permitted. Do not keep discovery and
+checking on the primary merely because it already knows the repository.
 
 - Give Luna explicit files or a bounded search area, questions, expected evidence,
   and a stopping condition. Suitable tasks include enumerating consumers of a
   field, mapping specified YAML forms to tests, checking a defined set of links,
   and running an agreed verification batch after the affected files are stable.
-- Keep open-ended ISA interpretation, architecture, semantic equivalence, and
-  final acceptance with the primary or an appropriate technical reviewer. For
+- Escalate architecture changes, unresolved complex ISA/semantic questions, and
+  conflicting review findings to the primary or an appropriate reviewer. Routine
+  interpretation within established contracts remains with Terra. For
   example, Luna gathers candidate duplicate tests and their assertions; the
   primary decides whether coverage is genuinely redundant.
-- Assign cohesive implementation and deep debugging to Terra. Reuse a worker's
+- Assign cohesive implementation, relevant tests, and failure repair to Terra.
+  A normal test failure stays with its implementation owner; it is not an
+  automatic primary-agent takeover. Reuse a worker's
   findings rather than rescanning the same area; investigate only unresolved
   evidence or review concerns.
-- Batch related routine work into one useful task packet. Keep trivial or tightly
-  coupled work local when there is no useful parallel work or independent check.
+- Batch related routine work into one useful task packet, including diagnosis,
+  edits, and checks. Keep only genuinely trivial work local when delegation
+  overhead exceeds its benefit.
   There is no agent-count quota or mandatory handoff sequence.
 
 If a worker reaches its stated boundary without enough evidence, request the
@@ -47,9 +63,9 @@ bounded scan into an unbounded review by default.
 
 | Role | Preferred model | Reasoning effort | Instructions |
 | --- | --- | --- | --- |
-| Primary | `gpt-6-astra` | Preserve the session setting | This document |
+| Primary: architecture, escalations, final acceptance | `gpt-6-astra` | Preserve the session setting | This document |
 | Optional independent technical review | `gpt-5.6-sol` | `high` | [Technical review](#independent-technical-review) |
-| Substantial implementation/deep debugging | `gpt-5.6-terra` | `high` | [Terra](terra.md) |
+| Routine issue delivery and deep debugging | `gpt-5.6-terra` | `high` | [Terra](terra.md) |
 | Bounded evidence scans, independent verification, Git | `gpt-5.6-luna` | `medium`; `high` for judgment-heavy verification | [Luna](luna.md) |
 | Optional narrow coding worker | `gpt-5.3-codex-spark` | `medium`; `high` only for a specific need | [Spark](gpt-5.3-codex-spark.md) |
 
@@ -61,16 +77,30 @@ model is controlled by the host/user; editing this file does not switch it.
 If Spark is unavailable, use Terra for a bounded implementation or Luna for
 read-only discovery, or complete the task directly. If Terra/Luna is unavailable,
 use a suitable supported worker or the primary agent. Agent unavailability must
-not block otherwise feasible authorized work.
+not block otherwise feasible authorized work. Report the unavailable model or
+tool constraint and chosen fallback; do not silently make Astra the execution
+default. An interrupted worker should be resumed or its remaining bounded work
+reassigned when supported, rather than automatically absorbed by the primary.
 
 If Sol is unavailable, use another suitable supported reviewer when independent
 review is warranted. Otherwise the primary agent reviews directly and reports
 any material verification gap; do not claim an independent review occurred.
 
-Use a minimal context fork with a self-contained task packet when practical.
-Model overrides and effort values must follow the tool's actual schema; if a
-full-history fork requires inheritance, omit overrides instead of sending an
-invalid request. Do not change effort solely because the primary model upgraded.
+Use a self-contained task packet and the smallest context fork that supports an
+explicit worker model and effort. For tools where a full-history fork inherits
+the parent model, use no history or a supported limited fork for Terra/Luna/Sol;
+do not drop the override merely to keep full history. If full-history inheritance
+is genuinely required, record that exception and the inherited model rather than
+claiming a different worker model. Follow the actual tool schema and do not change
+effort solely because the primary model upgraded.
+
+Record the requested model and effort in the delegation record. Distinguish them
+from the effective model when runtime metadata exposes it; otherwise mark the
+effective model as unverified. A role name or successful spawn is not proof of
+billing identity. For usage audits, distinguish request counts, input/cached-input
+tokens, output tokens, and cost over the same period. Do not invent telemetry or
+enforce arbitrary model-percentage quotas. Host model configuration is separate
+from this policy and must not be changed without user authorization.
 
 ## Independent technical review
 
@@ -83,8 +113,8 @@ and validation evidence. Prefer a reviewer that did not author the work.
 Review is read-only unless changes are explicitly assigned; return actionable
 findings with file/symbol evidence, their consequences, and remaining uncertainty.
 
-Sol provides a technical assessment; Luna remains the preferred execution and
-verification worker, and Terra the substantial implementation worker. The
+Sol provides a technical assessment; Luna remains the bounded evidence,
+verification, and Git worker, and Terra owns routine implementation delivery. The
 primary agent resolves conflicting findings and retains final design and
 acceptance responsibility.
 
@@ -100,8 +130,10 @@ Before delegating, read the selected worker's instructions. Provide:
 - whether Git operations or external publication are authorized.
 
 Workers report scope expansion or architectural conflicts to the primary agent.
-The primary resolves ordinary implementation choices itself or reassigns the
-task; escalation to another agent is not automatically a question for the user.
+Terra resolves ordinary implementation choices within the agreed contracts.
+Escalations identify the specific decision, evidence, attempted approaches, and
+available options. The primary resolves that decision and returns execution to
+the owner where feasible; escalation is not automatically a question for the user.
 
 ## Parallel work and integration
 
@@ -111,6 +143,9 @@ task; escalation to another agent is not automatically a question for the user.
 - Once delegated, avoid duplicating a worker's investigation or implementation.
   Review its evidence and relevant diff; investigate further when evidence is
   incomplete, conflicting, or reveals a correctness concern.
+- Prefer completion or blocker reports over frequent status polling and
+  step-by-step intervention. Review concise evidence and key diffs, not a second
+  full investigation. Final acceptance does not require replaying worker checks.
 - The primary owns final acceptance, including review of code it delegates.
   Use independent verification for substantial or risky work when useful;
   small changes do not require a separate agent solely to rerun a passing check.
@@ -125,10 +160,11 @@ unverified behavior, and relevant repository state without dumping full logs.
 ## Git workflow
 
 When Git work is authorized and ready, prefer a single bounded Luna task for
-status/diff checks, staging, commit, and any separately authorized publication
-when the primary can review the handoff or other task evidence in parallel.
-The primary may perform it when delegation offers no useful benefit or a worker
-is unavailable. Implementation workers do not stage or commit unless that scope
+status/diff checks, staging, commit, and any separately authorized publication.
+Batch the operation rather than delegating individual commands. Use useful
+parallel handoff/evidence review where the session requires it. The primary may
+perform genuinely trivial Git work or handle a documented tool/availability
+constraint. Implementation workers do not stage or commit unless that scope
 was explicitly assigned.
 
 The Git owner checks status and the intended diff, reuses valid verification

--- a/.agents/orchestration.md
+++ b/.agents/orchestration.md
@@ -66,8 +66,8 @@ bounded scan into an unbounded review by default.
 | Primary: architecture, escalations, final acceptance | `gpt-6-astra` | Preserve the session setting | This document |
 | Optional independent technical review | `gpt-5.6-sol` | `high` | [Technical review](#independent-technical-review) |
 | Routine issue delivery and deep debugging | `gpt-5.6-terra` | `high` | [Terra](terra.md) |
-| Bounded evidence scans, independent verification, Git | `gpt-5.6-luna` | `medium`; `high` for judgment-heavy verification | [Luna](luna.md) |
-| Optional narrow coding worker | `gpt-5.3-codex-spark` | `medium`; `high` only for a specific need | [Spark](gpt-5.3-codex-spark.md) |
+| Bounded evidence scans, independent verification, Git | `gpt-5.6-luna` | `xhigh` for judgment-heavy verification | [Luna](luna.md) |
+| Optional narrow coding worker | `gpt-5.3-codex-spark` | `high` only for a specific need | [Spark](gpt-5.3-codex-spark.md) |
 
 These are preferences, not assertions that every session offers these models.
 Check the actual tool's supported model list before assigning an override.

--- a/.agents/terra.md
+++ b/.agents/terra.md
@@ -1,16 +1,25 @@
-# Substantial implementation worker
+# Routine issue delivery and deep-debugging worker
 
 Read [orchestration.md](orchestration.md) for routing and model preferences.
 
-Own the assigned implementation or deep-debugging task: trace the relevant
-behavior, make a bounded change, and verify the affected contracts. This role
-suits interacting files, ownership/lifetime issues, state machines, complex
+Own the complete assigned issue-delivery or deep-debugging task: investigate the
+cause, make a bounded change, add or update relevant tests, verify the affected
+contracts, and fix failures caused by the change. A routine failing check remains
+with this role rather than automatically returning execution to the primary.
+This role suits interacting files, ownership/lifetime issues, state machines, complex
 tests, and bugs requiring wider context.
 
 The primary agent owns architecture and acceptance. Resolve routine choices
 within the agreed design; report conflicts or scope expansion with evidence
 before changing unrelated subsystems. Preserve useful investigation when a
 task must be reassigned.
+
+Escalate architecture changes, unresolved complex semantic questions, or
+conflicting review findings with the specific decision, evidence, attempted
+approaches, and options. Do not escalate routine implementation choices merely
+because they require judgment. After a decision, resume the implementation and
+verification loop within the assigned scope. Return concise completion or blocker
+reports instead of requiring primary-agent supervision of individual steps.
 
 Use the project's existing components and documentation conventions. Preserve
 unrelated edits and avoid opportunistic cleanup. Run meaningful local checks;

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -197,14 +197,20 @@ Modifier primitives include `bool`, `ScalarType`, and `RoundingMode`; the latter
 turns `.rn/.rz/.rm/.rp` into statically checkable values instead of runtime
 strings. Operand primitives include `ResolvedRegisterRef`, `ResolvedImmediate`,
 `ResolvedPredicate`, `ResolvedBranchTarget`, `ResolvedSpecialRegisterRef`,
-`ResolvedFunctionRef`, `ResolvedSymbolRef`, `ResolvedAddress`, `ResolvedMovSource`, and `RegOrImm`. A `ResolvedImmediate` stores integer bits
-and `ScalarType`, so the checker never has to reinterpret literal text.
+`ResolvedFunctionRef`, `ResolvedSymbolRef`, `ResolvedAddress`, `ResolvedMovSource`, and `RegOrImm`. A `ResolvedImmediate` stores use-width bits
+and `ScalarType`. Integer forms also retain evaluated 64-bit source bits and
+numerical signed-negativity, so fixed-control checks never reinterpret literal
+text or trust a narrowed value.
 
 `AstImmediateKind` retains the lexer's literal classification. Decimal, octal, and hex
-integers, including their optional `U` suffix, are range-checked against the
-target integer or bit type. Negative values are stored in `bits` as the
-target-width two's-complement representation rather than being unconditionally
-extended to 64 bits. Decimal floats currently convert to `F32` and `F64`, while
+integers, including their optional `U` suffix, first evaluate in the PTX
+64-bit signed/unsigned source domain; unary minus preserves that source type
+and unsigned negation wraps. Ordinary modifier-driven data uses retain the low
+target-width bits, while fixed-scalar instruction controls, call literals checked
+against formal parameter types, and address offsets
+retain strict target-width representability. A signed `-0` is numerically zero,
+whereas floating negative zero retains its IEEE sign bit. Decimal floats
+currently convert to `F32` and `F64`, while
 `0f<8 hex>` and `0d<16 hex>` are raw IEEE bit patterns for `F32` and `F64`
 respectively. Other floating formats require explicit quantization rules and
 must not silently take the integer path.

--- a/docs/us-en/resolved_ir_design.md
+++ b/docs/us-en/resolved_ir_design.md
@@ -205,10 +205,14 @@ text or trust a narrowed value.
 `AstImmediateKind` retains the lexer's literal classification. Decimal, octal, and hex
 integers, including their optional `U` suffix, first evaluate in the PTX
 64-bit signed/unsigned source domain; unary minus preserves that source type
-and unsigned negation wraps. Ordinary modifier-driven data uses retain the low
-target-width bits, while fixed-scalar instruction controls, call literals checked
-against formal parameter types, and address offsets
-retain strict target-width representability. A signed `-0` is numerically zero,
+and unsigned negation wraps. Ordinary data uses retain the low target-width
+bits. The generated operand descriptor independently selects narrowing or
+strict target-width representability for each semantic use; a fixed scalar type
+expresses provenance only. Generated range, exact-value, and multiple-of
+controls compare preserved source bits, while unconstrained controls opt into
+strict conversion explicitly. Call literals checked against formal parameter
+types and address offsets retain strict target-width representability. A signed
+`-0` is numerically zero,
 whereas floating negative zero retains its IEEE sign bit. Decimal floats
 currently convert to `F32` and `F64`, while
 `0f<8 hex>` and `0d<16 hex>` are raw IEEE bit patterns for `F32` and `F64`

--- a/docs/us-en/symbol_binding_design.md
+++ b/docs/us-en/symbol_binding_design.md
@@ -74,6 +74,11 @@ declaration that overlaps an explicit name, or another parameterized
 declaration with a different base, produces a same-scope duplicate diagnostic
 with the previous range. The base itself is not a generated member, so
 `name<2>` and an explicit `name` remain distinct symbols.
+Ordinary/ordinary comparisons use the two literal spellings; ordinary/group
+comparisons test the ordinary spelling against the group's members; and
+group/group comparisons test only generated members. Zero-count invalid groups
+have no members and do not create overlap candidates, while same-base compact
+declarations retain the exact-declaration duplicate policy.
 
 Parameterized names are valid in every state space, but cannot also declare an
 array or initializer. The previous `.reg`-only restriction was removed, and
@@ -103,10 +108,11 @@ record even when it is unresolved; declaration semantics and storage lowering
 therefore do not rescan all instruction and initializer references per symbol.
 
 Parameterized overlap checking uses a sparse 32-bit member-range trie keyed
-by canonical spelling decompositions. It identifies existing explicit names,
-existing group bases, and group first-member spellings relevant to the new
-base/count, then retains the first stored overlapping identity for the
-diagnostic. The existing name-set-overlap predicate remains authoritative.
+by canonical spelling decompositions. It identifies existing explicit names
+and nonempty group first-member spellings relevant to the new base/count, then
+retains the first stored overlapping identity for the diagnostic. Group bases
+are excluded because they are not members; the existing name-set-overlap
+predicate remains authoritative.
 The indexes store no logical members: a declaration with a very large count
 uses storage proportional to its spelling and the fixed 32-bit trie paths,
 not to its count. Index keys and trie storage are owned by the table, so

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -227,6 +227,25 @@ variant. The schema retains `same_as(...)`, `one_of(...)`, and
 `same_size_as(...)` as future syntax, but the normalizer explicitly rejects
 them as unsupported.
 
+`immediate_conversion` is a separate use contract for integer immediates. It
+defaults to `narrow`, which retains the low bits of the resolved scalar width
+after decoding the 64-bit source. Use `require_target_range` only where a
+semantic operand must be representable at that width:
+
+```yaml
+- name: barrier
+  kind: reg_or_imm
+  role: barrier
+  access: read
+  type: u32
+  immediate_conversion: require_target_range
+```
+
+It is independent of `type`: fixed scalar types and modifier-derived types may
+each use either conversion. Bounded control operands should instead reuse a
+generated range, exact-value, or multiple-of constraint when that fully states
+their rule; those constraints compare the original decoded source bits.
+
 An address operand may similarly derive its required state space from an
 active `kind: state_space` modifier:
 
@@ -476,10 +495,10 @@ and source-program errors distinguishable.
 operand_patterns:
   bar_sync_immediate_barrier:
     - {name: barrier, kind: imm, role: barrier,
-       access: read, type: u32}
+       access: read, type: u32, immediate_conversion: require_target_range}
   bar_sync_barrier:
     - {name: barrier, kind: reg_or_imm, role: barrier,
-       access: read, type: u32}
+       access: read, type: u32, immediate_conversion: require_target_range}
 
 instructions:
   - opcode: bar

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -449,13 +449,14 @@ Thus `192` is valid while `23`, `257`, and `25` are rejected. `bfe.u32` and
 `bfi.b32` each use two independent inclusive ranges, `offset` and `width`,
 both `0..255`; both operands are immediate operands in their only layout.
 
-At resolution time an integer immediate carries its scalar type, raw width
-limited bits, and a signed-source marker. For example, a signed `-1` has the
-two's-complement raw bits for its operand width and keeps `is_negative`; it is
-not converted to an abstract signed integer before checker rules run. Range
-and multiple-of checks reject that negative marker before comparing or taking
-a remainder. Exact-value checks intentionally compare raw bits, so an allowlist
-is a bit-value contract. Floating immediates resolve to IEEE raw bits: decimal
+At resolution time an integer immediate carries its scalar type, use-width
+bits, evaluated 64-bit source bits, and numerical signed-negativity. The
+source is signed unless it has `U`/`u` or exceeds `INT64_MAX`; unary minus
+preserves that type and wraps unsigned values. Range, multiple-of, and
+exact-value checks require a nonnegative source and compare original source
+bits, so a nonzero value that narrows to an allowed target-width bit pattern
+cannot satisfy a fixed control rule. A signed `-0` therefore behaves as zero.
+Floating immediates resolve to IEEE raw bits: decimal
 forms require `f32` or `f64`, and `0f...`/`0d...` are unsigned 32-/64-bit
 bit-pattern literals that require exactly `f32`/`f64` and cannot have a sign.
 Consequently these constraints are integer-domain rules; do not use their

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -164,10 +164,12 @@ fixed-control checker 不必重新解释 literal 文本，也不会信任已经�
 
 `AstImmediateKind` 保留 lexer 对 literal 的分类。整数 decimal/octal/hex（包括可选 `U`
 后缀）先在 PTX 64-bit signed/unsigned source domain 中求值；unary minus 保留该 source
-type，而 unsigned negation 按该宽度回绕。ordinary modifier-driven data use 随后保留 target
-width 的低位；fixed-scalar instruction control、按 formal parameter type 检查的 call literal
-与 address offset 则继续执行严格的
-target-width representability 检查。signed `-0` 在数值上是 zero，而 floating negative
+type，而 unsigned negation 按该宽度回绕。ordinary data use 随后保留 target width 的低位。
+generated operand descriptor 为每个 semantic use 独立选择截断或严格 target-width
+representability；fixed scalar type 只表达 provenance。generated range、exact-value 与
+multiple-of control 比较保留的 source bits，而无约束的 control 显式选择严格 conversion。
+按 formal parameter type 检查的 call literal 与 address offset 继续执行严格的 target-width
+representability 检查。signed `-0` 在数值上是 zero，而 floating negative
 zero 保留其 IEEE sign bit。decimal float 目前支持转换至 `F32` 与 `F64`；
 `0f<8 hex>` 与 `0d<16 hex>` 分别作为 `F32` 与 `F64` 的原始 IEEE bit pattern。
 其他浮点格式需要其明确的量化规则后再加入，不能静默按整数处理。

--- a/docs/zh-han/resolved_ir_design.md
+++ b/docs/zh-han/resolved_ir_design.md
@@ -158,12 +158,17 @@ modifier 得到的编译期常量，或由 optional modifier 的 YAML `default` 
 `ResolvedRegisterRef`、`ResolvedImmediate`、`ResolvedPredicate`、
 `ResolvedBranchTarget`、`ResolvedSpecialRegisterRef`、`ResolvedFunctionRef`、`ResolvedSymbolRef`、
 `ResolvedAddress`、`ResolvedMovSource` 与 `RegOrImm`。
-`ResolvedImmediate` 保存整数 bits 和 `ScalarType`，因此 checker 不必
-重新解释 literal 文本。
+`ResolvedImmediate` 保存 use-width bits 和 `ScalarType`。integer form 还会
+保留求值后的 64-bit source bits 与数值上的 signed-negative 性质，因此
+fixed-control checker 不必重新解释 literal 文本，也不会信任已经窄化的值。
 
 `AstImmediateKind` 保留 lexer 对 literal 的分类。整数 decimal/octal/hex（包括可选 `U`
-后缀）按目标整数或 bit type 的位宽做范围检查；负数以该目标宽度的二进制补码存入
-`bits`，不会再无条件扩展为 64 位。decimal float 目前支持转换至 `F32` 与 `F64`；
+后缀）先在 PTX 64-bit signed/unsigned source domain 中求值；unary minus 保留该 source
+type，而 unsigned negation 按该宽度回绕。ordinary modifier-driven data use 随后保留 target
+width 的低位；fixed-scalar instruction control、按 formal parameter type 检查的 call literal
+与 address offset 则继续执行严格的
+target-width representability 检查。signed `-0` 在数值上是 zero，而 floating negative
+zero 保留其 IEEE sign bit。decimal float 目前支持转换至 `F32` 与 `F64`；
 `0f<8 hex>` 与 `0d<16 hex>` 分别作为 `F32` 与 `F64` 的原始 IEEE bit pattern。
 其他浮点格式需要其明确的量化规则后再加入，不能静默按整数处理。
 

--- a/docs/zh-han/symbol_binding_design.md
+++ b/docs/zh-han/symbol_binding_design.md
@@ -61,6 +61,10 @@ program declaration 可以使用相同 spelling。`.loc` 的 basic 与 `inlined_
 以及两个不同 base 的 parameterized declaration，只要展开后存在同 scope 成员重叠，都会
 产生带 previous range 的 duplicate diagnostic；parameterized base 本身不属于展开集合，
 所以 `name<2>` 与 explicit `name` 仍是两个不同 symbol。
+ordinary/ordinary 只比较两个 literal spelling；ordinary/group 用 ordinary spelling
+匹配 group 的成员；group/group 只比较生成出的成员。非法的 zero-count group 没有成员，
+不会产生 overlap candidate；同 base 的 compact declaration 仍沿用 exact-declaration
+duplicate policy。
 
 Parameterized name 可用于任意 state space，但不能同时声明 array 或 initializer。原先
 只允许 `.reg` 的限制已移除，公共 CST/AST 字段也统一命名为 `parameterized_count`。
@@ -84,9 +88,9 @@ bound identity 的 consumer 暴露同 scope 的 exact index；它不走 parent�
 每个 symbol 重扫全部 instruction/initializer reference。
 
 Parameterized overlap check 使用按 canonical spelling decomposition 建立的稀疏 32-bit member
-range trie。它定位与新 base/count 有关的已有 explicit name、已有 group base 与 group 的
-first-member spelling，并为 diagnostic 保留最先存储的 overlap identity；现有的 name-set-
-overlap predicate 仍是最终事实来源。index 不会展开逻辑 member：count 很大的 declaration
+range trie。它定位与新 base/count 有关的已有 explicit name 和 nonempty group 的
+first-member spelling，并为 diagnostic 保留最先存储的 overlap identity；group base 因不属于
+member 而不进入此 index，现有的 name-set-overlap predicate 仍是最终事实来源。index 不会展开逻辑 member：count 很大的 declaration
 只消耗与 spelling 长度及固定 32-bit trie path 成比例的存储，而不与 count 成比例。index key
 和 trie storage 都由表拥有，所以 `symbols` vector 增长以及支持的 table copy/move 都不会留下
 悬空的 borrowed name key。

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -200,6 +200,23 @@ type-expression 函数是 `modifier(name)`：它读取当前 variant 的 active 
 schema 仍保留 `same_as(...)`、`one_of(...)` 和 `same_size_as(...)` 作为未来语法，但
 normalizer 会明确报错表示尚未支持。
 
+`immediate_conversion` 是 integer immediate 独立的 use contract。其默认值 `narrow`
+会在解码 64-bit source 后保留 resolved scalar width 的低位。仅当语义 operand 必须能由
+该宽度表示时才使用 `require_target_range`：
+
+```yaml
+- name: barrier
+  kind: reg_or_imm
+  role: barrier
+  access: read
+  type: u32
+  immediate_conversion: require_target_range
+```
+
+它独立于 `type`：fixed scalar type 与 modifier-derived type 都可选择任一 conversion。
+若 bounded control operand 的规则可由 generated range、exact-value 或 multiple-of constraint
+完整表达，应复用这些 constraint；它们比较原始 decoded source bits。
+
 address operand 也可以从 active `kind: state_space` modifier 派生所要求的
 state space：
 
@@ -415,10 +432,10 @@ configuration error 与 source-program error。
 operand_patterns:
   bar_sync_immediate_barrier:
     - {name: barrier, kind: imm, role: barrier,
-       access: read, type: u32}
+       access: read, type: u32, immediate_conversion: require_target_range}
   bar_sync_barrier:
     - {name: barrier, kind: reg_or_imm, role: barrier,
-       access: read, type: u32}
+       access: read, type: u32, immediate_conversion: require_target_range}
 
 instructions:
   - opcode: bar

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -393,11 +393,12 @@ constraints:
 独立的 inclusive range：`offset` 和 `width` 均为 `0..255`；两个 operand 在各自唯一的
 layout 中都是 immediate operand。
 
-resolver 中，integer immediate 携带 scalar type、受 operand width 限制的 raw bits，以及
-源端 signed marker。例如 signed `-1` 的 raw bits 是该 operand width 下的 two's-complement，
-同时保留 `is_negative`；checker rule 运行前不会把它转换成抽象 signed integer。range 和
-multiple-of 会先拒绝 negative marker，再比较或取余。exact-value 则有意比较 raw bits，
-所以 allowlist 是 bit-value contract。floating immediate 解析为 IEEE raw bits：decimal form
+resolver 中，integer immediate 携带 scalar type、use-width bits、求值后的 64-bit source bits，
+以及数值上的 signed-negative 性质。source 在没有 `U`/`u` 且不超过 `INT64_MAX` 时为 signed；
+unary minus 保留该 type，而 unsigned value 按该宽度回绕。range、multiple-of 与 exact-value
+都要求 source 为 nonnegative，并比较原始 source bits；因此非零 source 即使窄化为允许的
+target-width bit pattern，也不能满足 fixed control rule。signed `-0` 因而等同 zero。
+floating immediate 解析为 IEEE raw bits：decimal form
 要求 `f32` 或 `f64`，`0f...`/`0d...` 分别是 unsigned 32-/64-bit bit-pattern literal，
 必须恰好使用 `f32`/`f64`，且不能带符号。因此这些 constraint 是 integer-domain rule；不要
 用看似数值的 bounds 表达 floating-point ordering。

--- a/instructions/schemas/ptx-instr-v1.schema.yaml
+++ b/instructions/schemas/ptx-instr-v1.schema.yaml
@@ -770,6 +770,15 @@ $defs:
           - equal_or_wider
         default: same_width
 
+      immediate_conversion:
+        description: >
+          Integer conversion selected by this operand use after 64-bit source
+          decoding. The default narrows to the resolved scalar width;
+          require_target_range rejects a source not representable at that width.
+        type: string
+        enum: [narrow, require_target_range]
+        default: narrow
+
       allow_destination_sink:
         description: "Whether '_' is accepted as the data half of a shfl_dest pair."
         type: boolean

--- a/python/code_gen/_frontend/gen_resolved_descriptor.py
+++ b/python/code_gen/_frontend/gen_resolved_descriptor.py
@@ -446,6 +446,10 @@ def _emit_operand_binding_descriptor(
         CppDomain.REGISTER_WIDTH_POLICIES,
         binding.register_width_policy.value,
     )
+    immediate_conversion_policy = cpp_value(
+        CppDomain.IMMEDIATE_CONVERSION_POLICIES,
+        binding.immediate_conversion_policy.value,
+    )
     return f"""          check_end::ResolvedOperandBindingDescriptor{{
               .target_field_id = "{binding.target_field_id}",
               .type_expression = {_emit_type_expression_descriptor(binding.type_expression)},
@@ -453,6 +457,7 @@ def _emit_operand_binding_descriptor(
               .role = {cpp_value(CppDomain.RESOLVED_OPERAND_ROLES, binding.role.value)},
               .access = {cpp_value(CppDomain.RESOLVED_OPERAND_ACCESS, binding.access.value)},
               .allowed_shapes = {allowed_shapes},{vector_arities}{vector_arity_modifier}{vector_policy}{allow_vector_sink}{vector_sink_payload_bits}{allow_destination_sink}{allow_predicate_sink}{mbarrier_state_token_form}{sink_availability}{allow_function_symbol}{type_tag}{cardinality}{element_shapes}{address_state_spaces}{state_space}{parameter_constraint}
+              .immediate_conversion_policy = {immediate_conversion_policy},
           }}"""
 
 

--- a/python/code_gen/_frontend/gen_resolved_ir.py
+++ b/python/code_gen/_frontend/gen_resolved_ir.py
@@ -1343,6 +1343,7 @@ def _emit_check_operand_view(field: ResolvedField, object_name: str) -> str:
                   .immediate_is_negative = {object_name}.{field.name}.value.is_negative,
                   .register_type = std::nullopt,
                   .locations = {object_name}.{field.name}.locs,
+                  .integer_source_bits = {object_name}.{field.name}.value.integer_source_bits,
               }}"""
     if field.value_cpp_type == "ResolvedPredicate":
         return f"""              OperandView{{
@@ -1507,6 +1508,7 @@ def _emit_check_operand_view(field: ResolvedField, object_name: str) -> str:
                       .immediate_is_negative = immediate->is_negative,
                       .register_type = std::nullopt,
                       .locations = {object_name}.{field.name}.locs,
+                      .integer_source_bits = immediate->integer_source_bits,
                   }};
                 }}
                 const auto& register_ref =
@@ -1552,6 +1554,7 @@ def _emit_check_operand_view(field: ResolvedField, object_name: str) -> str:
                       .immediate_is_negative = immediate->is_negative,
                       .register_type = std::nullopt,
                       .locations = {object_name}.{field.name}.locs,
+                      .integer_source_bits = immediate->integer_source_bits,
                   }};
                 }}
                 if (const auto* register_ref =

--- a/python/code_gen/cpp_backend.py
+++ b/python/code_gen/cpp_backend.py
@@ -52,6 +52,7 @@ class CppDomain(str, Enum):
     PROXY_KIND_PAIRS = "proxy_kind_pairs"
     PARAMETER_DIRECTIONS = "parameter_directions"
     REGISTER_WIDTH_POLICIES = "register_width_policies"
+    IMMEDIATE_CONVERSION_POLICIES = "immediate_conversion_policies"
     MODIFIER_VALUE_CPP_TYPES = (  # YAML: domains.modifier_value_cpp_types
         "modifier_value_cpp_types"
     )

--- a/python/code_gen/model.py
+++ b/python/code_gen/model.py
@@ -22,6 +22,13 @@ class OperandRegisterWidthPolicy(str, Enum):
     EQUAL_OR_WIDER = "equal_or_wider"
 
 
+class OperandImmediateConversionPolicy(str, Enum):
+    """How a decoded integer immediate is converted at one operand use."""
+
+    NARROW = "narrow"
+    REQUIRE_TARGET_RANGE = "require_target_range"
+
+
 class OperandVectorTypePolicy(str, Enum):
     """How an instruction type maps onto a register-vector operand."""
 
@@ -200,6 +207,9 @@ class OperandSpec:
     type_expression: OperandTypeExpression | None = None
     register_width_policy: OperandRegisterWidthPolicy = (
         OperandRegisterWidthPolicy.SAME_WIDTH
+    )
+    immediate_conversion_policy: OperandImmediateConversionPolicy = (
+        OperandImmediateConversionPolicy.NARROW
     )
     state_space_values: tuple[OperandStateSpaceValue, ...] = ()
     state_space_expression: OperandStateSpaceExpression | None = None

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -19,6 +19,7 @@ from .model import (
     ModifierValueSpec,
     OperandLayoutSpec,
     OperandLayoutKind,
+    OperandImmediateConversionPolicy,
     OperandParameterConstraint,
     OperandRegisterWidthPolicy,
     OperandSpec,
@@ -284,6 +285,23 @@ def normalize_operand(raw: dict[str, Any]) -> OperandSpec:
                 "requires a type expression"
             )
 
+    try:
+        immediate_conversion_policy = OperandImmediateConversionPolicy(
+            raw.get("immediate_conversion", "narrow")
+        )
+    except ValueError as error:
+        raise ValueError(
+            f"operand {raw['name']!r}: unsupported immediate_conversion "
+            f"{raw.get('immediate_conversion')!r}"
+        ) from error
+    if (immediate_conversion_policy
+            is OperandImmediateConversionPolicy.REQUIRE_TARGET_RANGE and
+            raw["kind"] not in {"imm", "reg_or_imm", "tensor_coordinate"}):
+        raise ValueError(
+            f"operand {raw['name']!r}: require_target_range immediate_conversion "
+            "requires an immediate-capable operand"
+        )
+
     state_space_values, state_space_expression = _normalize_operand_state_space(
         raw.get("state_space")
     )
@@ -312,6 +330,7 @@ def normalize_operand(raw: dict[str, Any]) -> OperandSpec:
         access=raw.get("access"),
         type_expression=type_expression,
         register_width_policy=register_width_policy,
+        immediate_conversion_policy=immediate_conversion_policy,
         state_space_values=state_space_values,
         state_space_expression=state_space_expression,
         parameter_constraint=parameter_constraint,

--- a/python/code_gen/resources/ptx-instr-v1.schema.yaml
+++ b/python/code_gen/resources/ptx-instr-v1.schema.yaml
@@ -770,6 +770,15 @@ $defs:
           - equal_or_wider
         default: same_width
 
+      immediate_conversion:
+        description: >
+          Integer conversion selected by this operand use after 64-bit source
+          decoding. The default narrows to the resolved scalar width;
+          require_target_range rejects a source not representable at that width.
+        type: string
+        enum: [narrow, require_target_range]
+        default: narrow
+
       allow_destination_sink:
         description: "Whether '_' is accepted as the data half of a shfl_dest pair."
         type: boolean

--- a/python/code_gen/resources/ptx_cpp_backend_spec/ptx_frontend.yaml
+++ b/python/code_gen/resources/ptx_cpp_backend_spec/ptx_frontend.yaml
@@ -204,6 +204,12 @@ domains:
       same_width: base::ScalarTypeSizePolicy::SameWidth
       equal_or_wider: base::ScalarTypeSizePolicy::EqualOrWider
 
+  immediate_conversion_policies:
+    cpp_type: check_end::ImmediateConversionPolicy
+    values:
+      Narrow: check_end::ImmediateConversionPolicy::Narrow
+      RequireTargetRange: check_end::ImmediateConversionPolicy::RequireTargetRange
+
   modifier_value_cpp_types:
     cpp_type: CppType
     values:

--- a/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
+++ b/python/code_gen/resources/ptx_spec/data_movement_and_conversion.yaml
@@ -64,6 +64,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
+      immediate_conversion: require_target_range
 
   mapa_generic:
     - name: dst
@@ -86,6 +87,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
+      immediate_conversion: require_target_range
 
   getctarank_shared_cluster:
     - name: dst
@@ -1611,6 +1613,7 @@ instructions:
             role: src
             access: read
             type: u32
+            immediate_conversion: require_target_range
         rule: data_movement.cp_async_wait_group
         constraints:
           - kind: immediate_range

--- a/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
+++ b/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
@@ -14,6 +14,7 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
 
   bar_sync_barrier:
     - name: barrier
@@ -21,6 +22,7 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
   bar_warp_sync_membermask:
     - name: membermask
       kind: reg_or_imm
@@ -33,11 +35,13 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: thread_count
       kind: reg_or_imm
       role: thread_count
       access: read
       type: u32
+      immediate_conversion: require_target_range
   bar_red_popc_without_thread_count:
     - name: dst
       kind: reg
@@ -49,6 +53,7 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: predicate
       kind: pred_or_not
       role: predicate
@@ -65,11 +70,13 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: thread_count
       kind: reg_or_imm
       role: thread_count
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: predicate
       kind: pred_or_not
       role: predicate
@@ -86,6 +93,7 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: predicate
       kind: pred_or_not
       role: predicate
@@ -102,11 +110,13 @@ operand_patterns:
       role: barrier
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: thread_count
       kind: reg_or_imm
       role: thread_count
       access: read
       type: u32
+      immediate_conversion: require_target_range
     - name: predicate
       kind: pred_or_not
       role: predicate
@@ -281,6 +291,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
+      immediate_conversion: require_target_range
 
   mbarrier_arrive_cta:
     - name: state
@@ -374,6 +385,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
+      immediate_conversion: require_target_range
 
   mbarrier_arrive_expect_tx_cluster:
     - name: state
@@ -395,6 +407,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
+      immediate_conversion: require_target_range
 
   mbarrier_test_wait_token:
     - {name: wait_complete, kind: pred, role: dst, access: write, type: pred}
@@ -427,7 +440,7 @@ operand_patterns:
       type: b64
       register_width: exact
       mbarrier_state_token_form: register
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
 
   mbarrier_try_wait_parity_hint:
     - {name: wait_complete, kind: pred, role: dst, access: write, type: pred}
@@ -438,7 +451,7 @@ operand_patterns:
       access: read
       type: u32
       register_width: same_width
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
 
   mbarrier_wait_token_report_predicate:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
@@ -462,24 +475,24 @@ operand_patterns:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: state, kind: mbarrier_state_token, role: src, access: read, type: b64, register_width: exact, mbarrier_state_token_form: register}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
   mbarrier_try_wait_token_report_predicate_value_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: report_value, kind: reg, role: dst, access: write, type: b8, register_width: exact}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: state, kind: mbarrier_state_token, role: src, access: read, type: b64, register_width: exact, mbarrier_state_token_form: register}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
   mbarrier_try_wait_parity_report_predicate_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
   mbarrier_try_wait_parity_report_predicate_value_hint:
     - {name: wait_complete_report_predicate, kind: pred_pair, role: dst, access: write, type: pred}
     - {name: report_value, kind: reg, role: dst, access: write, type: b8, register_width: exact}
     - {name: address, kind: addr, role: addr, access: read, state_space: [shared]}
     - {name: phase_parity, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
-    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width}
+    - {name: time_hint, kind: reg_or_imm, role: src, access: read, type: u32, register_width: same_width, immediate_conversion: require_target_range}
   fence_proxy_acquire:
     - {name: address, kind: addr, role: addr, access: read, state_space: [global]}
     - {name: size, kind: imm, role: src, access: read, type: u32}

--- a/python/ir/resolved_ir.py
+++ b/python/ir/resolved_ir.py
@@ -30,6 +30,7 @@ from ptx_frontend.code_gen.model import (
     ModifierSpec,
     ModifierValueSpec,
     OperandParameterConstraint,
+    OperandImmediateConversionPolicy,
     OperandRegisterWidthPolicy,
     OperandSpec,
     OperandStateSpaceExpression,
@@ -155,6 +156,13 @@ class ResolvedRegisterWidthPolicy(Enum):
     EXACT = "exact"
     SAME_WIDTH = "same_width"
     EQUAL_OR_WIDER = "equal_or_wider"
+
+
+class ResolvedImmediateConversionPolicy(Enum):
+    """Descriptor-facing integer conversion behavior for an operand use."""
+
+    NARROW = "Narrow"
+    REQUIRE_TARGET_RANGE = "RequireTargetRange"
 
 
 class ResolvedVectorTypePolicy(Enum):
@@ -442,6 +450,7 @@ class ResolvedOperandBinding:
     target_field_id: str
     type_expression: ResolvedOperandTypeExpression
     register_width_policy: ResolvedRegisterWidthPolicy
+    immediate_conversion_policy: ResolvedImmediateConversionPolicy
     role: ResolvedOperandRole
     access: ResolvedOperandAccess
     allowed_shapes: tuple[ResolvedOperandShape, ...]
@@ -1103,6 +1112,12 @@ def _build_operand_layout(
                 ),
                 register_width_policy=ResolvedRegisterWidthPolicy(
                     operand.register_width_policy.value
+                ),
+                immediate_conversion_policy=ResolvedImmediateConversionPolicy(
+                    "".join(
+                        part.title()
+                        for part in operand.immediate_conversion_policy.value.split("_")
+                    )
                 ),
                 role=_require_operand_role(field),
                 access=_require_operand_access(field),

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -34,6 +34,7 @@ from ptx_frontend.code_gen.normalize import normalize_instruction_spec
 from ptx_frontend.ir.resolved_ir import (
     ResolvedFieldOrigin,
     ResolvedFieldStorage,
+    ResolvedImmediateConversionPolicy,
     ResolvedOperandAccess,
     ResolvedOperandRole,
     ResolvedOperandShape,
@@ -52,6 +53,7 @@ from ptx_frontend.code_gen.model import (
     ModifierSpec,
     ModifierValueSpec,
     OperandLayoutSpec,
+    OperandImmediateConversionPolicy,
     OperandSpec,
     OperandTypeExpression,
     OperandTypeExpressionKind,
@@ -896,6 +898,13 @@ class ResolvedIrBuildTest(unittest.TestCase):
             ],
         )
         self.assertEqual(
+            [
+                binding.immediate_conversion_policy
+                for binding in variants["Sync"].operand_layouts[2].bindings
+            ],
+            [ResolvedImmediateConversionPolicy.REQUIRE_TARGET_RANGE] * 2,
+        )
+        self.assertEqual(
             [layout.layout_id for layout in variants["RedPopcU32"].operand_layouts],
             ["without_thread_count", "with_thread_count"],
         )
@@ -919,6 +928,77 @@ class ResolvedIrBuildTest(unittest.TestCase):
         self.assertEqual(
             dict(variants["WarpSync"].availability),
             {"ptx": "6.0", "sm": 30},
+        )
+
+    def test_immediate_conversion_is_independent_of_type_expression(self) -> None:
+        """Fixed and modifier-derived types can select either conversion use."""
+
+        instruction = from_instruction_spec(
+            InstructionSpec(
+                opcode="conversion_test",
+                variants=(
+                    VariantSpec(
+                        name="conversion_test_default",
+                        availability={"ptx": "1.0", "sm": 0},
+                        modifiers=(
+                            ModifierSpec(
+                                name="type",
+                                kind="type",
+                                presence="required",
+                                domain="scalar_types",
+                                values=(ModifierValueSpec(value="u32"),),
+                            ),
+                        ),
+                        operand_layouts=(
+                            OperandLayoutSpec(
+                                name="default",
+                                operands=(
+                                    OperandSpec(
+                                        name="fixed_data",
+                                        kind="imm",
+                                        role="src",
+                                        access="read",
+                                        type_expression=OperandTypeExpression(
+                                            OperandTypeExpressionKind.FIXED_SCALAR,
+                                            scalar_type="b32",
+                                        ),
+                                    ),
+                                    OperandSpec(
+                                        name="strict_dynamic",
+                                        kind="reg_or_imm",
+                                        role="src",
+                                        access="read",
+                                        type_expression=OperandTypeExpression(
+                                            OperandTypeExpressionKind.MODIFIER,
+                                            modifier_name="type",
+                                        ),
+                                        immediate_conversion_policy=(
+                                            OperandImmediateConversionPolicy.REQUIRE_TARGET_RANGE
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+        bindings = instruction.variants[0].operand_layouts[0].bindings
+        self.assertEqual(
+            bindings[0].type_expression.kind,
+            ResolvedOperandTypeExpressionKind.FIXED_SCALAR,
+        )
+        self.assertEqual(
+            bindings[0].immediate_conversion_policy,
+            ResolvedImmediateConversionPolicy.NARROW,
+        )
+        self.assertEqual(
+            bindings[1].type_expression.kind,
+            ResolvedOperandTypeExpressionKind.MODIFIER_FIELD,
+        )
+        self.assertEqual(
+            bindings[1].immediate_conversion_policy,
+            ResolvedImmediateConversionPolicy.REQUIRE_TARGET_RANGE,
         )
 
     def test_barrier_cluster_model_defaults_and_availability(self) -> None:
@@ -3903,6 +3983,16 @@ class ResolvedIrBuildTest(unittest.TestCase):
         )
         self.assertIn(
             ".register_width_policy = base::ScalarTypeSizePolicy::SameWidth,",
+            source,
+        )
+        self.assertIn(
+            ".immediate_conversion_policy = "
+            "check_end::ImmediateConversionPolicy::Narrow,",
+            source,
+        )
+        self.assertIn(
+            ".immediate_conversion_policy = "
+            "check_end::ImmediateConversionPolicy::RequireTargetRange,",
             source,
         )
         self.assertIn(".direction = ParameterDirection::Input,", source)

--- a/submod/binding/include/ptx_symbol_table.hpp
+++ b/submod/binding/include/ptx_symbol_table.hpp
@@ -278,7 +278,7 @@ class SymbolTable {
   [[nodiscard]] static std::optional<SymbolId> parameterizedContaining(
       const ParameterizedPrefixIndex& index, const std::vector<Symbol>& symbols,
       std::string_view spelling);
-  /** Index every valid base/member decomposition of one stored spelling. */
+  /** Index every valid base/member decomposition of one actual member spelling. */
   static void indexMemberSpelling(ScopeNameIndex& index,
                                   std::string_view spelling, SymbolId symbol);
 

--- a/submod/binding/src/ptx_symbol_table.cpp
+++ b/submod/binding/src/ptx_symbol_table.cpp
@@ -46,20 +46,21 @@ bool parameterizedNameContains(std::string_view base, uint32_t count,
 
 bool symbolNameSetsOverlap(const Symbol& existing, std::string_view name,
                            std::optional<uint32_t> parameterized_count) {
-  if (existing.parameterized_count &&
-      parameterizedNameContains(existing.name, *existing.parameterized_count,
-                                name)) {
-    return true;
+  if (!existing.parameterized_count) {
+    if (!parameterized_count)
+      return existing.name == name;
+    return parameterizedNameContains(name, *parameterized_count,
+                                     existing.name);
   }
-  if (parameterized_count &&
-      parameterizedNameContains(name, *parameterized_count, existing.name)) {
-    return true;
-  }
-  if (!existing.parameterized_count || !parameterized_count)
+  if (!parameterized_count)
+    return parameterizedNameContains(existing.name,
+                                     *existing.parameterized_count, name);
+
+  if (*existing.parameterized_count == 0 || *parameterized_count == 0)
     return false;
 
-  // For distinct bases, an overlap can only begin at the zero element of one
-  // of the two parameterized declarations.
+  // Neither group base is a member.  If two nonempty groups overlap, the
+  // first member of one group is contained by the other group.
   const std::string existing_first = existing.name + "0";
   const std::string candidate_first = std::string{name} + "0";
   return parameterizedNameContains(existing.name, *existing.parameterized_count,
@@ -440,9 +441,9 @@ struct SymbolTableBuilder {
       return SymbolTable::parameterizedContaining(index.parameterized_prefixes,
                                                   result.table.symbols_, name);
 
-    if (const auto containing = SymbolTable::parameterizedContaining(
-            index.parameterized_prefixes, result.table.symbols_, name))
-      SymbolTable::keepEarliest(result_symbol, *containing);
+    if (*parameterized_count == 0)
+      return std::nullopt;
+
     const std::string first_member = std::string{name} + "0";
     if (const auto containing = SymbolTable::parameterizedContaining(
             index.parameterized_prefixes, result.table.symbols_, first_member))
@@ -468,8 +469,8 @@ struct SymbolTableBuilder {
     index.parameterized_exact.emplace(symbol.name, symbol.id);
     SymbolTable::indexParameterizedBase(index.parameterized_prefixes,
                                         symbol.name, symbol.id);
-    SymbolTable::indexMemberSpelling(index, symbol.name, symbol.id);
-    SymbolTable::indexMemberSpelling(index, symbol.name + "0", symbol.id);
+    if (*symbol.parameterized_count != 0)
+      SymbolTable::indexMemberSpelling(index, symbol.name + "0", symbol.id);
   }
 
   SymbolId addSymbol(

--- a/submod/binding/test/test_symbol_table_index_equivalence.cpp
+++ b/submod/binding/test/test_symbol_table_index_equivalence.cpp
@@ -1,10 +1,12 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <vector>
 
 #include <ptx_frontend/binding/ptx_symbol_table.hpp>
@@ -62,36 +64,49 @@ std::optional<SymbolId> linearExactDeclaration(const SymbolTable& table,
   return std::nullopt;
 }
 
-/** Test represented membership without using the production overlap helpers. */
-bool memberOf(std::string_view base, uint32_t count, std::string_view name) {
-  if (!name.starts_with(base) || name.size() == base.size())
-    return false;
-  const auto suffix = name.substr(base.size());
-  if (suffix.size() > 1 && suffix.front() == '0')
-    return false;
-  for (char character : suffix)
-    if (character < '0' || character > '9')
-      return false;
-  uint32_t index = 0;
-  const auto [end, error] = std::from_chars(
-      suffix.data(), suffix.data() + suffix.size(), index);
-  return error == std::errc{} && end == suffix.data() + suffix.size() &&
-         index < count;
+/** Expand a deliberately small declaration into its actual finite name set. */
+std::unordered_set<std::string> expandedNames(
+    std::string_view name, std::optional<uint32_t> parameterized_count) {
+  std::unordered_set<std::string> names;
+  if (!parameterized_count) {
+    names.emplace(name);
+    return names;
+  }
+  for (uint32_t member = 0; member < *parameterized_count; ++member)
+    names.emplace(std::string{name} + std::to_string(member));
+  return names;
 }
 
-/** Retain the existing overlap contract, including group-base comparisons. */
-bool overlaps(const Symbol& previous, const Symbol& current) {
-  if (previous.parameterized_count &&
-      memberOf(previous.name, *previous.parameterized_count, current.name))
-    return true;
-  if (current.parameterized_count &&
-      memberOf(current.name, *current.parameterized_count, previous.name))
-    return true;
-  return previous.parameterized_count && current.parameterized_count &&
-         (memberOf(previous.name, *previous.parameterized_count,
-                   current.name + "0") ||
-          memberOf(current.name, *current.parameterized_count,
-                   previous.name + "0"));
+/** Compare two finite explicit name sets without production parsing helpers. */
+bool expandedNamesOverlap(std::string_view left,
+                          std::optional<uint32_t> left_count,
+                          std::string_view right,
+                          std::optional<uint32_t> right_count) {
+  const auto left_names = expandedNames(left, left_count);
+  const auto right_names = expandedNames(right, right_count);
+  return std::any_of(left_names.begin(), left_names.end(),
+                     [&right_names](const auto& name) {
+    return right_names.contains(name);
+  });
+}
+
+/** Format a scalar or compact declaration for the parser-driven oracle. */
+std::string declaration(std::string_view name,
+                        std::optional<uint32_t> parameterized_count) {
+  std::string result = ".reg .u32 ";
+  result += name;
+  if (parameterized_count)
+    result += "<" + std::to_string(*parameterized_count) + ">";
+  result += ";\n";
+  return result;
+}
+
+/** Count duplicate-symbol diagnostics while ignoring intentional count errors. */
+size_t duplicateDiagnosticCount(const SymbolBinding& binding) {
+  return std::count_if(binding.diagnostics.begin(), binding.diagnostics.end(),
+                       [](const auto& diagnostic) {
+    return diagnostic.kind == BindDiagnosticKind::DuplicateSymbol;
+  });
 }
 
 /** Check indexes against lexical vector search, including diagnosed overlaps. */
@@ -145,7 +160,8 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
       if (previous.scope != current.scope ||
           previous.kind == SymbolKind::DebugFile ||
           previous.kind == SymbolKind::DebugStringLabel ||
-          !overlaps(previous, current))
+          !expandedNamesOverlap(previous.name, previous.parameterized_count,
+                                current.name, current.parameterized_count))
         continue;
       ASSERT_LT(overlap_count, duplicate_diagnostics.size());
       const BindDiagnostic& diagnostic = *duplicate_diagnostics[overlap_count++];
@@ -191,6 +207,123 @@ TEST(SymbolTableIndexEquivalence, MatchesLinearLookupAcrossMixedScopes) {
       }
     }
   }
+}
+
+/** Compare compact declaration diagnostics with many independently expanded sets. */
+TEST(SymbolTableIndexEquivalence,
+     MatchesExplicitFiniteOverlapSetsAcrossFormsAndOrders) {
+  constexpr std::array<std::string_view, 8> bases{
+      "%r", "%r1", "%r2", "%r9", "%x", "%x0", "%x9", "%q"};
+  constexpr std::array<uint32_t, 7> counts{0, 1, 2, 3, 9, 10, 12};
+
+  for (size_t left_base = 0; left_base < bases.size(); ++left_base) {
+    for (size_t right_base = 0; right_base < bases.size(); ++right_base) {
+      if (left_base == right_base)
+        continue;
+      for (const uint32_t left_count : counts) {
+        for (const uint32_t right_count : counts) {
+          for (const bool reverse : {false, true}) {
+            const std::string_view first =
+                reverse ? bases[right_base] : bases[left_base];
+            const uint32_t first_count =
+                reverse ? right_count : left_count;
+            const std::string_view second =
+                reverse ? bases[left_base] : bases[right_base];
+            const uint32_t second_count =
+                reverse ? left_count : right_count;
+            const std::string source = ".entry overlap() {\n" +
+                                       declaration(first, first_count) +
+                                       declaration(second, second_count) +
+                                       "ret;\n}\n";
+            PtxSyntaxParser parser(source);
+            const auto parsed = parser.parseModule();
+            ASSERT_TRUE(parsed.has_value()) << source;
+            ASSERT_TRUE(parsed.diagnostics.empty()) << source;
+            const auto bound = bindSymbols(*parsed);
+            SCOPED_TRACE(source);
+            EXPECT_EQ(duplicateDiagnosticCount(bound),
+                      expandedNamesOverlap(first, first_count, second,
+                                           second_count));
+          }
+        }
+      }
+    }
+  }
+
+  for (const std::string_view base : bases) {
+    for (const uint32_t count : counts) {
+      for (const std::string suffix : {"", "0", "1", "9", "10", "19"}) {
+        const std::string ordinary = std::string{base} + suffix;
+        for (const bool reverse : {false, true}) {
+          const std::string first = reverse ? ordinary : std::string{base};
+          const std::optional<uint32_t> first_count =
+              reverse ? std::nullopt : std::optional<uint32_t>{count};
+          const std::string second = reverse ? std::string{base} : ordinary;
+          const std::optional<uint32_t> second_count =
+              reverse ? std::optional<uint32_t>{count} : std::nullopt;
+          const std::string source = ".entry ordinary() {\n" +
+                                     declaration(first, first_count) +
+                                     declaration(second, second_count) +
+                                     "ret;\n}\n";
+          PtxSyntaxParser parser(source);
+          const auto parsed = parser.parseModule();
+          ASSERT_TRUE(parsed.has_value()) << source;
+          ASSERT_TRUE(parsed.diagnostics.empty()) << source;
+          const auto bound = bindSymbols(*parsed);
+          SCOPED_TRACE(source);
+          EXPECT_EQ(duplicateDiagnosticCount(bound),
+                    expandedNamesOverlap(first, first_count, second,
+                                         second_count));
+        }
+      }
+    }
+  }
+}
+
+/** Ensure a disjoint early prefix group cannot hide a later true overlap. */
+TEST(SymbolTableIndexEquivalence, IndexesOnlySemanticOverlapCandidates) {
+  constexpr std::string_view source = R"ptx(
+.entry candidates() {
+  .reg .u32 %sink;
+  .reg .u32 %r<10>;
+  .reg .u32 %r19;
+  .reg .u32 %r1<10>;
+  mov.u32 %sink, %r18;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto parsed = parser.parseModule();
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_TRUE(parsed.diagnostics.empty());
+  const auto bound = bindSymbols(*parsed);
+  ASSERT_EQ(duplicateDiagnosticCount(bound), 1u);
+  const BindDiagnostic& diagnostic = bound.diagnostics.front();
+  ASSERT_TRUE(diagnostic.previous_range.has_value());
+
+  const auto function = bound.table.lookup(bound.table.moduleScope(),
+                                           "candidates");
+  ASSERT_TRUE(function.has_value());
+  const auto scope = bound.table.symbol(function->symbol).owned_scope;
+  ASSERT_TRUE(scope.has_value());
+  const auto ordinary = bound.table.exactDeclaration(*scope, "%r19", false);
+  ASSERT_TRUE(ordinary.has_value());
+  EXPECT_EQ(diagnostic.previous_range,
+            bound.table.symbol(*ordinary).declaration_range);
+
+  const auto group = bound.table.exactDeclaration(*scope, "%r1", true);
+  ASSERT_TRUE(group.has_value());
+  const auto member = bound.table.lookup(*scope, "%r18");
+  ASSERT_TRUE(member.has_value());
+  EXPECT_EQ(member->symbol, *group);
+  EXPECT_EQ(member->parameterized_index, 8u);
+  const auto reference = std::find_if(
+      bound.table.references().begin(), bound.table.references().end(),
+      [](const SymbolReference& item) { return item.spelling == "%r18"; });
+  ASSERT_NE(reference, bound.table.references().end());
+  ASSERT_TRUE(reference->target.has_value());
+  EXPECT_EQ(reference->target->symbol, *group);
+  EXPECT_EQ(reference->target->parameterized_index, 8u);
 }
 
 }  // namespace

--- a/submod/binding/test/test_symbol_table_index_lifetime.cpp
+++ b/submod/binding/test/test_symbol_table_index_lifetime.cpp
@@ -72,8 +72,8 @@ TEST(SymbolTableIndexLifetime, SurvivesGrowthCopyAndMove) {
   expectIndexedLookups(move_assigned, scope);
 }
 
-/** Preserve legacy base-name overlap diagnostics in either declaration order. */
-TEST(SymbolTableIndexLifetime, RetainsParameterizedBaseOverlapDiagnostics) {
+/** Group bases are not members, so digit-ending group bases can be disjoint. */
+TEST(SymbolTableIndexLifetime, DoesNotTreatParameterizedBasesAsMembers) {
   for (const std::string_view declarations :
        {".reg .u32 %r<1>; .reg .u32 %r0<1>;",
         ".reg .u32 %r0<1>; .reg .u32 %r<1>;"}) {
@@ -83,18 +83,12 @@ TEST(SymbolTableIndexLifetime, RetainsParameterizedBaseOverlapDiagnostics) {
     ASSERT_TRUE(parsed.has_value());
     ASSERT_TRUE(parsed.diagnostics.empty());
     const auto bound = bindSymbols(*parsed);
-    ASSERT_EQ(bound.diagnostics.size(), 1u);
-    EXPECT_EQ(bound.diagnostics.front().kind,
-              BindDiagnosticKind::DuplicateSymbol);
-    EXPECT_TRUE(bound.diagnostics.front().previous_range.has_value());
-    EXPECT_NE(
-        bound.diagnostics.front().message.find("overlapping symbol names"),
-        std::string::npos);
+    EXPECT_TRUE(bound.diagnostics.empty());
   }
 }
 
-/** Invalid zero-count groups retain their legacy overlap and count diagnostics. */
-TEST(SymbolTableIndexLifetime, RetainsZeroCountOverlapDiagnostics) {
+/** Invalid zero-count groups have no members and therefore no overlap diagnostics. */
+TEST(SymbolTableIndexLifetime, ZeroCountGroupsDoNotCreateOverlapCandidates) {
   for (const std::string_view declarations :
        {".reg .u32 %r<1>; .reg .u32 %r0<0>;",
         ".reg .u32 %r0<0>; .reg .u32 %r<1>;"}) {
@@ -113,8 +107,28 @@ TEST(SymbolTableIndexLifetime, RetainsZeroCountOverlapDiagnostics) {
       duplicate_count += diagnostic.kind == BindDiagnosticKind::DuplicateSymbol;
     }
     EXPECT_EQ(invalid_count, 1u);
-    EXPECT_EQ(duplicate_count, 1u);
+    EXPECT_EQ(duplicate_count, 0u);
   }
+}
+
+/** Keep the sparse overlap index correct at the highest valid member number. */
+TEST(SymbolTableIndexLifetime, DetectsHighestRepresentableParameterizedMember) {
+  constexpr std::string_view source = R"ptx(
+.entry indexed() {
+  .reg .u32 %r<4294967295>;
+  .reg .u32 %r4294967294;
+  .reg .u32 %r4294967295;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto parsed = parser.parseModule();
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_TRUE(parsed.diagnostics.empty());
+  const auto bound = bindSymbols(*parsed);
+  ASSERT_EQ(bound.diagnostics.size(), 1u);
+  EXPECT_EQ(bound.diagnostics.front().kind, BindDiagnosticKind::DuplicateSymbol);
+  EXPECT_TRUE(bound.diagnostics.front().previous_range.has_value());
 }
 
 }  // namespace

--- a/submod/resolved_ir/include/ptx_resolved_ir_descriptors.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_descriptors.hpp
@@ -12,6 +12,7 @@ using OperandShape = checker::OperandShape;
 using OperandRole = checker::OperandRole;
 using OperandAccess = checker::OperandAccess;
 using OperandTypeExpressionKind = checker::OperandTypeExpressionKind;
+using ImmediateConversionPolicy = checker::ImmediateConversionPolicy;
 using TypeExpressionDescriptor = checker::TypeExpressionDescriptor;
 enum class OperandSyntaxShape : uint16_t {
   Identifier = 1 << 0,

--- a/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
@@ -122,6 +122,8 @@ enum class OperandTypeExpressionKind : uint8_t {
   FixedScalar,
   ModifierField
 };
+/** Integer conversion selected by a semantic operand use after source decode. */
+enum class ImmediateConversionPolicy : uint8_t { Narrow, RequireTargetRange };
 /** A PTX ISA version represented without syntax-AST ownership. */
 struct PtxVersion {
   uint16_t major = 0;
@@ -205,6 +207,9 @@ struct OperandDescriptor {
   std::span<const AddressStateSpaceDescriptor> allowed_address_state_spaces;
   std::string_view state_space_modifier_field_id{};
   ParameterAddressConstraint parameter_constraint;
+  /** Independent conversion contract; type provenance does not select it. */
+  ImmediateConversionPolicy immediate_conversion_policy =
+      ImmediateConversionPolicy::Narrow;
 };
 struct FieldView {
   std::string_view field_id;

--- a/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
+++ b/submod/resolved_ir/include/ptx_resolved_ir_foundation.hpp
@@ -238,6 +238,7 @@ struct OperandView {
   OperandShape actual_shape;
   std::optional<ScalarType> immediate_type;
   std::optional<uint64_t> immediate_bits;
+  /** Numerical negativity of the evaluated signed integer source. */
   std::optional<bool> immediate_is_negative;
   std::optional<ScalarType> register_type;
   bool is_sink = false;
@@ -259,6 +260,8 @@ struct OperandView {
   std::optional<AvailabilityDescriptor> value_availability;
   std::string_view value_name{};
   std::span<const SourceRange> locations;
+  /** Evaluated 64-bit integer bits before the operand use narrows them. */
+  std::optional<uint64_t> integer_source_bits;
 };
 /** Borrowed target properties used by checker availability validation. */
 struct TargetInfo {
@@ -454,10 +457,16 @@ struct ResolvedRegisterOrSink {
   std::optional<ResolvedRegisterRef> register_ref;
   bool operator==(const ResolvedRegisterOrSink&) const = default;
 };
+/** A typed immediate retaining both use-width and integer-source values. */
 struct ResolvedImmediate {
+  /** Bits after conversion to the scalar type selected by this operand use. */
   uint64_t bits;
+  /** Scalar type selected by this operand use. */
   ScalarType type;
+  /** True only when the evaluated integer source is signed and negative. */
   bool is_negative = false;
+  /** Evaluated 64-bit integer bits, absent for floating-point immediates. */
+  std::optional<uint64_t> integer_source_bits;
   bool operator==(const ResolvedImmediate&) const = default;
 };
 struct ResolvedRegisterVector {

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -1411,7 +1411,8 @@ resolve_vector_special_register(const syntax_ast::AstOperand& operand) {
 }
 
 std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_value(
-    const syntax_ast::AstImmediate& immediate, ScalarType type);
+    const syntax_ast::AstImmediate& immediate, ScalarType type,
+    bool require_target_range = false);
 
 std::expected<std::optional<ResolvedAddressOffset>, ResolveDiagnostic>
 resolve_address_offset(const syntax_ast::AstAddress& address) {
@@ -1419,7 +1420,8 @@ resolve_address_offset(const syntax_ast::AstAddress& address) {
     return std::nullopt;
 
   auto value =
-      resolve_immediate_value(address.offset->magnitude, ScalarType::S64);
+      resolve_immediate_value(address.offset->magnitude, ScalarType::S64,
+                              true);
   if (!value)
     return std::unexpected(value.error());
   return ResolvedAddressOffset{
@@ -1584,7 +1586,8 @@ std::expected<WithLocs<ResolvedAddress>, ResolveDiagnostic> resolve_address(
     }
   } else {
     const auto& immediate = std::get<syntax_ast::AstImmediate>(address->base);
-    auto immediate_base = resolve_immediate_value(immediate, ScalarType::U64);
+    auto immediate_base = resolve_immediate_value(immediate, ScalarType::U64,
+                                                  true);
     if (!immediate_base)
       return std::unexpected(immediate_base.error());
     base = std::move(*immediate_base);
@@ -1634,7 +1637,7 @@ std::expected<uint64_t, ResolveDiagnostic> parse_unsigned_literal(
 
 std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_integer_literal(
     const syntax_ast::AstImmediate& immediate, ScalarType type,
-    std::string_view text, bool negative) {
+    std::string_view text, bool negative, bool require_target_range = false) {
   using base::ScalarKind;
   const ScalarKind kind = scalar_kind(type);
   if (kind != ScalarKind::Unsigned && kind != ScalarKind::Signed &&
@@ -1663,22 +1666,39 @@ std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_integer_literal(
         immediate,
         fmt::format("Invalid integer literal '{}'.", immediate.syntax.text)));
 
-  uint64_t limit = bit_mask;
-  if (kind == base::ScalarKind::Signed) {
-    limit = negative ? (uint64_t{1} << (bit_width - 1))
-                     : (uint64_t{1} << (bit_width - 1)) - 1;
+  const bool source_is_unsigned =
+      text.ends_with('u') || text.ends_with('U') ||
+      *magnitude > static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  const uint64_t source_bits = negative ? uint64_t{0} - *magnitude : *magnitude;
+  const bool source_is_negative =
+      !source_is_unsigned && std::bit_cast<int64_t>(source_bits) < 0;
+  if (require_target_range) {
+    const uint64_t positive_limit =
+        kind == base::ScalarKind::Signed
+            ? (uint64_t{1} << (bit_width - 1)) - 1
+            : bit_mask;
+    const uint64_t negative_limit =
+        kind == base::ScalarKind::Signed
+            ? uint64_t{1} << (bit_width - 1)
+            : bit_mask;
+    const bool representable =
+        source_is_negative
+            ? uint64_t{0} - source_bits <= negative_limit
+            : source_bits <= positive_limit;
+    if (!representable) {
+      return std::unexpected(invalid_immediate(
+          immediate,
+          fmt::format(
+              "Integer literal '{}' is out of range for scalar type '{}'.",
+              immediate.syntax.text, to_string(type))));
+    }
   }
-  if (*magnitude > limit) {
-    return std::unexpected(invalid_immediate(
-        immediate,
-        fmt::format(
-            "Integer literal '{}' is out of range for scalar type '{}'.",
-            immediate.syntax.text, to_string(type))));
-  }
-
-  const uint64_t bits =
-      negative ? (uint64_t{0} - *magnitude) & bit_mask : *magnitude;
-  return ResolvedImmediate{.bits = bits, .type = type, .is_negative = negative};
+  return ResolvedImmediate{
+      .bits = source_bits & bit_mask,
+      .type = type,
+      .is_negative = source_is_negative,
+      .integer_source_bits = source_bits,
+  };
 }
 
 /**
@@ -1819,7 +1839,8 @@ resolve_decimal_float_literal(const syntax_ast::AstImmediate& immediate,
 }
 
 std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_value(
-    const syntax_ast::AstImmediate& immediate, ScalarType type) {
+    const syntax_ast::AstImmediate& immediate, ScalarType type,
+    bool require_target_range) {
   std::string_view text = immediate.syntax.text;
   bool negative = false;
   if (!text.empty() && (text.front() == '+' || text.front() == '-')) {
@@ -1830,7 +1851,8 @@ std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_value(
   switch (immediate.kind) {
     case syntax_ast::AstImmediateKind::DecimalInteger:
     case syntax_ast::AstImmediateKind::HexInteger:
-      return resolve_integer_literal(immediate, type, text, negative);
+      return resolve_integer_literal(immediate, type, text, negative,
+                                     require_target_range);
     case syntax_ast::AstImmediateKind::F32Hex:
       return resolve_float_bits_literal(immediate, type, text, negative, 32);
     case syntax_ast::AstImmediateKind::F64Hex:
@@ -1844,7 +1866,7 @@ std::expected<ResolvedImmediate, ResolveDiagnostic> resolve_immediate_value(
 
 std::expected<WithLocs<RegOrImm>, ResolveDiagnostic> resolve_reg_or_imm(
     const syntax_ast::AstOperand& operand, ScalarType type,
-    const ResolveContext* context) {
+    const ResolveContext* context, bool require_target_range = false) {
   if (const auto* identifier =
           std::get_if<syntax_ast::AstIdentifierRef>(&operand)) {
     auto register_ref = resolve_register(operand, context);
@@ -1854,7 +1876,8 @@ std::expected<WithLocs<RegOrImm>, ResolveDiagnostic> resolve_reg_or_imm(
                               identifier->syntax.range};
   }
   if (const auto* immediate = std::get_if<syntax_ast::AstImmediate>(&operand)) {
-    auto value = resolve_immediate_value(*immediate, type);
+    auto value = resolve_immediate_value(*immediate, type,
+                                         require_target_range);
     if (!value)
       return std::unexpected(value.error());
     return WithLocs<RegOrImm>{RegOrImm{*value}, immediate->syntax.range};
@@ -2109,7 +2132,10 @@ resolve_tensor_coordinate(
       }
       immediate_type = *type;
     }
-    auto value = resolve_immediate_value(immediate, *immediate_type);
+    auto value = resolve_immediate_value(
+        immediate, *immediate_type,
+        binding.type_expression.kind ==
+            checker::OperandTypeExpressionKind::FixedScalar);
     if (!value)
       return std::unexpected(value.error());
     locations.push_back(immediate.syntax.range);
@@ -2614,7 +2640,10 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
           type_for_operand(binding, fields, immediate->syntax.range);
       if (!type)
         return std::unexpected(type.error());
-      auto value = resolve_immediate_value(*immediate, *type);
+      auto value = resolve_immediate_value(
+          *immediate, *type,
+          binding.type_expression.kind ==
+              checker::OperandTypeExpressionKind::FixedScalar);
       if (!value)
         return std::unexpected(value.error());
       return ResolvedFieldValue{WithLocs<ResolvedImmediate>{
@@ -2625,7 +2654,10 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
           type_for_operand(binding, fields, syntax_ast::sourceRange(operand));
       if (!type)
         return std::unexpected(type.error());
-      auto value = resolve_reg_or_imm(operand, *type, context);
+      auto value = resolve_reg_or_imm(
+          operand, *type, context,
+          binding.type_expression.kind ==
+              checker::OperandTypeExpressionKind::FixedScalar);
       if (!value)
         return std::unexpected(value.error());
       return ResolvedFieldValue{std::move(*value)};
@@ -2967,7 +2999,8 @@ resolve_call_literal(
       .syntax = {.text = literal.spelling, .range = range},
       .kind = literal.kind,
   };
-  auto resolved = resolve_immediate_literal(immediate, *type);
+  // Call arguments retain their formal-parameter representability contract.
+  auto resolved = resolve_immediate_value(immediate, *type, true);
   if (!resolved)
     return std::unexpected(resolved.error());
   return WithLocs<ResolvedImmediate>{std::move(*resolved), range};

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -2134,8 +2134,8 @@ resolve_tensor_coordinate(
     }
     auto value = resolve_immediate_value(
         immediate, *immediate_type,
-        binding.type_expression.kind ==
-            checker::OperandTypeExpressionKind::FixedScalar);
+        binding.immediate_conversion_policy ==
+            checker::ImmediateConversionPolicy::RequireTargetRange);
     if (!value)
       return std::unexpected(value.error());
     locations.push_back(immediate.syntax.range);
@@ -2642,8 +2642,8 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
         return std::unexpected(type.error());
       auto value = resolve_immediate_value(
           *immediate, *type,
-          binding.type_expression.kind ==
-              checker::OperandTypeExpressionKind::FixedScalar);
+          binding.immediate_conversion_policy ==
+              checker::ImmediateConversionPolicy::RequireTargetRange);
       if (!value)
         return std::unexpected(value.error());
       return ResolvedFieldValue{WithLocs<ResolvedImmediate>{
@@ -2656,8 +2656,8 @@ std::expected<ResolvedFieldValue, ResolveDiagnostic> resolve_operand_value(
         return std::unexpected(type.error());
       auto value = resolve_reg_or_imm(
           operand, *type, context,
-          binding.type_expression.kind ==
-              checker::OperandTypeExpressionKind::FixedScalar);
+          binding.immediate_conversion_policy ==
+              checker::ImmediateConversionPolicy::RequireTargetRange);
       if (!value)
         return std::unexpected(value.error());
       return ResolvedFieldValue{std::move(*value)};

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -52,6 +52,19 @@ const OperandView* find_operand(std::span<const OperandView> operands,
   return it == operands.end() ? nullptr : &*it;
 }
 
+/**
+ * Return the evaluated integer value used by fixed immediate constraints.
+ *
+ * Integer source bits precede a data operand's width conversion, so a source
+ * value that narrows to an allowed bit pattern cannot satisfy a control rule.
+ * @pre `operand.immediate_bits` is engaged.
+ */
+std::pair<uint64_t, bool> integer_constraint_value(
+    const OperandView& operand) noexcept {
+  return {operand.integer_source_bits.value_or(*operand.immediate_bits),
+          operand.immediate_is_negative.value_or(false)};
+}
+
 void append_value_availability_diagnostics(const OperandView& operand,
                                            const Context& context,
                                            CheckDiagnostics& diagnostics) {
@@ -1217,7 +1230,8 @@ CheckResult check_address_alignment(
                      "immediate field.",
       }});
     }
-    required = *immediate->immediate_bits;
+    required = immediate->integer_source_bits.value_or(
+        *immediate->immediate_bits);
   } else if (required == 0) {
     const FieldView* type = find_field(fields, descriptor.type_field_id);
     const FieldView* vector =
@@ -1409,7 +1423,8 @@ CheckResult check_immediate_value(
             descriptor.operand_field_id),
     }});
   }
-  if (std::ranges::find(descriptor.allowed_values, *operand->immediate_bits) !=
+  const auto [value, negative] = integer_constraint_value(*operand);
+  if (!negative && std::ranges::find(descriptor.allowed_values, value) !=
       descriptor.allowed_values.end()) {
     return {};
   }
@@ -1418,7 +1433,7 @@ CheckResult check_immediate_value(
       .range = diagnostic_range(operand->locations, context),
       .message = fmt::format("Immediate operand '{}' has unsupported value {}.",
                              descriptor.operand_field_id,
-                             *operand->immediate_bits),
+                             value),
   }});
 }
 
@@ -1450,8 +1465,8 @@ CheckResult check_immediate_multiple_of(
                                descriptor.operand_field_id),
     }});
   }
-  if (!operand->immediate_is_negative.value_or(false) &&
-      *operand->immediate_bits % descriptor.divisor == 0) {
+  const auto [value, negative] = integer_constraint_value(*operand);
+  if (!negative && value % descriptor.divisor == 0) {
     return {};
   }
   return std::unexpected(CheckDiagnostics{CheckDiagnostic{
@@ -1460,7 +1475,7 @@ CheckResult check_immediate_multiple_of(
       .message = fmt::format("Immediate operand '{}' has value {} that is not a "
                              "multiple of {}.",
                              descriptor.operand_field_id,
-                             *operand->immediate_bits, descriptor.divisor),
+                             value, descriptor.divisor),
   }});
 }
 
@@ -1487,10 +1502,10 @@ CheckResult check_immediate_range(
                                descriptor.operand_field_id),
     }});
   }
-  if (!operand->immediate_is_negative.value_or(false) &&
-      *operand->immediate_bits >= descriptor.minimum &&
+  const auto [value, negative] = integer_constraint_value(*operand);
+  if (!negative && value >= descriptor.minimum &&
       (!descriptor.has_maximum ||
-       *operand->immediate_bits <= descriptor.maximum)) {
+       value <= descriptor.maximum)) {
     return {};
   }
   return std::unexpected(CheckDiagnostics{CheckDiagnostic{
@@ -1498,7 +1513,7 @@ CheckResult check_immediate_range(
       .range = diagnostic_range(operand->locations, context),
       .message = fmt::format(
           "Immediate operand '{}' has value {} outside the supported range.",
-          descriptor.operand_field_id, *operand->immediate_bits),
+          descriptor.operand_field_id, value),
   }});
 }
 

--- a/submod/resolved_ir/test/test_m13_synchronization_corpus.cpp
+++ b/submod/resolved_ir/test/test_m13_synchronization_corpus.cpp
@@ -395,5 +395,52 @@ TEST(ResolvedModule, ChecksM13ClusterlaunchcontrolBoundaryMatrix) {
   EXPECT_EQ(no_family.error().front().range, multicast_instruction.range);
 }
 
+/** Exercises integer zero normalization through generated mbarrier checking. */
+TEST(ResolvedModule, ChecksMbarrierParityIntegerSourceValues) {
+  const auto check_parity = [](std::string_view literal, bool expected_valid,
+                               bool expect_resolution_failure = false) {
+    const std::string source = R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.shared .align 8 .b64 mb;
+.entry k() {
+  .reg .pred %p;
+  mbarrier.test_wait.parity.shared.b64 %p, [mb], )ptx" +
+                               std::string{literal} + ";\n}\n";
+    const auto ast = parseModule(source);
+    const auto resolved = resolveModule(ast);
+    const auto& instruction = std::get<syntax_ast::AstInstruction>(
+        std::get<syntax_ast::AstFunction>(ast.items.back()).body.back());
+    if (!expected_valid) {
+      ASSERT_FALSE(resolved.has_value());
+      EXPECT_EQ(resolved.error().front().range,
+                std::get<syntax_ast::AstImmediate>(instruction.operands.back())
+                    .syntax.range);
+      if (expect_resolution_failure) {
+        EXPECT_FALSE(resolved.error().front().checker_kind.has_value());
+        EXPECT_EQ(resolved.error().front().message,
+                  "Integer literal '4294967296' is out of range for scalar type 'U32'.");
+      } else {
+        EXPECT_EQ(resolved.error().front().checker_kind,
+                  checker::CheckDiagnosticKind::ImmediateValueMismatch);
+      }
+      return;
+    }
+    ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+    const auto checked = checker::check(
+        std::get<Mbarrier>(resolved->functions.front().body.front()),
+        checker::Context{.target = {.ptx_version = {8, 0}, .sm_version = 80},
+                         .instruction_range = instruction.range});
+    EXPECT_EQ(checked.has_value(), expected_valid) << literal;
+  };
+
+  for (const auto literal : {"0", "+0", "-0", "-0U", "-0x0", "-0x0U", "1"})
+    check_parity(literal, true);
+  for (const auto literal : {"2", "-1"})
+    check_parity(literal, false);
+  check_parity("4294967296", false, true);
+}
+
 }  // namespace
 }  // namespace ptx_frontend::resolved_ir

--- a/submod/resolved_ir/test/test_m13_synchronization_corpus.cpp
+++ b/submod/resolved_ir/test/test_m13_synchronization_corpus.cpp
@@ -439,7 +439,7 @@ TEST(ResolvedModule, ChecksMbarrierParityIntegerSourceValues) {
     check_parity(literal, true);
   for (const auto literal : {"2", "-1"})
     check_parity(literal, false);
-  check_parity("4294967296", false, true);
+  check_parity("4294967296", false);
 }
 
 }  // namespace

--- a/submod/resolved_ir/test/test_parameterized_symbol_overlap.cpp
+++ b/submod/resolved_ir/test/test_parameterized_symbol_overlap.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Parse and resolve one digit-prefix compact-group ordering. */
+void expectDisjointDigitPrefixGroupsResolve(bool reverse) {
+  const std::string declarations =
+      reverse ? ".reg .u32 %r1<10>;\n.reg .u32 %r<10>;\n"
+              : ".reg .u32 %r<10>;\n.reg .u32 %r1<10>;\n";
+  PtxSyntaxParser parser(".entry digit_prefix() {\n" + declarations +
+                         ".reg .u32 %out;\n"
+                         "mov.u32 %out, %r0;\n"
+                         "mov.u32 %out, %r19;\n"
+                         "}\n");
+  const auto parsed = parser.parseModule();
+  ASSERT_TRUE(parsed.has_value());
+  ASSERT_TRUE(parsed.diagnostics.empty());
+  const auto resolved = resolveModule(*parsed);
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  ASSERT_EQ(resolved->functions.size(), 1u);
+
+  const auto function_scope =
+      resolved->symbols.symbol(resolved->functions.front().symbol_id).owned_scope;
+  ASSERT_TRUE(function_scope.has_value());
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 2>
+      expected{{{"%r0", "%r"}, {"%r19", "%r1"}}};
+  for (const auto [spelling, base] : expected) {
+    const auto reference = std::find_if(
+        resolved->symbols.references().begin(), resolved->symbols.references().end(),
+        [spelling](const binding::SymbolReference& item) {
+          return item.spelling == spelling;
+        });
+    ASSERT_NE(reference, resolved->symbols.references().end());
+    ASSERT_TRUE(reference->target.has_value());
+    const auto declaration =
+        resolved->symbols.exactDeclaration(*function_scope, base, true);
+    ASSERT_TRUE(declaration.has_value());
+    EXPECT_EQ(reference->target->symbol, *declaration);
+    EXPECT_EQ(reference->target->parameterized_index,
+              spelling == "%r0" ? 0u : 9u);
+  }
+}
+
+/** Bind and resolve both orders of two disjoint digit-prefix compact groups. */
+TEST(ResolvedModule, ResolvesDisjointDigitPrefixParameterizedGroups) {
+  expectDisjointDigitPrefixGroupsResolve(false);
+  expectDisjointDigitPrefixGroupsResolve(true);
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir

--- a/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_ir_checker.cpp
@@ -1290,6 +1290,77 @@ TEST(ResolvedIrChecker, RejectsZeroImmediateMultipleDivisor) {
   EXPECT_EQ(checked.error().front().kind, CheckDiagnosticKind::RuleViolation);
 }
 
+/** Verifies fixed rules consume integer source bits before use-width narrowing. */
+TEST(ResolvedIrChecker, PreservesIntegerSourceBitsForFixedConstraints) {
+  static constexpr std::array<uint64_t, 1> allowed_values{0};
+  constexpr VariantDescriptor::ImmediateValueDescriptor value_descriptor{
+      .operand_field_id = "control",
+      .allowed_values = allowed_values,
+  };
+  constexpr VariantDescriptor::ImmediateRangeDescriptor range_descriptor{
+      .operand_field_id = "control",
+      .minimum = 0,
+      .has_maximum = true,
+      .maximum = 1,
+  };
+  constexpr VariantDescriptor::ImmediateMultipleOfDescriptor multiple_descriptor{
+      .operand_field_id = "control",
+      .divisor = 3,
+  };
+  PtxSyntaxParser high_word_parser("mov.u32 %r0, 4294967296;");
+  const auto high_word_ast = high_word_parser.parseInstruction();
+  ASSERT_TRUE(high_word_ast.has_value()) << high_word_ast.diagnostics.front().message;
+  const auto high_word = resolve_immediate_literal(
+      std::get<syntax_ast::AstImmediate>(high_word_ast->operands.back()),
+      ScalarType::U32);
+  ASSERT_TRUE(high_word.has_value()) << high_word.error().message;
+  EXPECT_EQ(high_word->bits, 0U);
+  ASSERT_TRUE(high_word->integer_source_bits.has_value());
+  OperandView control{
+      .field_id = "control",
+      .actual_shape = OperandShape::Immediate,
+      .immediate_type = ScalarType::U32,
+      .immediate_bits = high_word->bits,
+      .immediate_is_negative = high_word->is_negative,
+      .integer_source_bits = high_word->integer_source_bits,
+  };
+  const auto operands = std::span<const OperandView>{&control, 1};
+  EXPECT_FALSE(check_immediate_value(value_descriptor, operands,
+                                     Context{.instruction_range = kInstructionRange})
+                   .has_value());
+  EXPECT_FALSE(check_immediate_range(range_descriptor, operands,
+                                     Context{.instruction_range = kInstructionRange})
+                   .has_value());
+
+  EXPECT_FALSE(check_immediate_multiple_of(
+                   multiple_descriptor, operands,
+                   Context{.instruction_range = kInstructionRange})
+                   .has_value());
+
+  PtxSyntaxParser minus_zero_parser("mov.u32 %r0, -0;");
+  const auto minus_zero_ast = minus_zero_parser.parseInstruction();
+  ASSERT_TRUE(minus_zero_ast.has_value())
+      << minus_zero_ast.diagnostics.front().message;
+  const auto minus_zero = resolve_immediate_literal(
+      std::get<syntax_ast::AstImmediate>(minus_zero_ast->operands.back()),
+      ScalarType::U32);
+  ASSERT_TRUE(minus_zero.has_value()) << minus_zero.error().message;
+  EXPECT_FALSE(minus_zero->is_negative);
+  control.immediate_bits = minus_zero->bits;
+  control.immediate_is_negative = minus_zero->is_negative;
+  control.integer_source_bits = minus_zero->integer_source_bits;
+  EXPECT_TRUE(check_immediate_value(value_descriptor, operands,
+                                    Context{.instruction_range = kInstructionRange})
+                  .has_value());
+  EXPECT_TRUE(check_immediate_range(range_descriptor, operands,
+                                    Context{.instruction_range = kInstructionRange})
+                  .has_value());
+  EXPECT_TRUE(check_immediate_multiple_of(
+                  multiple_descriptor, operands,
+                  Context{.instruction_range = kInstructionRange})
+                  .has_value());
+}
+
 TEST(ResolvedIrChecker, ChecksGeneratedBfeAvailabilityAndImmediateRanges) {
   for (const auto source : {"bfe.u32 %r0, %r1, 0, 8;",
                             "bfe.u32 %r0, %r1, 255, 255;"}) {
@@ -2816,6 +2887,14 @@ TEST(ResolvedIrChecker, ChecksStaticAddressAlignment) {
   EXPECT_TRUE(
       check_address_alignment(dynamic_descriptor, {}, copy_operands, context)
           .has_value());
+  copy_operands[2].integer_source_bits = 16;
+  EXPECT_EQ(
+      check_address_alignment(dynamic_descriptor, {}, copy_operands, context)
+          .error()
+          .front()
+          .kind,
+      CheckDiagnosticKind::AddressAlignmentMismatch);
+  copy_operands[2].integer_source_bits.reset();
   copy_operands[0].address_alignment = 4;
   EXPECT_EQ(
       check_address_alignment(dynamic_descriptor, {}, copy_operands, context)

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -414,6 +414,50 @@ TEST(ResolvedModule, ResolvesNegativeUnsignedImmediatesAtTargetWidth) {
   EXPECT_EQ(mov_immediate.bits, 0xffffffffU);
 }
 
+/** Verifies ordinary data operands narrow evaluated 64-bit integer sources. */
+TEST(ResolvedModule, ConvertsOrdinaryIntegerDataImmediatesAndMinusZero) {
+  const auto resolved = resolveModule(parseModule(R"ptx(
+.entry kernel() {
+  .reg .s32 %s0;
+  .reg .u32 %u<2>;
+  mov.s32 %s0, 0xffffffff;
+  mov.u32 %u0, 4294967296;
+  mov.u32 %u1, -0;
+}
+)ptx"));
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  const auto& body = resolved->functions.front().body;
+  ASSERT_EQ(body.size(), 3u);
+  const auto& signed_word = std::get<ResolvedImmediate>(
+      scalarMovOperands(std::get<Mov>(body[0])).src.value);
+  EXPECT_EQ(signed_word.bits, 0xffffffffU);
+  EXPECT_EQ(signed_word.integer_source_bits, 0xffffffffU);
+  const auto& zero_word = std::get<ResolvedImmediate>(
+      scalarMovOperands(std::get<Mov>(body[1])).src.value);
+  EXPECT_EQ(zero_word.bits, 0U);
+  EXPECT_EQ(zero_word.integer_source_bits, 4294967296U);
+  const auto& minus_zero = std::get<ResolvedImmediate>(
+      scalarMovOperands(std::get<Mov>(body[2])).src.value);
+  EXPECT_EQ(minus_zero.bits, 0U);
+  EXPECT_EQ(minus_zero.integer_source_bits, 0U);
+  EXPECT_FALSE(minus_zero.is_negative);
+}
+
+/** Keeps address offsets in their strict signed 64-bit domain. */
+TEST(ResolvedModule, RejectsOutOfRangeAddressOffsetBeforeNarrowing) {
+  const auto ast = parseModule(R"ptx(
+.global .u32 base;
+.entry kernel() {
+  .reg .u32 %r0;
+  ld.u32 %r0, [base+9223372036854775808];
+}
+)ptx");
+  const auto resolved = resolveModule(ast);
+  ASSERT_FALSE(resolved.has_value());
+  EXPECT_EQ(resolved.error().front().message,
+            "Integer literal '9223372036854775808' is out of range for scalar type 'S64'.");
+}
+
 TEST(ResolvedModule, ResolvesBareRetInDeviceFunctionAndEntry) {
   const auto ast = parseModule(R"ptx(
 .func device() {

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -1689,6 +1689,16 @@ TEST(ResolvedModule, ResolvesAndChecksCpAsyncWaitGroupSlice) {
   ASSERT_FALSE(negative_checked.has_value());
   EXPECT_EQ(negative_checked.error().front().kind,
             checker::CheckDiagnosticKind::ImmediateValueMismatch);
+
+  for (const auto literal : {"-1U", "4294967296"}) {
+    const auto out_of_range = resolveModule(parseModule(
+        std::string(".entry kernel() { cp.async.wait_group ") + literal + "; }"));
+    SCOPED_TRACE(literal);
+    ASSERT_FALSE(out_of_range.has_value());
+    EXPECT_EQ(out_of_range.error().front().message,
+              std::string("Integer literal '") + literal +
+                  "' is out of range for scalar type 'U32'.");
+  }
   const auto missing_operand = resolveModule(parseModule(R"ptx(
 .entry kernel() { cp.async.wait_group; }
 )ptx"));
@@ -3626,6 +3636,15 @@ TEST(ResolvedModule, ResolvesAndChecksMbarrierExpectTxSemanticsAndSpaces) {
     EXPECT_EQ(checked.error().front().kind,
               checker::CheckDiagnosticKind::AddressAlignmentMismatch);
   }
+
+  const auto out_of_range_tx_count = resolveModule(parseModule(R"ptx(
+.shared .align 8 .b64 shared_value;
+.entry kernel() { mbarrier.expect_tx.shared.b64 [shared_value], 4294967296; }
+)ptx"));
+  ASSERT_FALSE(out_of_range_tx_count.has_value());
+  EXPECT_FALSE(out_of_range_tx_count.error().front().checker_kind.has_value());
+  EXPECT_EQ(out_of_range_tx_count.error().front().message,
+            "Integer literal '4294967296' is out of range for scalar type 'U32'.");
 }
 
 TEST(ResolvedModule, ResolvesAndChecksMbarrierCompleteTxSemanticsAndSpaces) {
@@ -3816,6 +3835,18 @@ TEST(ResolvedModule, ResolvesAndChecksMbarrierArriveForms) {
   ASSERT_FALSE(cluster_register.has_value());
   EXPECT_NE(cluster_register.error().front().message.find("requires the '_' sink"),
             std::string::npos);
+
+  for (const std::string_view source : {
+           ".shared .align 8 .b64 shared_value; .entry kernel() { mbarrier.arrive.expect_tx.release.cta.shared.b64 _, [shared_value], 4294967296; }",
+           ".shared .align 8 .b64 shared_value; .entry kernel() { mbarrier.arrive.expect_tx.release.cluster.shared.b64 _, [shared_value], 4294967296; }",
+       }) {
+    SCOPED_TRACE(source);
+    const auto out_of_range = resolveModule(parseModule(source));
+    ASSERT_FALSE(out_of_range.has_value());
+    EXPECT_FALSE(out_of_range.error().front().checker_kind.has_value());
+    EXPECT_EQ(out_of_range.error().front().message,
+              "Integer literal '4294967296' is out of range for scalar type 'U32'.");
+  }
 }
 
 TEST(ResolvedModule, ResolvesAndChecksMbarrierArriveDropForms) {
@@ -4190,6 +4221,15 @@ TEST(ResolvedModule, ResolvesAndChecksMbarrierTryWaitBasicForms) {
     EXPECT_EQ(checked.error().front().kind,
               checker::CheckDiagnosticKind::OperandTypeMismatch);
   }
+  const auto out_of_range_time_hint = resolveModule(parseModule(R"ptx(
+.shared .align 8 .b64 shared_value;
+.entry kernel() { .reg .pred %p0; .reg .b64 %state;
+  mbarrier.try_wait.shared::cta.b64 %p0, [shared_value], %state, 4294967296; }
+)ptx"));
+  ASSERT_FALSE(out_of_range_time_hint.has_value());
+  EXPECT_FALSE(out_of_range_time_hint.error().front().checker_kind.has_value());
+  EXPECT_EQ(out_of_range_time_hint.error().front().message,
+            "Integer literal '4294967296' is out of range for scalar type 'U32'.");
 }
 
 TEST(ResolvedModule, ResolvesAndChecksMbarrierWaitPhaseAndReportForms) {
@@ -4483,6 +4523,18 @@ TEST(ResolvedModule, ResolvesAndChecksMapaClusterAddressSlices) {
   ASSERT_FALSE(bad_check.has_value());
   EXPECT_EQ(bad_check.error().front().kind,
             checker::CheckDiagnosticKind::OperandTypeMismatch);
+
+  for (const std::string_view source : {
+           ".entry kernel() { .reg .u32 %r<2>; mapa.u32 %r0, %r1, 4294967296; }",
+           ".entry kernel() { .reg .u32 %r<2>; mapa.shared::cluster.u32 %r0, %r1, 4294967296; }",
+       }) {
+    SCOPED_TRACE(source);
+    const auto out_of_range = resolveModule(parseModule(source));
+    ASSERT_FALSE(out_of_range.has_value());
+    EXPECT_FALSE(out_of_range.error().front().checker_kind.has_value());
+    EXPECT_EQ(out_of_range.error().front().message,
+              "Integer literal '4294967296' is out of range for scalar type 'U32'.");
+  }
 }
 
 TEST(ResolvedModule, ResolvesAndChecksGetctarankClusterAddressSlices) {

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -3274,7 +3274,7 @@ TEST(ResolveAdd, RejectsPredicateInGeneralRegisterSlot) {
             "Expected a non-predicate register, got '%p1'.");
 }
 
-TEST(ResolveImmediateLiteral, SupportsIntegerSuffixesAndTargetWidth) {
+TEST(ResolveImmediateLiteral, ConvertsEvaluatedIntegerSourcesAtTheUseWidth) {
   const auto decimal = parse_immediate("123U");
   EXPECT_EQ(decimal.kind, syntax_ast::AstImmediateKind::DecimalInteger);
   const auto decimal_value =
@@ -3302,13 +3302,23 @@ TEST(ResolveImmediateLiteral, SupportsIntegerSuffixesAndTargetWidth) {
       << negative_unsigned.error().message;
   EXPECT_EQ(negative_unsigned->bits, 0xffffU);
 
-  const auto out_of_range = parse_immediate("65536");
-  const auto rejected =
-      resolve_immediate_literal(out_of_range, ScalarType::U16);
-  ASSERT_FALSE(rejected.has_value());
-  EXPECT_EQ(rejected.error().range, out_of_range.syntax.range);
-  EXPECT_EQ(rejected.error().message,
-            "Integer literal '65536' is out of range for scalar type 'U16'.");
+  const auto narrowed = resolve_immediate_literal(parse_immediate("65536"),
+                                                  ScalarType::U16);
+  ASSERT_TRUE(narrowed.has_value()) << narrowed.error().message;
+  EXPECT_EQ(narrowed->bits, 0U);
+  EXPECT_EQ(narrowed->integer_source_bits, 65536U);
+
+  const auto signed_word = resolve_immediate_literal(
+      parse_immediate("0xffffffff"), ScalarType::S32);
+  ASSERT_TRUE(signed_word.has_value()) << signed_word.error().message;
+  EXPECT_EQ(signed_word->bits, 0xffffffffU);
+  EXPECT_EQ(signed_word->integer_source_bits, 0xffffffffU);
+
+  const auto unsigned_word = resolve_immediate_literal(
+      parse_immediate("4294967296"), ScalarType::U32);
+  ASSERT_TRUE(unsigned_word.has_value()) << unsigned_word.error().message;
+  EXPECT_EQ(unsigned_word->bits, 0U);
+  EXPECT_EQ(unsigned_word->integer_source_bits, 4294967296U);
 }
 
 /**
@@ -3348,31 +3358,82 @@ TEST(ResolveImmediateLiteral,
   EXPECT_TRUE(negative->is_negative);
 }
 
-/**
- * @brief Preserves scalar range rules at signed and uint64 octal boundaries.
- */
-TEST(ResolveImmediateLiteral, EnforcesOctalSignedAndUint64Boundaries) {
+/** @brief Retains evaluated 64-bit values while rejecting decoder overflow. */
+TEST(ResolveImmediateLiteral, RetainsIntegerSourceBitsAndRejectsOverflow) {
   const auto signed_limit =
       resolve_immediate_literal(parse_immediate("0177"), ScalarType::S8);
   ASSERT_TRUE(signed_limit.has_value()) << signed_limit.error().message;
   EXPECT_EQ(signed_limit->bits, 0x7fU);
+  EXPECT_EQ(signed_limit->integer_source_bits, 127U);
 
-  const auto signed_overflow =
+  const auto narrowed_octal =
       resolve_immediate_literal(parse_immediate("0200"), ScalarType::S8);
-  ASSERT_FALSE(signed_overflow.has_value());
-  EXPECT_EQ(signed_overflow.error().message,
-            "Integer literal '0200' is out of range for scalar type 'S8'.");
+  ASSERT_TRUE(narrowed_octal.has_value()) << narrowed_octal.error().message;
+  EXPECT_EQ(narrowed_octal->bits, 0x80U);
+  EXPECT_EQ(narrowed_octal->integer_source_bits, 128U);
+  EXPECT_FALSE(narrowed_octal->is_negative);
 
   const auto uint64_limit = resolve_immediate_literal(
       parse_immediate("01777777777777777777777"), ScalarType::U64);
   ASSERT_TRUE(uint64_limit.has_value()) << uint64_limit.error().message;
   EXPECT_EQ(uint64_limit->bits, std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(uint64_limit->integer_source_bits,
+            std::numeric_limits<uint64_t>::max());
 
   const auto uint64_overflow = resolve_immediate_literal(
       parse_immediate("02000000000000000000000"), ScalarType::U64);
   ASSERT_FALSE(uint64_overflow.has_value());
   EXPECT_EQ(uint64_overflow.error().message,
             "Invalid integer literal '02000000000000000000000'.");
+}
+
+/** @brief Normalizes integer minus zero without changing unsigned wraparound. */
+TEST(ResolveImmediateLiteral, NormalizesIntegerMinusZeroAndUnsignedNegation) {
+  for (const auto spelling : {"0", "+0", "-0", "-0U", "-0x0", "-0x0U"}) {
+    SCOPED_TRACE(spelling);
+    const auto resolved =
+        resolve_immediate_literal(parse_immediate(spelling), ScalarType::U32);
+    ASSERT_TRUE(resolved.has_value()) << resolved.error().message;
+    EXPECT_EQ(resolved->bits, 0U);
+    EXPECT_EQ(resolved->integer_source_bits, 0U);
+    EXPECT_FALSE(resolved->is_negative);
+  }
+
+  const auto signed_negative =
+      resolve_immediate_literal(parse_immediate("-1"), ScalarType::U32);
+  ASSERT_TRUE(signed_negative.has_value()) << signed_negative.error().message;
+  EXPECT_TRUE(signed_negative->is_negative);
+  EXPECT_EQ(signed_negative->integer_source_bits,
+            std::numeric_limits<uint64_t>::max());
+
+  const auto unsigned_negation = resolve_immediate_literal(
+      parse_immediate("-18446744073709551615U"), ScalarType::U32);
+  ASSERT_TRUE(unsigned_negation.has_value()) << unsigned_negation.error().message;
+  EXPECT_FALSE(unsigned_negation->is_negative);
+  EXPECT_EQ(unsigned_negation->integer_source_bits, 1U);
+  EXPECT_EQ(unsigned_negation->bits, 1U);
+
+  const auto negative_unsigned_one =
+      resolve_immediate_literal(parse_immediate("-1U"), ScalarType::U32);
+  ASSERT_TRUE(negative_unsigned_one.has_value())
+      << negative_unsigned_one.error().message;
+  EXPECT_FALSE(negative_unsigned_one->is_negative);
+  EXPECT_EQ(negative_unsigned_one->integer_source_bits,
+            std::numeric_limits<uint64_t>::max());
+  EXPECT_EQ(negative_unsigned_one->bits, 0xffffffffU);
+}
+
+/** @brief Keeps fixed scalar control operands out of ordinary narrowing. */
+TEST(ResolveBar, RejectsOutOfRangeFixedScalarImmediates) {
+  for (const auto literal : {"4294967296", "-1U"}) {
+    SCOPED_TRACE(literal);
+    const auto resolved = resolve<Bar>(
+        parse_instruction(std::string("bar.sync ") + literal + ";"));
+    ASSERT_FALSE(resolved.has_value());
+    EXPECT_EQ(resolved.error().message,
+              std::string("Integer literal '") + literal +
+                  "' is out of range for scalar type 'U32'.");
+  }
 }
 
 /**
@@ -3506,6 +3567,20 @@ TEST(ResolveImmediateLiteral, NarrowsAtIeeeBoundariesAndPreservesExactPayloads) 
   EXPECT_EQ(widened_nan->bits, 0x7ff8000020000000ULL);
 }
 
+/** @brief Keeps floating negative zero independent of integer normalization. */
+TEST(ResolveImmediateLiteral, PreservesFloatingNegativeZero) {
+  const auto negative_zero = parse_immediate("-0.0");
+  const auto f32 = resolve_immediate_literal(negative_zero, ScalarType::F32);
+  ASSERT_TRUE(f32.has_value()) << f32.error().message;
+  EXPECT_EQ(f32->bits, 0x80000000U);
+  EXPECT_FALSE(f32->integer_source_bits.has_value());
+
+  const auto f64 = resolve_immediate_literal(negative_zero, ScalarType::F64);
+  ASSERT_TRUE(f64.has_value()) << f64.error().message;
+  EXPECT_EQ(f64->bits, 0x8000000000000000ULL);
+  EXPECT_FALSE(f64->integer_source_bits.has_value());
+}
+
 TEST(ResolveCallLiteral, TypesAgainstTheFormalAndPreservesSourceRange) {
   const declaration_semantics::FunctionParameterContract u16{.type = ".u16"};
   const auto typed_immediate = parse_immediate("42");
@@ -3515,7 +3590,9 @@ TEST(ResolveCallLiteral, TypesAgainstTheFormalAndPreservesSourceRange) {
       typed_immediate.syntax.range, u16);
   ASSERT_TRUE(typed.has_value()) << typed.error().message;
   EXPECT_EQ(typed->value,
-            (ResolvedImmediate{.bits = 42, .type = ScalarType::U16}));
+            (ResolvedImmediate{.bits = 42,
+                               .type = ScalarType::U16,
+                               .integer_source_bits = 42}));
   EXPECT_EQ(typed->locs, std::vector{typed_immediate.syntax.range});
 
   const auto overflow_immediate = parse_immediate("65536");

--- a/submod/resolved_ir/test/test_select_variant.cpp
+++ b/submod/resolved_ir/test/test_select_variant.cpp
@@ -1631,6 +1631,64 @@ TEST(ResolveNot, SelectsB32VariantAndAcceptsImmediateSource) {
   EXPECT_TRUE(std::holds_alternative<ResolvedImmediate>(not_b32->src.value));
 }
 
+/**
+ * Fixed b32 operand type provenance must not impose a source-range conversion.
+ * These generated data uses preserve the full decoded source for later
+ * diagnostics while retaining their low 32 bits as the operand value.
+ */
+TEST(ResolveLogic, NarrowsFixedB32ImmediateDataOperands) {
+  const auto and_boundary =
+      resolve<And>(parse_instruction("and.b32 %r0, %r1, 4294967295;"));
+  ASSERT_TRUE(and_boundary.has_value()) << and_boundary.error().message;
+  const auto* and_b32 = std::get_if<And::B32>(&and_boundary->variant);
+  ASSERT_NE(and_b32, nullptr);
+  const auto* and_immediate = std::get_if<ResolvedImmediate>(&and_b32->src2.value);
+  ASSERT_NE(and_immediate, nullptr);
+  EXPECT_EQ(and_immediate->bits, 0xffffffffU);
+  EXPECT_EQ(and_immediate->integer_source_bits, 0xffffffffU);
+
+  const auto and_resolved =
+      resolve<And>(parse_instruction("and.b32 %r0, %r1, 4294967296;"));
+  ASSERT_TRUE(and_resolved.has_value()) << and_resolved.error().message;
+  and_b32 = std::get_if<And::B32>(&and_resolved->variant);
+  ASSERT_NE(and_b32, nullptr);
+  and_immediate = std::get_if<ResolvedImmediate>(&and_b32->src2.value);
+  ASSERT_NE(and_immediate, nullptr);
+  EXPECT_EQ(and_immediate->bits, 0U);
+  EXPECT_EQ(and_immediate->integer_source_bits, 0x100000000ULL);
+
+  const auto or_resolved =
+      resolve<Or>(parse_instruction("or.b32 %r0, %r1, 0x100000000;"));
+  ASSERT_TRUE(or_resolved.has_value()) << or_resolved.error().message;
+  const auto* or_b32 = std::get_if<Or::B32>(&or_resolved->variant);
+  ASSERT_NE(or_b32, nullptr);
+  const auto* or_immediate = std::get_if<ResolvedImmediate>(&or_b32->src2.value);
+  ASSERT_NE(or_immediate, nullptr);
+  EXPECT_EQ(or_immediate->bits, 0U);
+  EXPECT_EQ(or_immediate->integer_source_bits, 0x100000000ULL);
+
+  const auto xor_resolved =
+      resolve<Xor>(parse_instruction("xor.b32 %r0, %r1, 4294967296;"));
+  ASSERT_TRUE(xor_resolved.has_value()) << xor_resolved.error().message;
+  const auto* xor_b32 = std::get_if<Xor::B32>(&xor_resolved->variant);
+  ASSERT_NE(xor_b32, nullptr);
+  const auto* xor_immediate = std::get_if<ResolvedImmediate>(&xor_b32->src2.value);
+  ASSERT_NE(xor_immediate, nullptr);
+  EXPECT_EQ(xor_immediate->bits, 0U);
+  EXPECT_EQ(xor_immediate->integer_source_bits, 0x100000000ULL);
+
+  const auto not_resolved =
+      resolve<Not>(parse_instruction("not.b32 %r0, 0xffffffffffffffff;"));
+  ASSERT_TRUE(not_resolved.has_value()) << not_resolved.error().message;
+  const auto* not_b32 = std::get_if<Not::B32>(&not_resolved->variant);
+  ASSERT_NE(not_b32, nullptr);
+  const auto* not_immediate = std::get_if<ResolvedImmediate>(&not_b32->src.value);
+  ASSERT_NE(not_immediate, nullptr);
+  EXPECT_EQ(not_immediate->bits, 0xffffffffU);
+  EXPECT_EQ(not_immediate->integer_source_bits,
+            std::numeric_limits<uint64_t>::max());
+}
+
 TEST(ResolveShl, SelectsB32VariantAndAcceptsImmediateAmount) {
   const auto ast = parse_instruction("shl.b32 %r0, %r1, 1;");
   const auto resolved = resolve<Shl>(ast);

--- a/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
+++ b/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
@@ -224,6 +224,29 @@ TEST(ResolvedStorageDeclarations, PreservesValidAndDeferredIntegerConstants) {
   EXPECT_EQ(std::get<StorageConstant>(masked.initializer[0].value).bits, 255u);
 }
 
+/** Verifies declaration conversion matches ordinary instruction low-word use. */
+TEST(ResolvedStorageDeclarations, ConvertsIntegerSourcesAtStorageElementWidth) {
+  const auto resolved = resolveSource(R"ptx(
+.global .s32 signed_decimal = 4294967295;
+.global .s32 signed_hex = 0xffffffff;
+.global .u32 unsigned_decimal = 4294967296;
+.global .u32 unsigned_hex = 0x100000000;
+)ptx");
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  for (const auto name : {"signed_decimal", "signed_hex"}) {
+    const auto& declaration = storageNamed(*resolved, name);
+    ASSERT_EQ(declaration.initializer.size(), 1u);
+    EXPECT_EQ(std::get<StorageConstant>(declaration.initializer.front().value).bits,
+              0xffffffffU);
+  }
+  for (const auto name : {"unsigned_decimal", "unsigned_hex"}) {
+    const auto& declaration = storageNamed(*resolved, name);
+    ASSERT_EQ(declaration.initializer.size(), 1u);
+    EXPECT_EQ(std::get<StorageConstant>(declaration.initializer.front().value).bits,
+              0U);
+  }
+}
+
 /** Metadata owns values needed after both the syntax tree and source disappear. */
 TEST(ResolvedStorageDeclarations, RetainsAddressableDeclarationsWithoutAst) {
   std::optional<ResolvedModule> resolved_module;


### PR DESCRIPTION
## Summary

- Compare ordinary and parameterized declarations using their actual name sets; compact group prefixes are not members.
- Update indexed overlap candidates to exclude bare group bases and empty groups, preserving the earliest real conflict without expanding large counts.
- Add independent finite-set comparisons, both declaration orders, zero/count boundaries, candidate-masking diagnostics, and full module-resolution reference identity tests.
- Align English and Chinese binding documentation.

## Validation

- Debug build passed.
- Full Debug CTest: 762/762 passed.
- `git diff --check` passed; independent algorithm review found no blockers.
- Additional checks completed before the user requested Debug-only local validation: 29 binding tests passed under ASan/UBSan; a Release installed-package consumer accepted both disjoint declaration orders with correct symbol/member identities and rejected genuine overlaps.
- Remaining platform/configuration checks are delegated to CI.

## Compiler comparison limitation

Local ptxas 13.1.115 accepts explicitly expanded declarations and ordinary compact groups, but reports an unknown `%r19` for `%r1<10>` and accepts unused overlapping digit-prefix groups. It is therefore not used as the oracle for digit-ending group prefixes. Regression expectations follow the issue's explicit name-set contract, with real frontend binding and module-resolution checks; no full ptxas parity is claimed.

Closes #94

## Integer conversion and normalization (#83)

- Decode integers in the PTX signed/unsigned 64-bit source domain before narrowing ordinary data operands; retain original source bits for checker rules.
- Normalize integer minus zero, preserving floating negative-zero bits.
- Keep fixed control operands, address offsets, and call literals checked against formal parameter types strict. Range, allowed-value, divisibility, and immediate-driven alignment checks use original integer values.
- Add ordinary mov/storage exact-bit comparisons, public literal API and generated mbarrier parity regressions, overflow/control/address/call protections, and aligned English/Chinese numeric contracts.

### Latest validation

- Debug build and full Debug CTest: **770/770 passed** after both fixes.
- Diff whitespace checks passed.
- Per the requested Debug-only local validation policy, no new Release, sanitizer, or ptxas validation is claimed for #83; remaining validation is deferred to CI.

Closes #83
