### PR TITLE
fix(semantic): enforce declaration order for function and branch tables

### DIFF
--- a/docs/us-en/control_flow_syntax_design.md
+++ b/docs/us-en/control_flow_syntax_design.md
@@ -60,7 +60,10 @@ a generated modifier field and an opcode-common field respectively.
 is a `.u32` register and its `tlist` resolves as `ResolvedBranchTargetSet`,
 which retains the current-function `.branchtargets` `SymbolId`; standalone
 resolution retains the spelling. It does not expand target entries or build a
-control-flow graph. `bra` remains direct-only.
+control-flow graph. In a module, the `.branchtargets` declaration must occur
+earlier in the same function's lexical traversal; its member labels may still
+refer forward. Direct `bra` targets remain forward-referenceable. `bra` remains
+direct-only.
 
 `call` now uses the non-`Flat` `Call` layout algorithm. One generated direct
 variant has exactly three fixed payload layouts: target only, target plus the

--- a/docs/us-en/storage_declarations.md
+++ b/docs/us-en/storage_declarations.md
@@ -60,6 +60,11 @@ low eight bits. Arithmetic after extraction is rejected rather than reordered.
 Symbol identity follows lexical binding, including same-named declarations in
 inner scopes. Function references may be bare or byte-masked; generic conversion
 and address arithmetic on function references are rejected.
+For a function-address initializer, the referenced function spelling must have
+an earlier declaration occurrence; a later definition found by two-pass binding
+does not make the use legal. Compatible prototypes and definitions still share
+their stable identity, while an alias must itself have been declared before an
+initializer uses that alias spelling.
 Neither unresolved external symbols nor function references receive fabricated
 addresses. Downstream consumers resolve these references against their own
 linking/allocation model, without reparsing initializer text.

--- a/docs/zh-han/control_flow_syntax_design.md
+++ b/docs/zh-han/control_flow_syntax_design.md
@@ -46,7 +46,9 @@ generated modifier field 与 opcode 公共字段保留。
 `brx.idx{.uni} index, tlist` 是独立的 PTX 6.0 / SM 30 opcode。其 index 是 `.u32`
 register，`tlist` resolve 为 `ResolvedBranchTargetSet`，保留当前 function `.branchtargets`
 的 `SymbolId`；standalone resolution 仅保留 spelling。它不会展开 target entry 或构建 CFG；
-`bra` 仍只支持 direct form。
+在 module 中 `.branchtargets` declaration 必须在同一 function 的 lexical traversal 内早于
+其 use；其中 member label 仍可 forward reference。direct `bra` target 仍允许 forward
+reference，且 `bra` 仍只支持 direct form。
 
 `call` 现在使用非 `Flat` 的 `Call` layout algorithm。一个 generated direct variant 固定有
 三种 payload layout：仅 target、target 加可变 input group、return group 加 target 加 input

--- a/docs/zh-han/storage_declarations.md
+++ b/docs/zh-han/storage_declarations.md
@@ -52,6 +52,10 @@ mask 在应用 addend 之后选择一个 byte，并将其放入低八位；提�
 symbol identity 沿用 lexical binding，包括内层 scope 的同名声明。
 function reference 可以直接使用或提取 byte mask；对 function reference 做 generic
 转换或地址算术会被拒绝。
+function-address initializer 中的 function spelling 必须已有更早的 declaration
+occurrence；two-pass binding 即使能找到较晚的 definition，也不会使该 use 合法。
+兼容的 prototype 与 definition 仍共享 stable identity，但 initializer 使用 alias
+spelling 时，该 alias 本身也必须先声明。
 未解析的 external symbol 和 function reference 都不会
 获得臆造地址。下游根据自己的链接／分配模型解析这些引用，无需重新解析 initializer 文本。
 

--- a/submod/binding/include/ptx_symbol_table.hpp
+++ b/submod/binding/include/ptx_symbol_table.hpp
@@ -122,6 +122,16 @@ struct SymbolReference {
   std::optional<SymbolLookup> target;
 };
 
