### PR TITLE
fix(resolved-ir): validate CTA barriers and accept register formals

### DIFF
--- a/docs/us-en/parameter_declarations.md
+++ b/docs/us-en/parameter_declarations.md
@@ -29,6 +29,11 @@ its result is a type classification, not validation of context or availability.
 Instruction alternate formats such as `.bf16` and `.tf32` do not become legal
 declaration types by retaining their spelling. `.reg` formals retain their
 existing separate signature/address path; they are not `.param` table entries.
+Within the owning function body, register-space input and return formals are
+resolved as typed register operands and retain their lexical symbol identities.
+Parameter-space formals remain data objects: use an instruction appropriate to
+their parameter address or storage semantics rather than an arithmetic register
+operand.
 
 ## Alignment, pointers, and size
 

--- a/docs/us-en/yaml_instruction_spec.md
+++ b/docs/us-en/yaml_instruction_spec.md
@@ -421,7 +421,9 @@ Do not invent variants for layout differences: `bar.sync a` and
 ## Immediate operand constraints
 
 Variant-level `constraints` can impose executable integer rules on a named
-`kind: imm` operand:
+operand. Depending on the constraint kind, it may be `kind: imm` or
+`kind: reg_or_imm`; a `reg_or_imm` rule applies only when the source is a known
+immediate:
 
 ```yaml
 constraints:
@@ -433,8 +435,11 @@ constraints:
 `immediate_value` is one non-empty, duplicate-free allowlist per variant.
 `immediate_range` may occur once per operand and has an inclusive `minimum`
 and an optional inclusive `maximum`; omitting `maximum` means no upper bound.
-`immediate_multiple_of` is one divisor rule per variant. These descriptors may
-be combined when their named operands make that meaningful.
+`immediate_multiple_of` is one divisor rule per variant. Like
+`immediate_range`, it may name an `imm` or `reg_or_imm` operand: the generated
+checker evaluates known immediates and leaves dynamically unknown register
+values to runtime. These descriptors may be combined when their named operands
+make that meaningful.
 
 All configured values use the generated `uint64_t` domain: an actual YAML
 integer in `0..18446744073709551615` (`2^64 - 1`). Negative values, Boolean
@@ -443,15 +448,14 @@ The normalizer validates every `immediate_value.values[index]` before duplicate
 checking, validates `minimum`, present `maximum`, and `divisor` with the same
 rule, rejects `maximum < minimum`, and requires `divisor > 0`.
 
-The operand reference is deliberately variant-wide, not layout-local. For
-each of the three constraint kinds, the named operand must exist in **every**
-operand layout of the variant and must be `kind: imm` in each one. A missing
-operand or a `reg`/`reg_or_imm` occurrence in even one named layout is a
-normalization error that identifies the variant, constraint kind, operand, and
-layout. Do not work around this with a layout-local constraint DSL or a runtime
-"missing operand means skip" rule. If a future instruction genuinely needs a
-layout-specific rule, it needs a new explicitly designed contract; it must not
-weaken this invariant.
+The operand reference is deliberately variant-wide, not layout-local. It must
+occur in at least one operand layout; layouts that omit it do not produce a
+missing-field error. Where it occurs, `immediate_value` requires `kind: imm`,
+while `immediate_range` and `immediate_multiple_of` accept `kind: imm` or
+`kind: reg_or_imm`. A `reg` occurrence is a normalization error that identifies
+the variant, constraint kind, operand, and layout. This permits optional
+operands while preserving immediate-only rules where their value contract
+requires one.
 
 The current frozen `setmaxnreg.inc.sync.aligned.u32` form illustrates a range
 plus divisibility rule:

--- a/docs/zh-han/parameter_declarations.md
+++ b/docs/zh-han/parameter_declarations.md
@@ -26,6 +26,10 @@
 分类，不表示上下文或版本已通过验证。`.bf16`、`.tf32` 等 instruction alternate format
 不会因为 spelling 被保留就成为合法 declaration type。`.reg` formal 继续使用既有
 signature/address 路径，不属于 `.param` 声明表。
+在所属 function body 中，register-space input / return formal 会作为带类型的 register
+operand resolve，并保留 lexical symbol identity。parameter-space formal 仍是 data object；
+应使用符合其 parameter address 或 storage semantics 的 instruction，而不是将其作为
+arithmetic register operand。
 
 ## Alignment、pointer 与大小
 

--- a/docs/zh-han/yaml_instruction_spec.md
+++ b/docs/zh-han/yaml_instruction_spec.md
@@ -367,7 +367,9 @@ layout name 是稳定语义 ID，不是 C++ layout directive。它按声明顺�
 
 ## Immediate operand constraint
 
-variant-level `constraints` 可以对具名 `kind: imm` operand 声明可执行的整数规则：
+variant-level `constraints` 可以对具名 operand 声明可执行的整数规则。根据
+constraint kind，它可以是 `kind: imm` 或 `kind: reg_or_imm`；`reg_or_imm` rule
+仅在 source 是已知 immediate 时生效：
 
 ```yaml
 constraints:
@@ -379,8 +381,9 @@ constraints:
 每个 variant 最多一个 `immediate_value`，它是非空且无重复的 allowlist。每个 operand
 最多一个 `immediate_range`；`minimum` 为 inclusive，下界可选的 `maximum` 也为
 inclusive，省略 `maximum` 表示没有上界。每个 variant 最多一个
-`immediate_multiple_of` divisor rule。当具名 operand 的语义合理时，这些 descriptor
-可以组合使用。
+`immediate_multiple_of` divisor rule。和 `immediate_range` 一样，它可指向 `imm`
+或 `reg_or_imm` operand：生成的 checker 会检查已知 immediate，而把动态未知的
+register 值留给 runtime。当具名 operand 的语义合理时，这些 descriptor 可以组合使用。
 
 所有配置值使用生成代码的 `uint64_t` 域：YAML 中实际的整数必须落在
 `0..18446744073709551615`（`2^64 - 1`）。负数、Boolean、float 或其他非整数，以及
@@ -388,13 +391,12 @@ inclusive，省略 `maximum` 表示没有上界。每个 variant 最多一个
 `immediate_value.values[index]`，并以同一规则验证 `minimum`、出现时的 `maximum` 和
 `divisor`；还会拒绝 `maximum < minimum`，并要求 `divisor > 0`。
 
-operand 引用刻意是 variant-wide，而不是 layout-local。对三种 constraint kind 中的每一种，
-该具名 operand 都必须存在于此 variant 的**每一个** operand layout，且在每个 layout 中
-都必须是 `kind: imm`。哪怕只有一个具名 layout 缺少该 operand，或写成
-`reg`/`reg_or_imm`，normalization 也会报错，并指明 variant、constraint kind、operand 与
-layout。不得用 layout-local constraint DSL 或“runtime 缺 operand 就跳过”的规则绕过它。
-未来 instruction 若确实需要 layout-specific rule，必须新增经过明确设计的 contract；不能
-放宽这个不变量。
+operand 引用刻意是 variant-wide，而不是 layout-local。它必须至少出现在一个 operand
+layout；省略它的 layout 不会导致 missing-field error。出现时，`immediate_value` 要求
+`kind: imm`，而 `immediate_range` 与 `immediate_multiple_of` 接受 `kind: imm` 或
+`kind: reg_or_imm`。`reg` occurrence 会导致 normalization error，并指明 variant、
+constraint kind、operand 与 layout。这样既允许 optional operand，又在值 contract 要求时
+保留 immediate-only rule。
 
 当前冻结的 `setmaxnreg.inc.sync.aligned.u32` form 展示了 range 与 divisibility rule 的组合：
 

--- a/python/code_gen/normalize.py
+++ b/python/code_gen/normalize.py
@@ -1391,7 +1391,8 @@ def _normalize_immediate_multiple_of_constraint(
         )
     operand_name, divisor = raw["operand"], raw["divisor"]
     _validate_immediate_constraint_operand(
-        raw_variant, layouts, operand_name, "immediate_multiple_of"
+        raw_variant, layouts, operand_name, "immediate_multiple_of",
+        allowed_kinds=("imm", "reg_or_imm"),
     )
     _validate_uint64(raw_variant, "immediate_multiple_of", "divisor", divisor)
     if divisor <= 0:

--- a/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
+++ b/python/code_gen/resources/ptx_spec/parallel_synchronization_and_communication.yaml
@@ -555,6 +555,9 @@ instructions:
             availability:
               ptx: "2.0"
               sm: 20
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_sync
 
         examples:
@@ -585,6 +588,9 @@ instructions:
             operands: $bar_sync_barrier
           - name: barrier_and_thread_count
             operands: $bar_sync_barrier_and_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_sync
 
         examples:
@@ -610,6 +616,10 @@ instructions:
             value: true
             token: ".arrive"
         operands: $bar_sync_barrier_and_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_range, operand: thread_count, minimum: 1}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_arrive
 
         examples:
@@ -634,6 +644,10 @@ instructions:
             value: true
             token: ".arrive"
         operands: $bar_sync_barrier_and_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_range, operand: thread_count, minimum: 1}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_arrive
 
         examples:
@@ -673,6 +687,9 @@ instructions:
             operands: $bar_red_popc_without_thread_count
           - name: with_thread_count
             operands: $bar_red_popc_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_popc
 
         examples:
@@ -715,6 +732,9 @@ instructions:
             operands: $bar_red_popc_without_thread_count
           - name: with_thread_count
             operands: $bar_red_popc_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_popc
 
         examples:
@@ -754,6 +774,9 @@ instructions:
             operands: $bar_red_pred_without_thread_count
           - name: with_thread_count
             operands: $bar_red_pred_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_and
 
         examples:
@@ -794,6 +817,9 @@ instructions:
             operands: $bar_red_pred_without_thread_count
           - name: with_thread_count
             operands: $bar_red_pred_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_and
 
         examples:
@@ -833,6 +859,9 @@ instructions:
             operands: $bar_red_pred_without_thread_count
           - name: with_thread_count
             operands: $bar_red_pred_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_or
 
         examples:
@@ -873,6 +902,9 @@ instructions:
             operands: $bar_red_pred_without_thread_count
           - name: with_thread_count
             operands: $bar_red_pred_with_thread_count
+        constraints:
+          - {kind: immediate_range, operand: barrier, minimum: 0, maximum: 15}
+          - {kind: immediate_multiple_of, operand: thread_count, divisor: 32}
         rule: parallel_sync_and_communication.bar_red_or
 
         examples:

--- a/python/tests/ir/test_resolved_ir.py
+++ b/python/tests/ir/test_resolved_ir.py
@@ -930,6 +930,46 @@ class ResolvedIrBuildTest(unittest.TestCase):
             {"ptx": "6.0", "sm": 30},
         )
 
+    def test_cta_barrier_numeric_constraints_are_resolved_for_all_cta_forms(
+        self,
+    ) -> None:
+        bar = next(
+            instruction
+            for instruction in self.database.instructions
+            if instruction.opcode == "bar"
+        )
+        variants = {
+            variant.cpp_name: variant
+            for variant in from_instruction_spec(bar).variants
+        }
+
+        for name in ("Sync", "CtaSync", "Arrive", "CtaArrive", "RedPopcU32",
+                     "CtaRedPopcU32", "RedAndPred", "CtaRedAndPred", "RedOrPred",
+                     "CtaRedOrPred"):
+            with self.subTest(variant=name):
+                variant = variants[name]
+                ranges = [
+                    (constraint.operand_field_id, constraint.minimum, constraint.maximum)
+                    for constraint in variant.immediate_ranges
+                ]
+                self.assertIn(("barrier", 0, 15), ranges)
+                self.assertEqual(
+                    (variant.immediate_multiple_of.operand_field_id,
+                     variant.immediate_multiple_of.divisor),
+                    ("thread_count", 32),
+                )
+
+        for name in ("Arrive", "CtaArrive"):
+            with self.subTest(arrive_variant=name):
+                self.assertIn(
+                    ("thread_count", 1, None),
+                    [
+                        (constraint.operand_field_id, constraint.minimum,
+                         constraint.maximum)
+                        for constraint in variants[name].immediate_ranges
+                    ],
+                )
+
     def test_immediate_conversion_is_independent_of_type_expression(self) -> None:
         """Fixed and modifier-derived types can select either conversion use."""
 

--- a/python/tests/ir/test_syntax_ast.py
+++ b/python/tests/ir/test_syntax_ast.py
@@ -1234,6 +1234,10 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         normalize_constraint(
             {"kind": "immediate_multiple_of", "operand": "count", "divisor": 8}
         )