+/** One lexical declaration occurrence for a stable symbol identity. */
+struct SymbolDeclarationOccurrence {
+  /** Stable identity shared by compatible redeclarations. */
+  SymbolId symbol;
+  /** Declaration spelling location retained for diagnostics and association. */
+  SourceRange range;
+  /** Source traversal position; absent when the source location is ambiguous. */
+  std::optional<uint32_t> lexical_order;
+};
+
 enum class BindDiagnosticKind : uint8_t {
   DuplicateSymbol,
   InvalidParameterizedCount,
@@ -189,6 +199,20 @@ class SymbolTable {
    */
   [[nodiscard]] const SymbolReference* initializerReference(
       SourceRange range) const noexcept;
+
+  /** Return the brx.idx target-set reference recorded at ``range``, if any. */
+  [[nodiscard]] const SymbolReference* branchTargetSetReference(
+      SourceRange range) const noexcept;
+
+  /**
+   * Return whether a declaration occurrence for ``symbol`` precedes ``use``.
+   *
+   * ``nullopt`` means the supplied source has no unambiguous lexical ordering
+   * for ``use``.  This deliberately keeps occurrence visibility separate from
+   * the symbol's canonical identity.
+   */
+  [[nodiscard]] std::optional<bool> hasPriorDeclaration(
+      SymbolId symbol, SourceRange use) const noexcept;
 
  private:
   friend struct SymbolTableBuilder;
@@ -285,9 +309,17 @@ class SymbolTable {
   std::vector<Scope> scopes_;
   std::vector<Symbol> symbols_;
   std::vector<SymbolReference> references_;
+  /** Declaration occurrences grouped by stable SymbolId. */
+  std::vector<std::vector<SymbolDeclarationOccurrence>>
+      declaration_occurrences_;
+  /** Unambiguous lexical source order keyed by exact syntax range. */
+  std::unordered_map<SourceRange, uint32_t, SourceRangeHash> source_orders_;
   /** First initializer reference by exact source range; values index references_. */
   std::unordered_map<SourceRange, size_t, SourceRangeHash>
       initializer_reference_indexes_;
+  /** Exact brx.idx target-set reference ranges; values index references_. */
+  std::unordered_map<SourceRange, size_t, SourceRangeHash>
+      branch_target_set_reference_indexes_;
   /** Scope-aligned owned accelerators; never borrow Symbol::name storage. */
   std::vector<ScopeNameIndex> scope_name_indexes_;
 };

--- a/submod/binding/src/ptx_symbol_table.cpp
+++ b/submod/binding/src/ptx_symbol_table.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 
 #include <fmt/format.h>
@@ -367,6 +368,32 @@ const SymbolReference* SymbolTable::initializerReference(
   return &references_[found->second];
 }
 
+const SymbolReference* SymbolTable::branchTargetSetReference(
+    SourceRange range) const noexcept {
+  const auto found = branch_target_set_reference_indexes_.find(range);
+  if (found == branch_target_set_reference_indexes_.end())
+    return nullptr;
+  return &references_[found->second];
+}
+
+std::optional<bool> SymbolTable::hasPriorDeclaration(
+    SymbolId symbol, SourceRange use) const noexcept {
+  const auto use_order = source_orders_.find(use);
+  if (use_order == source_orders_.end() ||
+      symbol.value >= declaration_occurrences_.size()) {
+    return std::nullopt;
+  }
+  const auto& occurrences = declaration_occurrences_[symbol.value];
+  bool unknown_occurrence_order = false;
+  for (const SymbolDeclarationOccurrence& occurrence : occurrences) {
+    if (occurrence.lexical_order &&
+        *occurrence.lexical_order < use_order->second)
+      return true;
+    unknown_occurrence_order |= !occurrence.lexical_order.has_value();
+  }
+  return unknown_occurrence_order ? std::nullopt : std::optional{false};
+}
+
 struct SymbolTableBuilder {
   struct FunctionContext {
     const syntax_ast::AstFunction* function{};
@@ -375,6 +402,9 @@ struct SymbolTableBuilder {
 
   SymbolBinding result;
   std::vector<FunctionContext> functions;
+  std::unordered_set<SourceRange, SymbolTable::SourceRangeHash>
+      ambiguous_source_orders;
+  uint32_t next_source_order{};
 
   SymbolTableBuilder() {
     result.table.scopes_.push_back(Scope{
@@ -385,6 +415,131 @@ struct SymbolTableBuilder {
         .range = std::nullopt,
     });
     result.table.scope_name_indexes_.emplace_back();
+  }
+
+  /** Record one source event unless a duplicate range makes its order ambiguous. */
+  void indexSourceRange(SourceRange range) {
+    if (ambiguous_source_orders.contains(range))
+      return;
+    const auto [iterator, inserted] =
+        result.table.source_orders_.try_emplace(range, next_source_order++);
+    if (!inserted) {
+      result.table.source_orders_.erase(iterator);
+      ambiguous_source_orders.insert(range);
+    }
+  }
+
+  /** Index symbol references in a constant expression in lexical traversal order. */
+  void indexConstantExpression(
+      const syntax_ast::AstConstantExpression& expression) {
+    std::visit(
+        [this](const auto& value) {
+          using Value = std::remove_cvref_t<decltype(value)>;
+          if constexpr (std::same_as<Value, syntax_ast::AstConstantSymbol>) {
+            indexSourceRange(value.name.syntax.range);
+          } else if constexpr (std::same_as<
+                                   Value,
+                                   syntax_ast::AstConstantParenthesized>) {
+            indexConstantExpression(*value.expression);
+          } else if constexpr (std::same_as<Value,
+                                            syntax_ast::AstConstantCall>) {
+            indexConstantExpression(*value.callee);
+            indexConstantExpression(*value.argument);
+          } else if constexpr (std::same_as<Value,
+                                            syntax_ast::AstConstantCast> ||
+                               std::same_as<Value,
+                                            syntax_ast::AstConstantUnary>) {
+            indexConstantExpression(*value.operand);
+          } else if constexpr (std::same_as<Value,
+                                            syntax_ast::AstConstantBinary>) {
+            indexConstantExpression(*value.left);
+            indexConstantExpression(*value.right);
+          } else if constexpr (std::same_as<
+                                   Value, syntax_ast::AstConstantConditional>) {
+            indexConstantExpression(*value.condition);
+            indexConstantExpression(*value.true_expression);
+            indexConstantExpression(*value.false_expression);
+          }
+        },
+        expression.node);
+  }
+
+  /** Index initializer symbol use sites in one declaration before later items. */
+  void indexVariableInitializers(
+      const syntax_ast::AstVariableDeclaration& declaration) {
+    for (const auto& declarator : declaration.declarators) {
+      if (!declarator.initializer)
+        continue;
+      const auto index_initializer =
+          [this](const auto& self,
+                 const syntax_ast::AstInitializer& initializer) -> void {
+        if (const auto* expression =
+                std::get_if<syntax_ast::AstConstantExpression>(
+                    &initializer.value)) {
+          indexConstantExpression(*expression);
+        } else {
+          const auto& elements =
+              std::get<syntax_ast::AstInitializerList>(initializer.value)
+                  .elements;
+          for (const auto& element : elements)
+            self(self, element);
+        }
+      };
+      index_initializer(index_initializer, *declarator.initializer);
+    }
+  }
+
+  /** Index declaration/use events in a function body, including nested blocks. */
+  void indexBodySourceOrder(
+      const std::vector<syntax_ast::AstFunctionBodyItem>& body) {
+    for (const auto& item : body) {
+      if (const auto* declaration =
+              std::get_if<syntax_ast::AstVariableDeclaration>(&item)) {
+        indexVariableInitializers(*declaration);
+      } else if (const auto* targets =
+                     std::get_if<syntax_ast::AstBranchTargets>(&item)) {
+        indexSourceRange(targets->label.syntax.range);
+      } else if (const auto* instruction =
+                     std::get_if<syntax_ast::AstInstruction>(&item)) {
+        for (const auto& operand : instruction->operands) {
+          if (const auto* target_set =
+                  std::get_if<syntax_ast::AstBranchTargetSet>(&operand))
+            indexSourceRange(target_set->name.syntax.range);
+        }
+      } else if (const auto* block =
+                     std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(&item);
+                 block != nullptr && *block) {
+        indexBodySourceOrder((*block)->body);
+      }
+    }
+  }
+
+  /** Build a unique lexical-order index without deriving order from coordinates. */
+  void indexSourceOrder(const syntax_ast::AstModule& module) {
+    for (const auto& item : module.items) {
+      if (const auto* declaration =
+              std::get_if<syntax_ast::AstVariableDeclaration>(&item)) {
+        indexVariableInitializers(*declaration);
+      } else if (const auto* function =
+                     std::get_if<syntax_ast::AstFunction>(&item)) {
+        indexSourceRange(function->name.syntax.range);
+        indexBodySourceOrder(function->body);
+      }
+    }
+  }
+
+  /** Retain a declaration occurrence independently of its canonical SymbolId. */
+  void recordDeclarationOccurrence(SymbolId symbol, SourceRange range) {
+    if (symbol.value >= result.table.declaration_occurrences_.size())
+      throw std::logic_error("Symbol occurrence has no stable identity.");
+    const auto order = result.table.source_orders_.find(range);
+    result.table.declaration_occurrences_[symbol.value].push_back(
+        SymbolDeclarationOccurrence{
+            .symbol = symbol,
+            .range = range,
+            .lexical_order = order == result.table.source_orders_.end()
+                                 ? std::nullopt
+                                 : std::optional{order->second}});
   }
 
   /** Associate a declaration's range with its scope, not its canonical symbol. */
@@ -531,6 +686,7 @@ struct SymbolTableBuilder {
         .function_is_entry = function_is_entry,
         .canonical_function = std::nullopt,
     });
+    result.table.declaration_occurrences_.emplace_back();
     indexSymbol(result.table.symbols_.back());
     return id;
   }
@@ -568,6 +724,7 @@ struct SymbolTableBuilder {
         .name = std::string{name},
         .declaration_range = declaration_range,
     });
+    result.table.declaration_occurrences_.emplace_back();
     return id;
   }
 
@@ -673,6 +830,7 @@ struct SymbolTableBuilder {
         std::nullopt, std::nullopt, std::nullopt, true, function.is_entry);
     const ScopeId function_scope = addFunctionScope(
         function_symbol, function.range, !function.is_prototype);
+    recordDeclarationOccurrence(function_symbol, function.name.syntax.range);
     functions.push_back(FunctionContext{&function, function_scope});
 
     for (const auto& parameter : function.return_parameters) {
@@ -725,8 +883,10 @@ struct SymbolTableBuilder {
                   targets->label.syntax.text, targets->label.syntax.range);
       } else if (const auto* targets =
                      std::get_if<syntax_ast::AstBranchTargets>(&item)) {
-        addSymbol(function_scope, SymbolKind::BranchTargetSet,
-                  targets->label.syntax.text, targets->label.syntax.range);
+        const SymbolId target_set =
+            addSymbol(function_scope, SymbolKind::BranchTargetSet,
+                      targets->label.syntax.text, targets->label.syntax.range);
+        recordDeclarationOccurrence(target_set, targets->label.syntax.range);
       } else if (const auto* block =
                      std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(&item);
                  block != nullptr && *block) {
@@ -760,6 +920,9 @@ struct SymbolTableBuilder {
     });
     if (kind == ReferenceKind::Initializer) {
       result.table.initializer_reference_indexes_.try_emplace(
+          identifier.syntax.range, result.table.references_.size() - 1);
+    } else if (kind == ReferenceKind::BranchTargetSet) {
+      result.table.branch_target_set_reference_indexes_.try_emplace(
           identifier.syntax.range, result.table.references_.size() - 1);
     }
     if (classification == ReferenceClassification::Unresolved) {
@@ -1093,6 +1256,7 @@ struct SymbolTableBuilder {
   }
 
   SymbolBinding build(const syntax_ast::AstModule& module) {
+    indexSourceOrder(module);
     for (const auto& item : module.items) {
       if (const auto* declaration =
               std::get_if<syntax_ast::AstVariableDeclaration>(&item)) {

--- a/submod/resolved_ir/test/test_ptx_resolved_module.cpp
+++ b/submod/resolved_ir/test/test_ptx_resolved_module.cpp
@@ -8914,6 +8914,32 @@ done:
   EXPECT_TRUE(checker::check(brx, supported).has_value());
 }
 
+TEST(ResolvedModule, RejectsIndexedBranchTargetSetDeclaredAfterUse) {
+  const auto ast = parseModule(R"ptx(
+.version 6.0
+.target sm_30
+.entry kernel() {
+  .reg .u32 %index;
+  brx.idx %index, targets;
+  targets: .branchtargets done;
+done:
+  ret;
+}
+)ptx");
+
+  const auto resolved = resolveModule(ast);
+
+  ASSERT_FALSE(resolved.has_value());
+  EXPECT_TRUE(std::ranges::any_of(
+      resolved.error(), [](const ResolveDiagnostic& diagnostic) {
+        return diagnostic.declaration_kind ==
+                   declaration_semantics::DeclarationDiagnosticKind::
+                       UnresolvedMetadataTarget &&
+               diagnostic.message.find("must be defined before") !=
+                   std::string::npos;
+      }));
+}
+
 TEST(ResolvedModule, IndexedBranchRequiresU32IndexRegister) {
   const auto ast = parseModule(R"ptx(
 .entry kernel() {

--- a/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
+++ b/submod/resolved_ir/test/test_storage_declaration_metadata.cpp
@@ -742,6 +742,32 @@ TEST(ResolvedStorageDeclarations, RetainsDirectAndMaskedFunctionRelocations) {
   }
 }
 
+/** Function-address relocation legality retains declaration occurrence order. */
+TEST(ResolvedStorageDeclarations,
+     RejectsFunctionAddressBeforeItsFirstDeclaration) {
+  const auto rejected = resolveSource(R"ptx(
+.version 9.3
+.target sm_80
+.address_size 64
+.global .u64 targets[1] = { later };
+.func later() { ret; }
+)ptx");
+  ASSERT_FALSE(rejected.has_value());
+  EXPECT_TRUE(hasDeclarationKind(
+      rejected.error(), declaration_semantics::DeclarationDiagnosticKind::
+                            FunctionAddressBeforeDeclaration));
+
+  const auto accepted = resolveSource(R"ptx(
+.version 9.3
+.target sm_80
+.address_size 64
+.func declared();
+.global .u64 targets[1] = { declared };
+.func declared() { ret; }
+)ptx");
+  ASSERT_TRUE(accepted.has_value()) << accepted.error().front().message;
+}
+
 /** Relocations retain the initializer's lexical binding rather than its spelling. */
 TEST(ResolvedStorageDeclarations, RetainsScopedInitializerSymbolIdentity) {
   const auto scoped = resolveSource(R"ptx(

--- a/submod/semantic/include/ptx_declaration_semantics.hpp
+++ b/submod/semantic/include/ptx_declaration_semantics.hpp
@@ -117,6 +117,8 @@ enum class DeclarationDiagnosticKind : uint8_t {
   UnsupportedParameterDeclaration,
   /** An integer literal cannot be decoded as an exact uint64_t magnitude. */
   InvalidIntegerLiteral,
+  /** A function address was used before its declaration occurrence. */
+  FunctionAddressBeforeDeclaration,
 };
 
 struct DeclarationDiagnostic {

--- a/submod/semantic/src/ptx_declaration_semantics.cpp
+++ b/submod/semantic/src/ptx_declaration_semantics.cpp
@@ -1707,12 +1707,50 @@ class Checker {
       } else if (const auto* targets =
                      std::get_if<syntax_ast::AstBranchTargets>(&body_item)) {
         checkBranchTargets(function_scope, *targets);
+      } else if (const auto* instruction =
+                     std::get_if<syntax_ast::AstInstruction>(&body_item)) {
+        checkIndexedBranchTargetSetVisibility(function_scope, *instruction);
       } else if (const auto* block =
                      std::get_if<std::unique_ptr<syntax_ast::AstBlock>>(
                          &body_item);
                  block != nullptr && *block) {
         checkControlFlowMetadataBody((*block)->body, function_scope,
                                      seen_functions, module_version, module_sm);
+      }
+    }
+  }
+
+  /** Require each brx.idx target-set declaration to precede its use site. */
+  void checkIndexedBranchTargetSetVisibility(
+      binding::ScopeId function_scope,
+      const syntax_ast::AstInstruction& instruction) {
+    for (const auto& operand : instruction.operands) {
+      const auto* target_set =
+          std::get_if<syntax_ast::AstBranchTargetSet>(&operand);
+      if (target_set == nullptr)
+        continue;
+      const binding::SymbolReference* reference =
+          symbols_.branchTargetSetReference(target_set->name.syntax.range);
+      if (reference == nullptr || !reference->target)
+        continue;
+      const binding::Symbol& symbol =
+          symbols_.symbol(reference->target->symbol);
+      if (symbol.kind != binding::SymbolKind::BranchTargetSet ||
+          symbol.scope != function_scope)
+        continue;
+      const auto prior = symbols_.hasPriorDeclaration(
+          symbol.id, target_set->name.syntax.range);
+      if (!prior || !*prior) {
+        diagnose(
+            DeclarationDiagnosticKind::UnresolvedMetadataTarget,
+            target_set->name.syntax.range,
+            prior ? fmt::format("brx.idx branch target list '{}' must be "
+                                "defined before its use.",
+                                target_set->name.syntax.text)
+                  : fmt::format("Cannot establish whether brx.idx branch "
+                                "target list '{}' is defined before its use.",
+                                target_set->name.syntax.text),
+            prior ? std::optional{symbol.declaration_range} : std::nullopt);
       }
     }
   }
@@ -1978,6 +2016,24 @@ class Checker {
                            "Initializer symbol '{}' must name a function or a "
                            ".global/.const variable.",
                            value.name.syntax.text));
+            } else if (symbol.kind == binding::SymbolKind::Function) {
+              const auto prior = symbols_.hasPriorDeclaration(
+                  symbol.id, value.name.syntax.range);
+              if (!prior || !*prior) {
+                diagnose(
+                    DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration,
+                    value.name.syntax.range,
+                    prior ? fmt::format("Function '{}' must be declared "
+                                        "before its address is used in an "
+                                        "initializer.",
+                                        value.name.syntax.text)
+                          : fmt::format("Cannot establish whether function "
+                                        "'{}' is declared before its address "
+                                        "is used in an initializer.",
+                                        value.name.syntax.text),
+                    prior ? std::optional{symbol.declaration_range}
+                          : std::nullopt);
+              }
             }
           } else if constexpr (std::same_as<
                                    Value,

--- a/submod/semantic/test/test_ptx_declaration_semantics.cpp
+++ b/submod/semantic/test/test_ptx_declaration_semantics.cpp
@@ -916,6 +916,162 @@ second_label:
             1u);
 }
 
+TEST(PtxDeclarationSemantics, RequiresFunctionDeclarationsBeforeAddressInitializers) {
+  const CheckedModule result = check(R"ptx(
+.global .u64 late_table[1] = { late };
+.func late() { ret; }
+.func declared();
+.func local_table() {
+  .global .u64 targets[1] = { declared };
+}
+.func declared() { ret; }
+)ptx");
+
+  EXPECT_TRUE(result.binding.diagnostics.empty());
+  EXPECT_EQ(
+      diagnosticCount(
+          result, DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration),
+      1u);
+  const auto diagnostic =
+      std::ranges::find_if(result.diagnostics, [](const auto& candidate) {
+        return candidate.kind ==
+               DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration;
+      });
+  ASSERT_NE(diagnostic, result.diagnostics.end());
+  EXPECT_EQ(diagnostic->range.start.line, 2);
+  ASSERT_TRUE(diagnostic->previous_range.has_value());
+  EXPECT_EQ(diagnostic->previous_range->start.line, 3);
+}
+
+TEST(PtxDeclarationSemantics,
+     PreservesAliasIdentityWhileCheckingAliasDeclarationVisibility) {
+  const CheckedModule accepted = check(R"ptx(
+.func alias_fn();
+.global .u64 targets[1] = { alias_fn };
+.func target() { ret; }
+.alias alias_fn, target;
+)ptx");
+  EXPECT_TRUE(accepted.binding.diagnostics.empty());
+  EXPECT_EQ(diagnosticCount(
+                accepted,
+                DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration),
+            0u);
+
+  const CheckedModule rejected = check(R"ptx(
+.func target();
+.global .u64 targets[1] = { alias_fn };
+.func alias_fn();
+.func target() { ret; }
+.alias alias_fn, target;
+)ptx");
+  EXPECT_TRUE(rejected.binding.diagnostics.empty());
+  EXPECT_EQ(diagnosticCount(
+                rejected,
+                DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration),
+            1u);
+}
+
+TEST(PtxDeclarationSemantics,
+     RejectsFunctionAddressWhenSourceOrderCannotBeEstablished) {
+  PtxSyntaxParser parser(R"ptx(
+.global .u64 targets[1] = { later };
+.func later() { ret; }
+)ptx");
+  auto module = parser.parseModule();
+  ASSERT_TRUE(module.has_value());
+  ASSERT_TRUE(module.diagnostics.empty());
+  auto& declaration =
+      std::get<syntax_ast::AstVariableDeclaration>(module->items.front());
+  auto& initializer_list = std::get<syntax_ast::AstInitializerList>(
+      declaration.declarators.front().initializer->value);
+  auto& expression = std::get<syntax_ast::AstConstantExpression>(
+      initializer_list.elements.front().value);
+  auto& symbol = std::get<syntax_ast::AstConstantSymbol>(expression.node);
+  auto& function = std::get<syntax_ast::AstFunction>(module->items.back());
+  symbol.name.syntax.range = SourceRange{};
+  function.name.syntax.range = SourceRange{};
+
+  auto binding = binding::bindSymbols(*module);
+  const auto diagnostics = checkDeclarations(*module, binding.table);
+  const auto diagnostic =
+      std::ranges::find_if(diagnostics, [](const auto& candidate) {
+        return candidate.kind ==
+               DeclarationDiagnosticKind::FunctionAddressBeforeDeclaration;
+      });
+  ASSERT_NE(diagnostic, diagnostics.end());
+  EXPECT_FALSE(diagnostic->previous_range.has_value());
+  EXPECT_NE(diagnostic->message.find("Cannot establish"), std::string::npos);
+}
+
+TEST(PtxDeclarationSemantics,
+     KeepsDeclarationOccurrencesAlignedAfterDebugMetadataSymbols) {
+  const CheckedModule result = check(R"ptx(
+.file 1 "source.ptx"
+.func declared();
+.global .u64 targets[1] = { declared };
+.func declared() { ret; }
+)ptx");
+  EXPECT_TRUE(result.binding.diagnostics.empty());
+  EXPECT_TRUE(result.diagnostics.empty());
+}
+
+TEST(PtxDeclarationSemantics,
+     RequiresBranchTargetMetadataBeforeIndexedBranchUse) {
+  const CheckedModule late = check(R"ptx(
+.entry kernel() {
+  .reg .u32 %index;
+  brx.idx %index, targets;
+  targets: .branchtargets L0;
+L0:
+  ret;
+}
+)ptx");
+  EXPECT_TRUE(late.binding.diagnostics.empty());
+  EXPECT_EQ(diagnosticCount(
+                late, DeclarationDiagnosticKind::UnresolvedMetadataTarget),
+            1u);
+
+  const CheckedModule prior = check(R"ptx(
+.entry kernel() {
+  .reg .u32 %index;
+  { targets: .branchtargets L0; }
+  brx.idx %index, targets;
+  bra done;
+L0:
+done:
+  ret;
+}
+)ptx");
+  EXPECT_TRUE(prior.binding.diagnostics.empty());
+  EXPECT_TRUE(prior.diagnostics.empty());
+}
+
+TEST(PtxDeclarationSemantics,
+     KeepsNestedBranchTargetSetShadowingAtItsBoundIdentity) {
+  const CheckedModule result = check(R"ptx(
+.entry kernel() {
+  .reg .u32 %index;
+  targets: .branchtargets done;
+  {
+    .reg .u32 targets;
+    brx.idx %index, targets;
+  }
+done:
+  ret;
+}
+)ptx");
+  EXPECT_EQ(std::ranges::count_if(
+                result.binding.diagnostics,
+                [](const auto& diagnostic) {
+                  return diagnostic.kind ==
+                         binding::BindDiagnosticKind::InvalidReferenceTarget;
+                }),
+            1u);
+  EXPECT_EQ(diagnosticCount(
+                result, DeclarationDiagnosticKind::UnresolvedMetadataTarget),
+            0u);
+}
+
 TEST(PtxDeclarationSemantics, RequiresPositivePowerOfTwoAlignment) {
   const CheckedModule result = check(R"ptx(
 .global .align 0 .u32 zero;


### PR DESCRIPTION
## Summary

Fixes #85
Fixes #96

Stacked on #119 (`fix/issue_94`). This PR targets that branch so its diff contains only the declaration-order fixes. Merge the parent first, then retarget this PR to `main` so the closing references take effect on the default branch.

- Preserve two-pass identity binding while recording lexical declaration/use occurrences independently of canonical symbol identity.
- Require a prior declaration of the referenced function spelling in function-address initializers; retain compatible prototypes and alias identity.
- Require `.branchtargets` before `brx.idx` use in the same function, following the exact bound reference through nested scopes. Ordinary forward labels remain supported.
- Diagnose unknown ordering without guessing from source coordinates; preserve occurrence-index alignment for debug metadata symbols.
- Add declaration/module/storage regressions and align English/Chinese contracts.

## Validation

- Debug build passed.
- Full Debug CTest: 780/780 passed.
- After restoring unrelated formatting changes: Debug rebuild and focused regressions 8/8 passed; code tokens/string contents preserved.
- Debug installed-package consumer passed.
- `git diff --check` passed.
- Local ptxas 13.1.115 (`.version 8.0`, `sm_80`) rejected both late-declaration fixtures and accepted the prior-prototype/prior-target-table controls.
- No Release, sanitizer, or GPU execution was performed locally.