+        normalize_constraint(
+            {"kind": "immediate_multiple_of", "operand": "count", "divisor": 8},
+            operand_kind="reg_or_imm",
+        )
         for constraint, message, kind in (
             ({"kind": "immediate_multiple_of", "operand": "missing", "divisor": 8}, "kind 'imm'", "imm"),
             ({"kind": "immediate_multiple_of", "operand": "count", "divisor": 0}, "positive integer", "imm"),
@@ -1442,9 +1446,11 @@ class SyntaxAstDescriptorBuildTest(unittest.TestCase):
         normalize_constraint(
             {"kind": "immediate_range", "operand": "count", "minimum": 1}
         )
+        normalize_constraint(
+            {"kind": "immediate_multiple_of", "operand": "count", "divisor": 1}
+        )
         for constraint in (
             {"kind": "immediate_value", "operand": "count", "values": [1]},
-            {"kind": "immediate_multiple_of", "operand": "count", "divisor": 1},
         ):
             with self.assertRaisesRegex(ValueError, r"kind 'imm'.*'reg_or_imm'"):
                 normalize_constraint(constraint)

--- a/submod/resolved_ir/src/ptx_resolved_ir.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir.cpp
@@ -712,7 +712,11 @@ std::expected<ResolvedRegisterRef, ResolveDiagnostic> resolve_bound_register(
   }
 
   const binding::Symbol& symbol = context.symbols.symbol(lookup->symbol);
-  if (symbol.kind != binding::SymbolKind::Variable ||
+  const bool register_valued_role =
+      symbol.kind == binding::SymbolKind::Variable ||
+      symbol.kind == binding::SymbolKind::InputParameter ||
+      symbol.kind == binding::SymbolKind::ReturnParameter;
+  if (!register_valued_role ||
       symbol.state_space != syntax_ast::AstStateSpace::Register) {
     return std::unexpected(ResolveDiagnostic{
         .range = range,

--- a/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
+++ b/submod/resolved_ir/src/ptx_resolved_ir_checker.cpp
@@ -1446,6 +1446,19 @@ CheckResult check_immediate_multiple_of(
       find_operand(operands, descriptor.operand_field_id);
   if (operand == nullptr)
     return {};
+  if (descriptor.divisor == 0) {
+    return std::unexpected(CheckDiagnostics{CheckDiagnostic{
+        .kind = CheckDiagnosticKind::RuleViolation,
+        .range = context.instruction_range,
+        .message = fmt::format("Immediate-multiple constraint for '{}' has zero "
+                               "divisor.",
+                               descriptor.operand_field_id),
+    }});
+  }
+  // A register operand is dynamically unknown; the generated divisibility
+  // rule applies only when it resolves to an immediate.
+  if (operand->actual_shape == OperandShape::Register)
+    return {};
   if (operand->actual_shape != OperandShape::Immediate ||
       !operand->immediate_bits) {
     return std::unexpected(CheckDiagnostics{CheckDiagnostic{
@@ -1453,15 +1466,6 @@ CheckResult check_immediate_multiple_of(
         .range = context.instruction_range,
         .message = fmt::format("Immediate-multiple constraint references missing "
                                "immediate operand '{}'.",
-                               descriptor.operand_field_id),
-    }});
-  }
-  if (descriptor.divisor == 0) {
-    return std::unexpected(CheckDiagnostics{CheckDiagnostic{
-        .kind = CheckDiagnosticKind::RuleViolation,
-        .range = context.instruction_range,
-        .message = fmt::format("Immediate-multiple constraint for '{}' has zero "
-                               "divisor.",
                                descriptor.operand_field_id),
     }});
   }

--- a/submod/resolved_ir/test/test_cta_barrier_numeric.cpp
+++ b/submod/resolved_ir/test/test_cta_barrier_numeric.cpp
@@ -1,0 +1,208 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** Parse a module fixture and surface parse failures in its calling test. */
+std::optional<syntax_ast::AstModule> parse_module(std::string_view source) {
+  PtxSyntaxParser parser(source);
+  auto module = parser.parseModule();
+  if (!module) {
+    ADD_FAILURE() << (module.diagnostics.empty()
+                         ? "PTX source did not parse."
+                         : module.diagnostics.front().message);
+    return std::nullopt;
+  }
+  return std::move(*module);
+}
+
+TEST(CtaBarrierNumeric, RejectsInvalidKnownImmediateValuesAtTheirOperands) {
+  /** Resolve one numeric-negative fixture and require an operand diagnostic. */
+  const auto reject = [](std::string_view instruction,
+                         std::size_t invalid_operand_index,
+                         std::size_t expected_diagnostic_count = 1) {
+    const std::string source = R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.entry k() {
+  .reg .u32 %r;
+  .reg .pred %p<2>;
+  )ptx" + std::string(instruction) + R"ptx(
+  ret;
+}
+)ptx";
+    const auto ast = parse_module(source);
+    ASSERT_TRUE(ast.has_value());
+    const auto& body =
+        std::get<syntax_ast::AstFunction>(ast->items.back()).body;
+    const auto bar = std::find_if(
+        body.begin(), body.end(), [](const syntax_ast::AstFunctionBodyItem& item) {
+          const auto* instruction = std::get_if<syntax_ast::AstInstruction>(&item);
+          return instruction != nullptr && instruction->opcode.syntax.text == "bar";
+        });
+    ASSERT_NE(bar, body.end());
+    const auto& syntax_instruction = std::get<syntax_ast::AstInstruction>(*bar);
+    const auto resolved = resolveModule(*ast);
+
+    ASSERT_FALSE(resolved.has_value());
+    ASSERT_EQ(resolved.error().size(), expected_diagnostic_count);
+    for (const auto& diagnostic : resolved.error()) {
+      EXPECT_EQ(diagnostic.checker_kind,
+                checker::CheckDiagnosticKind::ImmediateValueMismatch);
+      EXPECT_EQ(diagnostic.range, syntax_ast::sourceRange(
+                                      syntax_instruction.operands[
+                                          invalid_operand_index]));
+    }
+  };
+
+  reject("bar.sync 16;", 0);
+  reject("bar.sync 0, 33;", 1);
+  reject("bar.cta.sync 16;", 0);
+  reject("bar.cta.sync 0, 33;", 1);
+  reject("bar.arrive 16, 32;", 0);
+  reject("bar.arrive 0, 33;", 1);
+  reject("bar.arrive 0, 0;", 1);
+  reject("bar.cta.arrive 16, 32;", 0);
+  reject("bar.cta.arrive 0, 33;", 1);
+  reject("bar.cta.arrive 0, 0;", 1);
+  reject("bar.red.popc.u32 %r, 16, %p0;", 1);
+  reject("bar.red.popc.u32 %r, 0, 33, %p0;", 2);
+  reject("bar.cta.red.popc.u32 %r, 16, %p0;", 1);
+  reject("bar.cta.red.popc.u32 %r, 0, 33, %p0;", 2);
+  reject("bar.red.and.pred %p0, 16, %p1;", 1);
+  reject("bar.red.and.pred %p0, 0, 33, %p1;", 2);
+  reject("bar.cta.red.and.pred %p0, 16, %p1;", 1);
+  reject("bar.cta.red.and.pred %p0, 0, 33, %p1;", 2);
+  reject("bar.red.or.pred %p0, 16, %p1;", 1);
+  reject("bar.red.or.pred %p0, 0, 33, %p1;", 2);
+  reject("bar.cta.red.or.pred %p0, 16, %p1;", 1);
+  reject("bar.cta.red.or.pred %p0, 0, 33, %p1;", 2);
+  reject("bar.sync -1;", 0);
+  reject("bar.sync 0, -1;", 1);
+}
+
+TEST(CtaBarrierNumeric, AcceptsStaticBoundariesAndOptionalLayouts) {
+  const auto ast = parse_module(R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.entry k() {
+  .reg .u32 %r;
+  .reg .pred %p<2>;
+  bar.sync 0;
+  bar.sync 15;
+  bar.sync 0, 0;
+  bar.sync 0, 32;
+  bar.arrive 0, 32;
+  bar.cta.sync 15, 32;
+  bar.cta.arrive 0, 32;
+  bar.red.popc.u32 %r, 0, %p0;
+  bar.cta.red.popc.u32 %r, 15, 32, %p0;
+  bar.red.and.pred %p0, 0, 32, %p1;
+  bar.cta.red.and.pred %p0, 15, !%p1;
+  bar.red.or.pred %p0, 0, %p1;
+  bar.cta.red.or.pred %p0, 15, 0, !%p1;
+  ret;
+}
+)ptx");
+  ASSERT_TRUE(ast.has_value());
+  const auto resolved = resolveModule(*ast);
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+}
+
+TEST(CtaBarrierNumeric, LeavesRegisterValueContractsDynamic) {
+  const auto ast = parse_module(R"ptx(
+.version 8.0
+.target sm_80
+.address_size 64
+.entry k() {
+  .reg .u32 %r<3>;
+  .reg .pred %p<2>;
+  bar.sync %r0, %r1;
+  bar.cta.sync %r0, %r1;
+  bar.arrive %r0, %r1;
+  bar.cta.arrive %r0, %r1;
+  bar.red.popc.u32 %r2, %r0, %r1, %p0;
+  bar.cta.red.popc.u32 %r2, %r0, %r1, %p0;
+  bar.red.and.pred %p0, %r0, %r1, %p1;
+  bar.cta.red.and.pred %p0, %r0, %r1, %p1;
+  bar.red.or.pred %p0, %r0, %r1, %p1;
+  bar.cta.red.or.pred %p0, %r0, %r1, %p1;
+  ret;
+}
+)ptx");
+  ASSERT_TRUE(ast.has_value());
+  const auto resolved = resolveModule(*ast);
+
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+}
+
+TEST(CtaBarrierNumeric, PreservesImmediateAndCtaAvailabilityBoundaries) {
+  const auto legacy_ast = parse_module(R"ptx(
+.version 1.0
+.address_size 64
+.entry k() { bar.sync 0; ret; }
+)ptx");
+  ASSERT_TRUE(legacy_ast.has_value());
+  const auto legacy = resolveModule(*legacy_ast);
+  ASSERT_TRUE(legacy.has_value()) << legacy.error().front().message;
+  const auto& legacy_instruction = std::get<Bar>(
+      legacy->functions.front().body.front());
+  EXPECT_TRUE(checker::check(
+                  legacy_instruction,
+                  checker::Context{
+                      .target = {.ptx_version = {1, 0}, .sm_version = 10},
+                      .instruction_range =
+                          legacy->functions.front().instruction_ranges.front(),
+                  })
+                  .has_value());
+
+  const auto cta_before_introduction_ast = parse_module(R"ptx(
+.version 7.7
+.target sm_80
+.address_size 64
+.entry k() { bar.cta.sync 0; ret; }
+)ptx");
+  ASSERT_TRUE(cta_before_introduction_ast.has_value());
+  const auto cta_before_introduction =
+      resolveModule(*cta_before_introduction_ast);
+  ASSERT_FALSE(cta_before_introduction.has_value());
+  ASSERT_EQ(cta_before_introduction.error().size(), 1U);
+  EXPECT_EQ(cta_before_introduction.error().front().checker_kind,
+            checker::CheckDiagnosticKind::UnsupportedPtxVersion);
+}
+
+TEST(CtaBarrierNumeric, RejectsMalformedDivisibilityDescriptorForRegister) {
+  constexpr checker::VariantDescriptor::ImmediateMultipleOfDescriptor descriptor{
+      .operand_field_id = "thread_count",
+      .divisor = 0,
+  };
+  const checker::OperandView thread_count{
+      .field_id = "thread_count",
+      .actual_shape = checker::OperandShape::Register,
+  };
+  const auto checked = checker::check_immediate_multiple_of(
+      descriptor, std::span<const checker::OperandView>{&thread_count, 1},
+      checker::Context{.instruction_range = SourceRange{{4, 3}, {4, 17}}});
+
+  ASSERT_FALSE(checked.has_value());
+  ASSERT_EQ(checked.error().size(), 1U);
+  EXPECT_EQ(checked.error().front().kind,
+            checker::CheckDiagnosticKind::RuleViolation);
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir

--- a/submod/resolved_ir/test/test_register_formals.cpp
+++ b/submod/resolved_ir/test/test_register_formals.cpp
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <ptx_frontend/binding/ptx_symbol_table.hpp>
+#include <ptx_frontend/resolved_ir/ptx_resolved_ir.hpp>
+#include <ptx_frontend/syntax/ptx_syntax_parser.hpp>
+
+namespace ptx_frontend::resolved_ir {
+namespace {
+
+/** One scalar register-formal arithmetic case and its operand type. */
+struct RegisterFormalArithmeticCase {
+  /** PTX type spelling used by the formal declarations. */
+  std::string_view type_spelling;
+  /** Arithmetic instruction suffix, including any required rounding mode. */
+  std::string_view instruction_suffix;
+  /** Literal spelling that is valid for the selected instruction type. */
+  std::string_view immediate;
+  /** Expected resolved scalar type retained on both register references. */
+  ScalarType scalar_type;
+};
+
+/** Assert the bound type, class, shape, and identity of two scalar formals. */
+void expectBoundFormalMetadata(
+    const ResolvedRegisterRef& result, const ResolvedRegisterRef& input,
+    const RegisterFormalArithmeticCase& test_case,
+    const binding::SymbolLookup& result_symbol,
+    const binding::SymbolLookup& input_symbol) {
+  EXPECT_EQ(result.register_class, ResolvedRegisterClass::General);
+  EXPECT_EQ(input.register_class, ResolvedRegisterClass::General);
+  EXPECT_EQ(result.declared_type, test_case.scalar_type);
+  EXPECT_EQ(input.declared_type, test_case.scalar_type);
+  EXPECT_FALSE(result.vector_width.has_value());
+  EXPECT_FALSE(input.vector_width.has_value());
+  EXPECT_EQ(result.symbol_id, result_symbol.symbol);
+  EXPECT_EQ(input.symbol_id, input_symbol.symbol);
+  EXPECT_NE(result.symbol_id, input.symbol_id);
+}
+
+/** Read and write register formals in a function body for each supported width. */
+TEST(RegisterFormals, ResolveArithmeticReadsAndWritesWithBoundIdentity) {
+  constexpr std::array cases = {
+      RegisterFormalArithmeticCase{"u32", "u32", "1", ScalarType::U32},
+      RegisterFormalArithmeticCase{"b32", "u32", "1", ScalarType::B32},
+      RegisterFormalArithmeticCase{"f32", "rn.f32", "0f3f800000",
+                                  ScalarType::F32},
+      RegisterFormalArithmeticCase{"u64", "u64", "1", ScalarType::U64},
+  };
+  const checker::Context context{.target = {.ptx_version = {8, 0},
+                                             .sm_version = 80}};
+
+  for (const RegisterFormalArithmeticCase& test_case : cases) {
+    const std::string source =
+        ".version 8.0\n.target sm_80\n.address_size 64\n.func (.reg ." +
+        std::string(test_case.type_spelling) + " %result) formal(.reg ." +
+        std::string(test_case.type_spelling) + " %input) {\n  add." +
+        std::string(test_case.instruction_suffix) + " %result, %input, " +
+        std::string(test_case.immediate) + ";\n  ret;\n}\n";
+    SCOPED_TRACE(source);
+
+    PtxSyntaxParser parser(source);
+    const auto ast = parser.parseModule();
+    ASSERT_TRUE(ast.has_value()) << ast.diagnostics.front().message;
+    ASSERT_TRUE(ast.diagnostics.empty());
+    const auto bound = binding::bindSymbols(*ast);
+    ASSERT_TRUE(bound.diagnostics.empty());
+
+    const auto resolved = resolveModule(*ast);
+    ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+    ASSERT_EQ(resolved->functions.size(), 1u);
+    ASSERT_EQ(resolved->functions.front().body.size(), 2u);
+    const Add& add = std::get<Add>(resolved->functions.front().body.front());
+    EXPECT_TRUE(checker::check(add, context).has_value());
+
+    const auto& syntax_function =
+        std::get<syntax_ast::AstFunction>(ast->items.back());
+    const auto function_scope = bound.table.functionScope(syntax_function.range);
+    ASSERT_TRUE(function_scope.has_value());
+    const auto result_symbol = bound.table.lookup(*function_scope, "%result");
+    const auto input_symbol = bound.table.lookup(*function_scope, "%input");
+    ASSERT_TRUE(result_symbol.has_value());
+    ASSERT_TRUE(input_symbol.has_value());
+    EXPECT_EQ(bound.table.symbol(result_symbol->symbol).kind,
+              binding::SymbolKind::ReturnParameter);
+    EXPECT_EQ(bound.table.symbol(input_symbol->symbol).kind,
+              binding::SymbolKind::InputParameter);
+
+    if (test_case.scalar_type == ScalarType::F32) {
+      const auto* float_add = std::get_if<Add::FloatF32>(&add.variant);
+      ASSERT_NE(float_add, nullptr);
+      expectBoundFormalMetadata(
+          float_add->dst.value,
+          std::get<ResolvedRegisterRef>(float_add->src1.value), test_case,
+          *result_symbol, *input_symbol);
+    } else {
+      const auto* integer_add = std::get_if<Add::IntegerNoSat>(&add.variant);
+      ASSERT_NE(integer_add, nullptr);
+      expectBoundFormalMetadata(
+          integer_add->dst.value,
+          std::get<ResolvedRegisterRef>(integer_add->src1.value), test_case,
+          *result_symbol, *input_symbol);
+    }
+  }
+}
+
+/** Predicate formals retain predicate class while serving as body operands. */
+TEST(RegisterFormals, ResolvePredicateReadAndWrite) {
+  constexpr std::string_view source = R"ptx(.version 8.0
+.target sm_80
+.address_size 64
+.func (.reg .pred %result) formal(.reg .pred %input) {
+  bar.red.and.pred %result, 0, %input;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  ASSERT_TRUE(ast.has_value()) << ast.diagnostics.front().message;
+  ASSERT_TRUE(ast.diagnostics.empty());
+
+  const auto resolved = resolveModule(*ast);
+  ASSERT_TRUE(resolved.has_value()) << resolved.error().front().message;
+  ASSERT_EQ(resolved->functions.front().body.size(), 2u);
+  const auto& bar = std::get<Bar>(resolved->functions.front().body.front());
+  const auto& reduction = std::get<Bar::RedAndPred>(bar.variant);
+  const auto& operands =
+      std::get<Bar::RedAndPred::WithoutThreadCountOperands>(reduction.operands);
+  EXPECT_EQ(operands.dst.value.register_ref.register_class,
+            ResolvedRegisterClass::Predicate);
+  EXPECT_EQ(operands.predicate.value.register_ref.register_class,
+            ResolvedRegisterClass::Predicate);
+  EXPECT_EQ(operands.dst.value.register_ref.declared_type, ScalarType::Pred);
+  EXPECT_EQ(operands.predicate.value.register_ref.declared_type,
+            ScalarType::Pred);
+}
+
+/** Parameter-space formals remain invalid in arithmetic register operands. */
+TEST(RegisterFormals, RejectParameterSpaceFormalAsArithmeticRegister) {
+  constexpr std::string_view source = R"ptx(.version 8.0
+.target sm_80
+.address_size 64
+.func (.reg .u32 %result) formal(.param .u32 input) {
+  add.u32 %result, input, 1;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  ASSERT_TRUE(ast.has_value()) << ast.diagnostics.front().message;
+  ASSERT_TRUE(ast.diagnostics.empty());
+
+  const auto resolved = resolveModule(*ast);
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), 1u);
+  EXPECT_EQ(resolved.error().front().stage(),
+            ResolveDiagnosticStage::Resolution);
+  EXPECT_EQ(resolved.error().front().message,
+            "Symbol 'input' is not a .reg variable.");
+}
+
+/** Module resolution projects checker rejection of a mismatched register formal. */
+TEST(RegisterFormals, ReportsProjectedTypeMismatch) {
+  constexpr std::string_view source = R"ptx(.version 8.0
+.target sm_80
+.address_size 64
+.func (.reg .u64 %result) formal(.reg .u32 %input) {
+  add.u32 %result, %input, 1;
+  ret;
+}
+)ptx";
+  PtxSyntaxParser parser(source);
+  const auto ast = parser.parseModule();
+  ASSERT_TRUE(ast.has_value()) << ast.diagnostics.front().message;
+  ASSERT_TRUE(ast.diagnostics.empty());
+
+  const auto resolved = resolveModule(*ast);
+  ASSERT_FALSE(resolved.has_value());
+  ASSERT_EQ(resolved.error().size(), 1u);
+  EXPECT_EQ(resolved.error().front().stage(), ResolveDiagnosticStage::Checking);
+  EXPECT_EQ(resolved.error().front().checker_kind,
+            checker::CheckDiagnosticKind::OperandTypeMismatch);
+  EXPECT_EQ(resolved.error().front().message,
+            "Register operand 'dst' has declared type 'U64' but instruction "
+            "type source 'type' is 'U32'.");
+}
+
+}  // namespace
+}  // namespace ptx_frontend::resolved_ir


### PR DESCRIPTION
## Summary

Fixes #104
Fixes #74

Two issue-scoped commits:

- `1184490`: enforce known-immediate CTA barrier IDs in 0..15 and participating counts divisible by 32 across supported sync/arrive/reduction and `.cta` forms. Only arrive requires nonzero counts. Preserve optional layouts, dynamic register operands, source-value checks, and availability boundaries.
- `48e406b`: accept register-space input/return parameters as bound register operands while retaining symbol identity, register class/type/width checks, and rejection of memory-space `.param` arithmetic operands. This does not expand call ABI support.

Includes generated/model and actual C++ module regressions, plus aligned English/Chinese documentation.

## Validation

- Debug build passed.
- Debug CTest: 788/788 passed, including package consumer.
- Python/model/generator suite: 202/202 passed.
- Focused CTA barrier tests: 5/5 passed; register-formal tests: 4/4 passed.
- `git diff --check` passed.
- Local ptxas 13.1.115 (`.version 8.0`, `sm_80`) rejects barrier ID 16, count 33, and arrive count zero; accepts valid boundary/count examples, explicit sync count zero, and register-formal arithmetic.
- No Release, sanitizer, or GPU execution performed locally.